### PR TITLE
ci: unblock the agent workflows, sign CI commits with our own service

### DIFF
--- a/.claude/commands/verify-live.md
+++ b/.claude/commands/verify-live.md
@@ -1,0 +1,29 @@
+---
+description: Probe the live deployment and compare it against documented behavior
+---
+
+Verify the live gpg-signing-service deployment matches what the repo claims.
+Base URL: use $GPG_SIGN_URL if set, otherwise https://gpg.kajkowalski.nl.
+
+Probe each endpoint with WebFetch or `curl -sS -w '%{http_code}'` and compare
+against `src/index.ts`, the OpenAPI config, and README.md:
+
+1. `GET /health` — expect 200 with a healthy status body.
+2. `GET /public-key` — expect 200, `application/pgp-keys`, an armored
+   `PGP PUBLIC KEY BLOCK`.
+3. `GET /doc` — expect 200 with a valid OpenAPI JSON document.
+4. `GET /ui` — expect 200 AND a non-empty Swagger UI page: the HTML must
+   actually reference the swagger-ui assets and render `/doc`. A 200 with a
+   gutted/empty body is a FAILURE (see issue #25).
+5. `POST /sign` without credentials — expect 401/403, NOT 500.
+6. `GET /admin/...` without credentials — expect 401/403 and evidence the
+   rate limiter is in front of auth.
+7. Any endpoint the README or docs/ mention that is not covered above.
+
+Then:
+
+- Run `task t` to confirm the tree itself is green before blaming the deploy.
+- Report a table: endpoint, expected, observed, verdict.
+- For each mismatch, check open GitHub issues before filing: update the
+  existing issue with fresh evidence instead of creating a duplicate. File a
+  new issue only for undocumented drift, with curl output included.

--- a/.github/actions/setup-claude-signing/action.yml
+++ b/.github/actions/setup-claude-signing/action.yml
@@ -1,0 +1,38 @@
+name: Setup service-signed commits
+description: >-
+  Configure git so every commit made in this job (including commits made by
+  Claude Code) is GPG-signed by our own gpg-signing-service. Dogfooding: the
+  service authenticates the workflow via GitHub OIDC, signs the raw commit
+  object, and git attaches the signature — every @claude run doubles as a live
+  integration test of the /sign endpoint.
+
+  Requires `id-token: write` on the calling job (the shim mints a fresh OIDC
+  token per signature — see .github/scripts/gpg-sign-git-program.sh).
+
+inputs:
+  service-url:
+    description: Base URL of the signing service (e.g. vars.SIGNING_SERVICE_URL)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Repo-root action: downloads a released gpg-sign binary onto PATH
+    - uses: ./
+
+    - shell: bash
+      env:
+        SERVICE_URL: ${{ inputs.service-url }}
+      run: |
+        shim="${GITHUB_WORKSPACE}/.github/scripts/gpg-sign-git-program.sh"
+        chmod +x "$shim"
+        git config --local gpg.program "$shim"
+        git config --local commit.gpgsign true
+        # Exported so the shim (invoked by git, possibly deep inside a Claude
+        # session) knows where the service lives.
+        echo "GPG_SIGN_URL=${SERVICE_URL}" >> "$GITHUB_ENV"
+        # NOTE: commits will show as "Unverified" on github.com unless the
+        # service's public key (/public-key) is uploaded to a GitHub account
+        # whose email matches the committer identity. The signature itself is
+        # still real and verifiable: git log --show-signature after importing
+        # the key from ${SERVICE_URL}/public-key.

--- a/.github/scripts/gpg-sign-git-program.sh
+++ b/.github/scripts/gpg-sign-git-program.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# git gpg.program shim that signs commits via this repo's own signing service.
+#
+# git invokes the configured gpg.program as:  <program> --status-fd=2 -bsau <key>
+# with the commit object on stdin, and accepts the signature iff:
+#   - the armored detached signature is written to stdout
+#   - a "[GNUPG:] SIG_CREATED " status line is written to the status fd (2)
+#   - exit code is 0
+# (see gpg-interface.c in git's source)
+#
+# `gpg-sign sign` prints exactly the armored detached signature (fmt.Print in
+# client/cmd/gpg-sign/main.go), so we pipe stdin straight through.
+#
+# A fresh OIDC token is fetched per invocation: GitHub's job-level OIDC tokens
+# expire after ~5 minutes, while a Claude session can run much longer. The
+# ACTIONS_ID_TOKEN_REQUEST_* vars are present in the environment of any job
+# with `id-token: write`, and are inherited by every child process, including
+# Claude's Bash tool.
+set -euo pipefail
+
+signing=false
+for arg in "$@"; do
+  case "$arg" in
+    -bsau|-bsa|--detach-sign) signing=true ;;
+  esac
+done
+if ! "$signing"; then
+  # git also calls gpg.program with --verify when showing signatures; we only
+  # sign. Fail loudly rather than pretending to verify.
+  echo "gpg-sign-git-program: unsupported invocation (sign-only shim): $*" >&2
+  exit 1
+fi
+
+: "${GPG_SIGN_URL:?GPG_SIGN_URL must point at the signing service}"
+: "${ACTIONS_ID_TOKEN_REQUEST_URL:?job needs 'id-token: write' permission}"
+: "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:?job needs 'id-token: write' permission}"
+
+GPG_SIGN_TOKEN="$(
+  curl -sSf \
+    -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+    "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=gpg-signing-service" |
+    jq -r '.value'
+)"
+export GPG_SIGN_TOKEN
+
+gpg-sign sign
+
+printf '\n[GNUPG:] SIG_CREATED \n' >&2

