### PR TITLE
ci: make the review job report what it did

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,6 +24,8 @@ jobs:
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}
           settings: ${{ vars.CLAUDE_SETTINGS }}
           allowed_bots: dependabot[bot]
+          show_full_output: true
+          claude_args: --permission-mode bypassPermissions
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -39,5 +41,10 @@ jobs:
 
             Do not post duplicate comments, check what changed recently etc.
             If shit's really simple to solve, then fucking solve it.
+
+            Always append your review as markdown to the file at $GITHUB_STEP_SUMMARY.
+            It is a plain writable file and it renders on the job page, so your work
+            survives even when posting a comment gets denied. Do it every run, whether
+            or not the comment went through.
 # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
 # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options


### PR DESCRIPTION
Run [30734268965](https://github.com/kjanat/gpg-signing-service/actions/runs/30734268965/job/91459988160) spent 49 turns and 8m21s, hit 21 permission denials, posted nothing, and reported success. A denial is not an error, so the job goes green while producing no review.

## Why the denials happen

`vars.CLAUDE_SETTINGS` sets `permissions.defaultMode: bypassPermissions`, but the SDK options the action printed carry no `permissionMode`:

```
SDK options: {
  "systemPrompt": { "type": "preset", "preset": "claude_code" },
  "pathToClaudeCodeExecutable": "/home/runner/.local/bin/claude",
  "settingSources": ["user","project","local"]
}
```

`settingSources` governs which settings files get loaded, which is how the attribution and model settings take effect. The SDK's permission mode is a separate parameter that a settings file's `defaultMode` does not populate. Unset means `default`, and "ask the user" in a headless run resolves to denial.

## Changes

`claude_args: --permission-mode bypassPermissions` passes the mode through the CLI, where it does reach the SDK.

`show_full_output: true` names the denied tools if it happens again. The truncated log only reports a count.

The prompt now instructs the reviewer to append its review to `$GITHUB_STEP_SUMMARY` on every run. That is a plain writable file needing no tool permission, so the review survives even when commenting is blocked.

`actionlint` passes on the workflow.
