### PR TITLE
feat(ci): sign the default branch

### DIFF
--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -75,14 +75,19 @@ def key_identities(armored: bytes) -> set[str]:
 
 
 def verify(commit: bytes, home: str) -> None:
+    ok, detail = verify_status(commit, home)
+    if not ok:
+        sys.exit(f"::error::{commit.decode()} did not verify: {detail}")
+
+
+def verify_status(commit: bytes, home: str) -> tuple[bool, str]:
     result = subprocess.run(
         ["git", "verify-commit", "--raw", commit.decode()],
         capture_output=True,
         env={**os.environ, "GNUPGHOME": home},
     )
-    if b"[GNUPG:] GOODSIG" not in result.stderr:
-        detail = result.stderr.decode(errors="replace").strip()
-        sys.exit(f"::error::{commit.decode()} did not verify: {detail}")
+    detail = result.stderr.decode(errors="replace").strip()
+    return b"[GNUPG:] GOODSIG" in result.stderr, detail
 
 
 def header_of(raw: bytes) -> bytes:
@@ -147,11 +152,18 @@ def with_signature(payload: bytes, signature: bytes) -> bytes:
     return b"\n".join(header.split(b"\n") + gpgsig) + b"\n\n" + message
 
 
-def last_signed() -> str:
-    bound = [f"--max-count={SCAN_LIMIT}"] if SCAN_LIMIT else []
+def scan_bound() -> list[str]:
+    if not SCAN_LIMIT:
+        return []
+    if not (SCAN_LIMIT.isascii() and SCAN_LIMIT.isdecimal() and int(SCAN_LIMIT) > 0):
+        sys.exit(f"::error::scan_limit must be a positive integer, got {SCAN_LIMIT!r}")
+    return [f"--max-count={SCAN_LIMIT}"]
+
+
+def last_signed(home: str) -> str:
     objects = subprocess.run(
         ["git", "cat-file", "--batch"],
-        input=git("rev-list", *bound, "HEAD"),
+        input=git("rev-list", *scan_bound(), "HEAD"),
         capture_output=True,
     )
     if objects.returncode != 0:
@@ -164,20 +176,20 @@ def last_signed() -> str:
         end = data.index(b"\n", offset)
         sha, _, size = data[offset:end].split(b" ")
         offset = end + 1
-        if is_signed(data[offset : offset + int(size)]):
+        if is_signed(data[offset : offset + int(size)]) and verify_status(sha, home)[0]:
             return sha.decode()
         offset += int(size) + 1
 
     scope = f"the last {SCAN_LIMIT} commit(s) on HEAD" if SCAN_LIMIT else "HEAD"
-    sys.exit(f"::error::no signed commit in {scope}; pass base explicitly")
+    sys.exit(f"::error::no verified commit in {scope}; pass base explicitly")
 
 
-def resolve_base(branch: str) -> str:
+def resolve_base(branch: str, home: str) -> str:
     base = os.environ.get("BASE_REF", "").strip()
     if base:
         return git("rev-parse", "--verify", f"{base}^{{commit}}").strip().decode()
     if branch == DEFAULT_BRANCH:
-        return last_signed()
+        return last_signed(home)
     return git("merge-base", "HEAD", f"origin/{DEFAULT_BRANCH}").strip().decode()
 
 
@@ -186,15 +198,15 @@ def main() -> None:
     if branch == "HEAD":
         sys.exit("::error::HEAD is detached; check out the branch you want signed")
 
-    base = resolve_base(branch)
+    armored = gpg_sign("public-key")
+    identities = key_identities(armored)
+    home = keyring(armored)
+
+    base = resolve_base(branch, home)
     commits = git("rev-list", "--reverse", "--topo-order", f"{base}..HEAD").split()
     if not commits:
         print(f"No commits in {base}..HEAD; nothing to sign.")
         return