--- a/.github/scripts/gpg-sign-git-program.sh
+++ b/.github/scripts/gpg-sign-git-program.sh
@@ -20,15 +20,15 @@ set -euo pipefail
 
 signing=false
 for arg in "$@"; do
-  case "$arg" in
-    -bsau|-bsa|--detach-sign) signing=true ;;
-  esac
+	case "$arg" in
+		-bsau | -bsa | --detach-sign) signing=true ;;
+	esac
 done
 if ! "$signing"; then
-  # git also calls gpg.program with --verify when showing signatures; we only
-  # sign. Fail loudly rather than pretending to verify.
-  echo "gpg-sign-git-program: unsupported invocation (sign-only shim): $*" >&2
-  exit 1
+	# git also calls gpg.program with --verify when showing signatures; we only
+	# sign. Fail loudly rather than pretending to verify.
+	echo "gpg-sign-git-program: unsupported invocation (sign-only shim): $*" >&2
+	exit 1
 fi
 
 : "${GPG_SIGN_URL:?GPG_SIGN_URL must point at the signing service}"
@@ -36,10 +36,10 @@ fi
 : "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:?job needs 'id-token: write' permission}"
 
 GPG_SIGN_TOKEN="$(
-  curl -sSf \
-    -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-    "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=gpg-signing-service" |
-    jq -r '.value'
+	curl -sSf \
+		-H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+		"${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=gpg-signing-service" \
+		| jq -r '.value'
 )"
 export GPG_SIGN_TOKEN
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,6 +24,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # env beats the action's hardcoded bot git config — see claude.yml
+          GIT_AUTHOR_NAME: Kaj Kowalski
+          GIT_AUTHOR_EMAIL: info@kajkowalski.nl
+          GIT_COMMITTER_NAME: Kaj Kowalski
+          GIT_COMMITTER_EMAIL: info@kajkowalski.nl
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,10 +15,15 @@ jobs:
       - { uses: kjanat/install-dprint@v2 }
       - { uses: kjanat/runner@master }
       - { run: runner install }
+      # Dogfood: fixes Claude pushes to PR branches get signed by our own service
+      - uses: ./.github/actions/setup-claude-signing
+        with: { service-url: "${{ vars.SIGNING_SERVICE_URL }}" }
       - name: Run Claude Code Review
         id: claude-review
         if: env.HAS_CLAUDE_TOKEN == 'true'
         uses: anthropics/claude-code-action@v1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}
@@ -41,6 +46,13 @@ jobs:
 
             Do not post duplicate comments, check what changed recently etc.
             If shit's really simple to solve, then fucking solve it.
+
+            If this PR was opened by dependabot: don't just review it. Check
+            whether the bump breaks anything (task typecheck, task t, and
+            task c:t if the Go client is affected). If it breaks and the fix
+            is mechanical (renamed API, changed types, lockfile drift), fix
+            it, verify tests pass, and push to the PR branch so the update
+            can actually merge instead of rotting.
 
             Always append your review as markdown to the file at $GITHUB_STEP_SUMMARY.
             It is a plain writable file and it renders on the job page, so your work

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,10 +25,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           # env beats the action's hardcoded bot git config — see claude.yml
-          GIT_AUTHOR_NAME: Kaj Kowalski
-          GIT_AUTHOR_EMAIL: info@kajkowalski.nl
-          GIT_COMMITTER_NAME: Kaj Kowalski
-          GIT_COMMITTER_EMAIL: info@kajkowalski.nl
+          GIT_AUTHOR_NAME: ${{ vars.GIT_AUTHOR_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ vars.GIT_AUTHOR_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ vars.GIT_COMMITTER_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ vars.GIT_COMMITTER_EMAIL }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}

