### PR TITLE
fix(ci): let the review run on actions-bot pushes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}
           settings: ${{ vars.CLAUDE_SETTINGS }}
-          allowed_bots: dependabot[bot]
+          allowed_bots: dependabot[bot],github-actions[bot]
           show_full_output: true
           claude_args: --permission-mode bypassPermissions
           prompt: |


### PR DESCRIPTION
`Sign Commits` force-pushes the rewritten head with `GITHUB_TOKEN`, so the `synchronize` event it produces carries `github-actions[bot]` as its actor. The review workflow only allowed `dependabot[bot]`, so every run after a signing pass died on the actor check before doing any work:

```
Workflow initiated by non-human actor: github-actions (type: Bot).
Add bot to allowed_bots list or use ‘*’ to allow all bots.
```

Adds `github-actions[bot]` to `allowed_bots`. The action normalises both sides of the comparison (lowercase, `[bot]` suffix stripped), so the entry matches the actor as reported.

Scoped to the two bots that actually push to pull requests here rather than `*`, which would let any bot with write access start a run under `--permission-mode bypassPermissions`.

Observed on [run 30734792515](https://github.com/kjanat/gpg-signing-service/actions/runs/30734792515/job/91461546625?pr=20).