-
-    armored = gpg_sign("public-key")
-    identities = key_identities(armored)
-    home = keyring(armored)
 
     raw = {commit: git("cat-file", "commit", commit.decode()) for commit in commits}
     ours = {

--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -4,8 +4,6 @@ import subprocess
 import sys
 import tempfile
 
-SERVICE = os.environ["SIGNING_SERVICE_URL"].rstrip("/")
-TOKEN = os.environ["OIDC_TOKEN"]
 DEFAULT_BRANCH = os.environ.get("DEFAULT_BRANCH") or "master"
 ALLOW_RESIGN = os.environ.get("ALLOW_RESIGN") == "true"
 SIGN_OTHERS = os.environ.get("SIGN_OTHERS") == "true"
@@ -22,30 +20,11 @@ def git(*args: str, stdin: bytes | None = None) -> bytes:
     return result.stdout
 
 
-def curl(*args: str, stdin: bytes | None = None) -> bytes:
-    result = subprocess.run(
-        [
-            "curl",
-            "-sf",
-            "--retry",
-            "3",
-            "--retry-all-errors",
-            "--retry-delay",
-            "2",
-            "--connect-timeout",
-            "10",
-            "--max-time",
-            "60",
-            *args,
-        ],
-        input=stdin,
-        capture_output=True,
-    )
+def gpg_sign(*args: str, stdin: bytes | None = None) -> bytes:
+    result = subprocess.run(["gpg-sign", *args], input=stdin, capture_output=True)
     if result.returncode != 0:
         detail = result.stderr.decode(errors="replace").strip()
-        sys.exit(
-            f"::error::{SERVICE} refused the request (curl {result.returncode}): {detail}"
-        )
+        sys.exit(f"::error::gpg-sign {' '.join(args)} failed: {detail}")
     return result.stdout
 
 
@@ -58,18 +37,7 @@ def gpg(*args: str, stdin: bytes | None = None) -> bytes:
 
 
 def request_signature(payload: bytes) -> bytes:
-    signature = curl(
-        "-X",
-        "POST",
-        f"{SERVICE}/sign",
-        "-H",
-        f"Authorization: Bearer {TOKEN}",
-        "-H",
-        "Content-Type: text/plain",
-        "--data-binary",
-        "@-",
-        stdin=payload,
-    )
+    signature = gpg_sign("sign", stdin=payload)
     if ARMOR_MARKER not in signature:
         sys.exit(f"::error::signing service returned no signature: {signature!r}")
     return signature.strip(b"\n")
@@ -224,7 +192,7 @@ def main() -> None:
         print(f"No commits in {base}..HEAD; nothing to sign.")
         return
 
-    armored = curl(f"{SERVICE}/public-key")
+    armored = gpg_sign("public-key")
     identities = key_identities(armored)
     home = keyring(armored)
 

--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -9,6 +9,7 @@ TOKEN = os.environ["OIDC_TOKEN"]
 DEFAULT_BRANCH = os.environ.get("DEFAULT_BRANCH") or "master"
 ALLOW_RESIGN = os.environ.get("ALLOW_RESIGN") == "true"
 SIGN_OTHERS = os.environ.get("SIGN_OTHERS") == "true"
+SCAN_LIMIT = os.environ.get("SCAN_LIMIT", "").strip()
 
 ARMOR_MARKER = b"BEGIN PGP SIGNATURE"
 
@@ -178,10 +179,37 @@ def with_signature(payload: bytes, signature: bytes) -> bytes:
     return b"\n".join(header.split(b"\n") + gpgsig) + b"\n\n" + message
 
 
-def resolve_base() -> str:
+def last_signed() -> str:
+    bound = [f"--max-count={SCAN_LIMIT}"] if SCAN_LIMIT else []
+    objects = subprocess.run(
+        ["git", "cat-file", "--batch"],
+        input=git("rev-list", *bound, "HEAD"),
+        capture_output=True,
+    )
+    if objects.returncode != 0:
+        detail = objects.stderr.decode(errors="replace").strip()
+        sys.exit(f"::error::git cat-file --batch failed: {detail}")
+
+    data = objects.stdout
+    offset = 0
+    while offset < len(data):
+        end = data.index(b"\n", offset)
+        sha, _, size = data[offset:end].split(b" ")
+        offset = end + 1
+        if is_signed(data[offset : offset + int(size)]):
+            return sha.decode()
+        offset += int(size) + 1
+
+    scope = f"the last {SCAN_LIMIT} commit(s) on HEAD" if SCAN_LIMIT else "HEAD"
+    sys.exit(f"::error::no signed commit in {scope}; pass base explicitly")
+
+
+def resolve_base(branch: str) -> str:
     base = os.environ.get("BASE_REF", "").strip()
     if base:
         return git("rev-parse", "--verify", f"{base}^{{commit}}").strip().decode()
+    if branch == DEFAULT_BRANCH:
+        return last_signed()
     return git("merge-base", "HEAD", f"origin/{DEFAULT_BRANCH}").strip().decode()
 
 
@@ -189,10 +217,8 @@ def main() -> None:
     branch = git("rev-parse", "--abbrev-ref", "HEAD").strip().decode()
     if branch == "HEAD":
         sys.exit("::error::HEAD is detached; check out the branch you want signed")
-    if branch == DEFAULT_BRANCH:
-        sys.exit(f"::error::refusing to rewrite history on {DEFAULT_BRANCH}")
 
-    base = resolve_base()
+    base = resolve_base(branch)
     commits = git("rev-list", "--reverse", "--topo-order", f"{base}..HEAD").split()
     if not commits:
         print(f"No commits in {base}..HEAD; nothing to sign.")

--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -87,7 +87,8 @@ def verify_status(commit: bytes, home: str) -> tuple[bool, str]:
         env={**os.environ, "GNUPGHOME": home},
     )
     detail = result.stderr.decode(errors="replace").strip()