--- a/.github/workflows/claude-scheduled.yml
+++ b/.github/workflows/claude-scheduled.yml
@@ -33,10 +33,10 @@ jobs:
           # still works.
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           # env beats the action's hardcoded bot git config — see claude.yml
-          GIT_AUTHOR_NAME: Kaj Kowalski
-          GIT_AUTHOR_EMAIL: info@kajkowalski.nl
-          GIT_COMMITTER_NAME: Kaj Kowalski
-          GIT_COMMITTER_EMAIL: info@kajkowalski.nl
+          GIT_AUTHOR_NAME: ${{ vars.GIT_AUTHOR_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ vars.GIT_AUTHOR_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ vars.GIT_COMMITTER_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ vars.GIT_COMMITTER_EMAIL }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}

--- a/.github/workflows/claude-scheduled.yml
+++ b/.github/workflows/claude-scheduled.yml
@@ -32,6 +32,11 @@ jobs:
           # secret is unset the server just fails to connect; everything else
           # still works.
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # env beats the action's hardcoded bot git config — see claude.yml
+          GIT_AUTHOR_NAME: Kaj Kowalski
+          GIT_AUTHOR_EMAIL: info@kajkowalski.nl
+          GIT_COMMITTER_NAME: Kaj Kowalski
+          GIT_COMMITTER_EMAIL: info@kajkowalski.nl
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}

--- a/.github/workflows/claude-scheduled.yml
+++ b/.github/workflows/claude-scheduled.yml
@@ -1,0 +1,56 @@
+name: Claude Scheduled Audit
+# Weekly autonomous run. Passing `prompt` puts claude-code-action into "agent
+# mode" (src/modes/agent/index.ts), which — unlike tag mode — injects NO
+# hardcoded --permission-mode/--allowedTools, so claude_args below is the
+# entire permission story.
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+concurrency: claude-scheduled
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions: { contents: write, pull-requests: write, issues: write, id-token: write, actions: read }
+    steps:
+      - { uses: actions/checkout@v7, with: { fetch-depth: 0 } }
+      - { uses: ./.github/actions/setup-bun, id: bun }
+      - { uses: ./.github/actions/setup-task }
+      - { uses: kjanat/runner@master }
+      - { run: runner install }
+      # Dogfood: any commit this run makes is signed by the service itself
+      - uses: ./.github/actions/setup-claude-signing
+        with: { service-url: "${{ vars.SIGNING_SERVICE_URL }}" }
+      - uses: anthropics/claude-code-action@v1
+        env:
+          # gh CLI is preinstalled on ubuntu-latest; used for issue triage
+          GH_TOKEN: ${{ github.token }}
+          # Consumed by .mcp.json (Cloudflare MCP accepts a plain API token as
+          # Bearer auth for CI — see the "Servers for Cloudflare" docs). If the
+          # secret is unset the server just fails to connect; everything else
+          # still works.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}
+          settings: ${{ vars.CLAUDE_SETTINGS }}
+          prompt: |
+            Run the /verify-live audit for this repository (see
+            .claude/commands/verify-live.md) against
+            ${{ vars.SIGNING_SERVICE_URL }}.
+
+            Afterwards:
+            - Use `gh issue list` / `gh issue view` to triage open issues:
+              close ones the live probe proves fixed (with evidence), comment
+              fresh evidence on ones that still reproduce.
+            - If the Cloudflare MCP server is connected, pull recent Worker
+              logs/analytics for the service and mention anomalies (error
+              spikes, unusual latency) in your report.
+            - Write the full report to $GITHUB_STEP_SUMMARY.
+            - Do not open duplicate issues. Only push commits if a fix is
+              trivial and test-verified; otherwise file/update an issue.
+          claude_args: |
+            --permission-mode bypassPermissions
+            --allowedTools Edit,MultiEdit,Write,Bash,WebFetch,WebSearch,Task,TodoWrite

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,17 @@ jobs:
       - { uses: ./.github/actions/setup-task }
       - { uses: kjanat/runner@master }
       - { run: runner install }
+      # Dogfood: git is configured so commits Claude makes are GPG-signed by
+      # this very service (OIDC-authenticated /sign call per commit). Every
+      # @claude run doubles as a live integration test.
+      - uses: ./.github/actions/setup-claude-signing
+        with: { service-url: "${{ vars.SIGNING_SERVICE_URL }}" }
       - uses: anthropics/claude-code-action@v1
