### PR TITLE
ci: skip Claude review step when the OAuth token is unavailable

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -5,6 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions: { contents: write, pull-requests: write, issues: write, id-token: write }
     steps:
+      - name: Check for Claude token
+        env:
+          CLAUDE_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: echo "HAS_CLAUDE_TOKEN=${CLAUDE_TOKEN:+true}" >> "$GITHUB_ENV"
       - { uses: actions/checkout@v7, with: { fetch-depth: 0 } }
       - { uses: ./.github/actions/setup-bun, id: bun }
       - { uses: ./.github/actions/setup-task }
@@ -13,6 +17,7 @@ jobs:
       - { run: runner install }
       - name: Run Claude Code Review
         id: claude-review
+        if: env.HAS_CLAUDE_TOKEN == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Dependabot-triggered runs don't receive Actions secrets, so `secrets.CLAUDE_CODE_OAUTH_TOKEN` resolves empty and the review step fails on a missing token.

The `secrets` context can't be referenced in an `if:` condition, so the presence check has to go through `env`. A preflight step reads the secret and exports a boolean; the review step gates on that.

```yaml
- name: Check for Claude token
  env:
    CLAUDE_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
  run: echo "HAS_CLAUDE_TOKEN=${CLAUDE_TOKEN:+true}" >> "$GITHUB_ENV"
...
- name: Run Claude Code Review
  if: env.HAS_CLAUDE_TOKEN == 'true'
```

Scoping the secret to that one step rather than to job-level `env` keeps it out of the environment of the third-party actions the job also runs (`install-dprint`, `runner`, `checkout`). Only the `HAS_CLAUDE_TOKEN=true` boolean crosses into later steps.

`${CLAUDE_TOKEN:+true}` yields `true` when the secret is set and empty when it is either empty-string or entirely absent, so the `== 'true'` comparison fails closed. Verified against all three cases.

### Notes

- `allowed_bots: dependabot[bot]` is inert until `CLAUDE_CODE_OAUTH_TOKEN` is added to the **Dependabot** secret store (Settings → Secrets and variables → Dependabot, separate from Actions). With this gate those PRs skip silently; adding the secret there makes them reviewed as the input intends, with no further workflow change.
- The setup steps (checkout, bun, task, dprint, runner) still run on token-less PRs. Adding the same `if:` to each would skip them too, since `GITHUB_ENV` is visible to every subsequent step.
- Unrelated to this diff: `kjanat/runner@master` is a floating ref in a job holding `contents: write`.