-    return b"[GNUPG:] GOODSIG" in result.stderr, detail
+    good = result.returncode == 0 and b"[GNUPG:] GOODSIG" in result.stderr
+    return good, detail
 
 
 def header_of(raw: bytes) -> bytes:

--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -155,7 +155,7 @@ def with_signature(payload: bytes, signature: bytes) -> bytes:
 def scan_bound() -> list[str]:
     if not SCAN_LIMIT:
         return []
-    if not (SCAN_LIMIT.isascii() and SCAN_LIMIT.isdecimal() and int(SCAN_LIMIT) > 0):
+    if not (SCAN_LIMIT.isascii() and SCAN_LIMIT.isdecimal() and SCAN_LIMIT.strip("0")):
         sys.exit(f"::error::scan_limit must be a positive integer, got {SCAN_LIMIT!r}")
     return [f"--max-count={SCAN_LIMIT}"]
 

--- a/.github/workflows/sign-commits.yml
+++ b/.github/workflows/sign-commits.yml
@@ -5,8 +5,8 @@ on:
     inputs:
       base:
         description: Sign every commit after this ref (exclusive). Defaults to the merge base with the default branch.
+        type: string
         required: false
-        default: ""
       allow_resign:
         description: Permit rewriting commits that already carry a signature
         type: boolean
@@ -19,9 +19,8 @@ on:
         default: false
       scan_limit:
         description: Stop looking for the last signed commit after this many commits. Blank searches the whole history.
-        type: string
+        type: number
         required: false
-        default: ""
 
 permissions:
   id-token: write # Required for OIDC token

--- a/.github/workflows/sign-commits.yml
+++ b/.github/workflows/sign-commits.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - { uses: actions/checkout@v7, with: { fetch-depth: 0 } }
-      - { uses: ./.github/actions/setup-task }
 
       - name: Get OIDC Token
         id: oidc
@@ -43,11 +42,6 @@ jobs:
             const token = await core.getIDToken('gpg-signing-service');
             core.setSecret(token);
             core.setOutput('token', token);
-
-      - name: Fetch Default Branch
-        env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: git fetch --no-tags origin "${DEFAULT_BRANCH}"
 
       - name: Sign Commits
         env:

--- a/.github/workflows/sign-commits.yml
+++ b/.github/workflows/sign-commits.yml
@@ -17,6 +17,11 @@ on:
         type: boolean
         required: false
         default: false
+      scan_limit:
+        description: Stop looking for the last signed commit after this many commits. Blank searches the whole history.
+        type: number
+        required: false
+        default: ""
 
 permissions:
   id-token: write # Required for OIDC token
@@ -52,6 +57,7 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           ALLOW_RESIGN: ${{ inputs.allow_resign }}
           SIGN_OTHERS: ${{ inputs.sign_others }}
+          SCAN_LIMIT: ${{ inputs.scan_limit }}
         run: python3 .github/scripts/sign-commits.py
 
       - name: Push Signed Commits

--- a/.github/workflows/sign-commits.yml
+++ b/.github/workflows/sign-commits.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - { uses: actions/checkout@v7, with: { fetch-depth: 0 } }
+      - { uses: ./ }
 
       - name: Get OIDC Token
         id: oidc
@@ -45,8 +46,8 @@ jobs:
 
       - name: Sign Commits
         env:
-          OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
-          SIGNING_SERVICE_URL: ${{ vars.SIGNING_SERVICE_URL }}
+          GPG_SIGN_TOKEN: ${{ steps.oidc.outputs.token }}
+          GPG_SIGN_URL: ${{ vars.SIGNING_SERVICE_URL }}
           BASE_REF: ${{ inputs.base }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           ALLOW_RESIGN: ${{ inputs.allow_resign }}

--- a/.github/workflows/sign-commits.yml
+++ b/.github/workflows/sign-commits.yml
@@ -19,7 +19,7 @@ on:
         default: false
       scan_limit:
         description: Stop looking for the last signed commit after this many commits. Blank searches the whole history.
-        type: number
+        type: string
         required: false
         default: ""
 

--- a/action.yml
+++ b/action.yml
@@ -79,10 +79,14 @@ runs:
         if ($checksums) {
           $sumHeaders = $headers.Clone()
           $sumHeaders['Accept'] = 'application/octet-stream'
-          $sumText = (Invoke-WebRequest -Uri $checksums.url -Headers $sumHeaders).Content
-          $line = ($sumText -split "`n") | Where-Object { $_ -match [regex]::Escape($assetName) + '\s*$' } | Select-Object -First 1
+          $sumRaw = (Invoke-WebRequest -Uri $checksums.url -Headers $sumHeaders).Content
+          $sumText = if ($sumRaw -is [byte[]]) { [Text.Encoding]::UTF8.GetString($sumRaw) } else { [string]$sumRaw }
+          $line = ($sumText -split "`r?`n") | Where-Object {
+            $fields = $_ -split '\s+' | Where-Object { $_ }
+            $fields.Count -ge 2 -and (Split-Path -Leaf $fields[-1]) -eq $assetName
+          } | Select-Object -First 1
           if (-not $line) { throw "No checksum entry for $assetName in checksums.txt" }
-          $want = ($line -split '\s+')[0].ToLower()
+          $want = (($line -split '\s+' | Where-Object { $_ })[0]).ToLower()
           $got = (Get-FileHash -Algorithm SHA256 -Path $binPath).Hash.ToLower()
           if ($want -ne $got) { throw "Checksum mismatch for ${assetName}: expected $want, got $got" }
           Write-Host "Checksum verified: $got"

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
           $sumText = if ($sumRaw -is [byte[]]) { [Text.Encoding]::UTF8.GetString($sumRaw) } else { [string]$sumRaw }
           $line = ($sumText -split "`r?`n") | Where-Object {
             $fields = $_ -split '\s+' | Where-Object { $_ }
-            $fields.Count -ge 2 -and (Split-Path -Leaf $fields[-1]) -eq $assetName
+            $fields.Count -ge 2 -and (Split-Path -Leaf ($fields[-1] -replace '^\*', '')) -eq $assetName
           } | Select-Object -First 1
           if (-not $line) { throw "No checksum entry for $assetName in checksums.txt" }
           $want = (($line -split '\s+' | Where-Object { $_ })[0]).ToLower()


### PR DESCRIPTION
A rebase or squash merge replays a branch as new objects, dropping every `gpgsig` header, so the default branch lands unsigned no matter what the merged branch carried. The signing workflow refused to run there, leaving nowhere to restore them from.

## Changes

**Sign the default branch.** The refusal is gone. A `workflow_dispatch` is deliberate, and restoring signatures is the only reason to aim this at it. When run there, the base resolves to the newest commit that already carries a signature, so a run covers exactly what the merge stripped and leaves everything below untouched. The `scan_limit` input bounds that search; blank searches all history.

**Sign through `gpg-sign`.** The script called the service with curl while this repo publishes a client for exactly that. It now installs the released binary via the root action and calls `gpg-sign sign` and `gpg-sign public-key`. Retry and rate-limit handling move to the client.

**Drop two dead workflow steps.** `setup-task` installed go-task, which the job never invoked. Fetching the default branch repeated what `checkout` already did at `fetch-depth: 0`. Together about 3.3s of a 10s run.

**Fix checksum matching in `action.yml`.** `Invoke-WebRequest` returns `byte[]` for an octet-stream response, so splitting it on newlines produced one element and no entry ever matched, failing every install with `No checksum entry`. It now decodes first, tolerates CRLF, and compares basenames so the `./` prefix in `checksums.txt` matches too.

## Verification

Against a local stand-in service with a real ed25519 key:

- the CLI transmits stdin byte-for-byte, trailing newline included
- a merge range signed 3 of 4 commits, the foreign one reparented and left unsigned, both merge parents remapped, all independently `GOODSIG` under a separate keyring
- re-dispatch is a no-op
- a signature over a tampered payload aborts on the first commit with `HEAD` unmoved
- detached `HEAD`, an unresolvable base, and a `scan_limit` too small to reach the last signed commit each fail with their own message
- an unreachable service surfaces the connection error through the CLI

In CI, run 30733021602 signed both unsigned commits on this branch through the new path and pushed them; all four commits on the branch verify.

`ruff`, `ty` and `basedpyright` from `.github/scripts` report 0/0/0. `task format:check`, `task lint` and `task test:coverage` (746 tests) pass.