+        env:
+          # Consumed by .mcp.json — Cloudflare's MCP endpoint accepts a plain
+          # API token as Bearer auth for CI (no OAuth dance needed). Unset
+          # secret = that one MCP server fails to connect, nothing else breaks.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         with:
           additional_permissions: "actions: read"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,7 +12,7 @@ jobs:
                     github.event_name == 'issues', format('{0} {1}', github.event.issue.title, github.event.issue.body),
                     github.event.comment.body), '@claude')
     runs-on: ubuntu-latest
-    permissions: { contents: read, pull-requests: read, issues: read, id-token: write, actions: read }
+    permissions: { contents: write, pull-requests: write, issues: write, id-token: write, actions: read }
     steps:
       - { uses: actions/checkout@v7, with: { fetch-depth: 0 } }
       - { uses: ./.github/actions/setup-bun, id: bun }
@@ -25,11 +25,12 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}
           settings: ${{ vars.CLAUDE_SETTINGS }}
+          claude_args: |
+            --permission-mode bypassPermissions
+            --allowedTools Edit,MultiEdit,Write,NotebookEdit,Bash,WebFetch,WebSearch,Task,TodoWrite
 
 # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
 # prompt: 'Update the pull request description to include a summary of changes.'
 
-# Optional: Add claude_args to customize behavior and configuration
 # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
 # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-# claude_args: '--allowed-tools Bash(gh pr:*)'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,10 +34,10 @@ jobs:
           # to <botId>+<botName>@users.noreply.github.com in
           # src/github/operations/git-config.ts — this makes CI commits use the
           # repo owner's real identity instead of a bot one.
-          GIT_AUTHOR_NAME: Kaj Kowalski
-          GIT_AUTHOR_EMAIL: info@kajkowalski.nl
-          GIT_COMMITTER_NAME: Kaj Kowalski
-          GIT_COMMITTER_EMAIL: info@kajkowalski.nl
+          GIT_AUTHOR_NAME: ${{ vars.GIT_AUTHOR_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ vars.GIT_AUTHOR_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ vars.GIT_COMMITTER_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ vars.GIT_COMMITTER_EMAIL }}
         with:
           additional_permissions: "actions: read"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,14 @@ jobs:
           # API token as Bearer auth for CI (no OAuth dance needed). Unset
           # secret = that one MCP server fails to connect, nothing else breaks.
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # git env vars outrank `git config user.*`, which the action hardcodes
+          # to <botId>+<botName>@users.noreply.github.com in
+          # src/github/operations/git-config.ts — this makes CI commits use the
+          # repo owner's real identity instead of a bot one.
+          GIT_AUTHOR_NAME: Kaj Kowalski
+          GIT_AUTHOR_EMAIL: info@kajkowalski.nl
+          GIT_COMMITTER_NAME: Kaj Kowalski
+          GIT_COMMITTER_EMAIL: info@kajkowalski.nl
         with:
           additional_permissions: "actions: read"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,7 +24,26 @@ jobs:
           additional_permissions: "actions: read"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}
+          # `settings` is honored for model/attribution/MCP, but NOT for permissions here:
+          # tag mode (the @claude flow) hardcodes its own CLI flags in
+          # src/modes/tag/index.ts (v1):
+          #   claudeArgs += ` --permission-mode acceptEdits --allowedTools "${tagModeTools}"`
+          # and a CLI --permission-mode flag always outranks a settings-file
+          # `permissions.defaultMode`. That's why CLAUDE_SETTINGS' bypassPermissions
+          # alone had no effect (see run 30770718579: 7 permission denials).
           settings: ${{ vars.CLAUDE_SETTINGS }}
+          # User claude_args are appended AFTER the action's hardcoded flags
+          # (src/modes/tag/index.ts: `claudeArgs += \` ${userClaudeArgs}\``), and the
+          # parser (base-action/src/parse-sdk-options.ts) treats:
+          #   --permission-mode  as last-wins  -> our bypassPermissions overrides acceptEdits
+          #   --allowedTools     as accumulating -> merges with tag mode's list (git +
+          #                                         comment/CI MCP tools survive)
+          # Without bypass, the headless SDK has no prompt handler, so any tool that
+          # falls through to "ask" (Bash(task:*), WebFetch, ...) is auto-denied.
+          # WebSearch/WebFetch look "disallowed" in logs, but that DISALLOWED_TOOLS env
+          # export is dead code (src/create-prompt/index.ts: "nothing reads
+          # ALLOWED_TOOLS / DISALLOWED_TOOLS") — they were only blocked by absence from
+          # the allowlist, so naming them here is sufficient.
           claude_args: |
             --permission-mode bypassPermissions
             --allowedTools Edit,MultiEdit,Write,NotebookEdit,Bash,WebFetch,WebSearch,Task,TodoWrite

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "cloudflare": {
+      "type": "http",
+      "url": "https://mcp.cloudflare.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${CLOUDFLARE_API_TOKEN}"
+      }
+    },
+    "cloudflare-docs": {
+      "type": "http",
+      "url": "https://docs.mcp.cloudflare.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
Refs #26. Fixes the permission wall that made run [`30770718579`](https://github.com/kjanat/gpg-signing-service/actions/runs/30770718579) (on #25) useless, then builds on the mechanics it exposed.

## The bug

The `@claude` mention workflow ran with only read tools plus `git add/commit/push` — no `Edit`/`Write`, no general `Bash`, and `WebFetch`/`WebSearch` unavailable. On #25 it hit **7 permission denials**, never created a branch, and could only leave a comment.

`vars.CLAUDE_SETTINGS` already asked for `bypassPermissions`, but tag mode hardcodes `--permission-mode acceptEdits --allowedTools "..."` when invoking the CLI (`src/modes/tag/index.ts` in the action), and a CLI flag always outranks a settings-file `permissions.defaultMode`. User `claude_args` are appended *after* those hardcoded flags, and the parser treats `--permission-mode` as last-wins and `--allowedTools` as accumulating — so overriding there wins while the action's own git and MCP tools survive. Without bypass, the headless SDK has no prompt handler, so anything falling through to "ask" (every `task ...` command, every `WebFetch`) is auto-denied. The `DISALLOWED_TOOLS` line visible in logs is dead code; `WebFetch`/`WebSearch` were blocked only by absence from the allowlist.

All of this is now commented inline in `claude.yml` with pointers to the action source, so it doesn't have to be re-derived.

## Changes

- **`claude.yml`** — `claude_args` with `--permission-mode bypassPermissions` and an explicit `--allowedTools` list; job permissions raised to write; annotated with the rationale above.
- **Self-signed CI commits** — `.github/scripts/gpg-sign-git-program.sh` is a `gpg.program` shim that mints a fresh OIDC token per signature (job tokens expire in ~5 min, agent sessions run longer), calls the released `gpg-sign` CLI against the live `/sign` endpoint, and emits the `SIG_CREATED` status line git requires. The `setup-claude-signing` composite action wires it up. Applied to both agent workflows, so every run doubles as a live integration test of the service.
- **`claude-scheduled.yml`** — weekly agent-mode audit (Mondays 06:00 UTC + manual dispatch): probes the live deployment, triages open issues, pulls Worker logs via Cloudflare MCP, reports to the job summary. Agent mode injects no hardcoded permission flags, so `claude_args` there is the whole permission story.
- **`.mcp.json`** — Cloudflare MCP (plain API token as Bearer auth; no OAuth flow needed for automation) plus the auth-free docs server. Auto-loaded via the existing `enableAllProjectMcpServers` setting.
- **`.claude/commands/verify-live.md`** — reusable live-deployment audit covering `/health`, `/public-key`, `/doc`, `/ui` (with an explicit "200-but-empty is a failure" rule, per #25), and the auth-gated routes.
- **`claude-code-review.yml`** — dependabot PRs get mechanical breakage fixed and pushed rather than only reviewed.
- **Commit identity** — `GIT_AUTHOR_*`/`GIT_COMMITTER_*` sourced from repo variables. Those env vars outrank the `git config user.*` the action hardcodes to a bot noreply address.

## Before merging

Define the repo variables `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL`. An unset variable renders as an empty string, and an empty `GIT_AUTHOR_*` makes git reject the commit outright rather than falling back to config.

Optional: secret `CLOUDFLARE_API_TOKEN` with Workers observability read scope. Unset just means that one MCP server doesn't connect; nothing else breaks.

## Caveats

Service-signed commits will show as "Unverified" on github.com until the service's public key (`/public-key`) is attached to a GitHub account whose email matches the committer identity. The signature is genuine — `git log --show-signature` verifies it after importing the key.

`bypassPermissions` gives the agent whatever the runner has. Reasonable for a single-owner repo with ephemeral runners; if outside contributors can ever trigger `@claude`, the `acceptEdits` + scoped-allowlist middle ground is documented in the workflow comments.

Verified: all YAML parses, `.mcp.json` is valid, the shim passes `bash -n`. The workflow changes themselves can only be exercised once merged to `master`.
