### PR TITLE
fix: allow Swagger UI assets through the CSP

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -141,4 +141,51 @@ describe("API Documentation Routes", () => {
 		expect(csp).toContain("https://cdn.jsdelivr.net");
 		expect(csp).toContain("'unsafe-inline'");
 	});
+
+	it("should allow every remote asset the Swagger UI page actually references", async () => {
+		const ctx = createExecutionContext();
+		const response = await app.fetch(new Request("http://localhost/ui"), env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		const html = await response.text();
+		const csp = response.headers.get("Content-Security-Policy") ?? "";
+		const directive = (name: string): string => csp.split("; ").find((entry) => entry.startsWith(`${name} `)) ?? "";
+
+		const originsIn = (pattern: RegExp): string[] => [
+			...new Set(
+				[...html.matchAll(pattern)]
+					.map((match) => match[1])
+					.filter((url): url is string => url !== undefined)
+					.map((url) => new URL(url).origin),
+			),
+		];
+
+		// The CDN host lives inside @hono/swagger-ui, not in our code. Asserting
+		// against the URLs the page emits — rather than a hardcoded jsDelivr
+		// string — makes a CDN change fail here instead of silently shipping a
+		// blank /ui again (#25).
+		const scriptOrigins = originsIn(/<script[^>]+src="(https?:\/\/[^"]+)"/g);
+		const styleOrigins = originsIn(/<link[^>]+href="(https?:\/\/[^"]+)"/g);
+
+		expect(scriptOrigins.length).toBeGreaterThan(0);
+		expect(styleOrigins.length).toBeGreaterThan(0);
+
+		for (const origin of scriptOrigins) {
+			expect(directive("script-src")).toContain(origin);
+		}
+		for (const origin of styleOrigins) {
+			expect(directive("style-src")).toContain(origin);
+		}
+	});
+
+	it("should disable the third-party Swagger validator badge", async () => {
+		const ctx = createExecutionContext();
+		const response = await app.fetch(new Request("http://localhost/ui"), env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		// Left at its default, Swagger UI loads an <img> from validator.swagger.io,
+		// which the docs CSP blocks into a broken "Error" image — and which would
+		// hand the spec URL to a third party if it were allowed.
+		expect(await response.text()).toContain("validatorUrl: 'none'");
+	});
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -112,3 +112,33 @@ describe("Global Error Handling", () => {
 		}
 	});
 });
+
+describe("API Documentation Routes", () => {
+	it("should serve the OpenAPI spec at /doc", async () => {
+		const ctx = createExecutionContext();
+		const response = await app.fetch(new Request("http://localhost/doc"), env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
+		const spec = (await response.json()) as { openapi: string; paths: Record<string, unknown> };
+		expect(spec.openapi).toMatch(/^3\./);
+		expect(Object.keys(spec.paths).length).toBeGreaterThan(0);
+	});
+
+	it("should serve the Swagger UI at /ui with a usable CSP", async () => {
+		const ctx = createExecutionContext();
+		const response = await app.fetch(new Request("http://localhost/ui"), env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toBe(200);
+		const html = await response.text();
+		expect(html).toContain('id="swagger-ui"');
+		expect(html).toContain("SwaggerUIBundle");
+
+		// The page is useless unless the CSP allows the CDN assets and the
+		// inline bootstrap that mounts SwaggerUIBundle.
+		const csp = response.headers.get("Content-Security-Policy") ?? "";
+		expect(csp).toContain("https://cdn.jsdelivr.net");
+		expect(csp).toContain("'unsafe-inline'");
+	});
+});

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -68,6 +68,24 @@ describe("Security Headers Middleware", () => {
 		expect(response.headers.get("Content-Security-Policy")).toBe("default-src 'none'; frame-ancestors 'none'");
 	});
 
+	it("should relax Content-Security-Policy for the Swagger UI page", async () => {
+		const response = await makeRequest("/ui");
+		const csp = response.headers.get("Content-Security-Policy") ?? "";
+
+		expect(csp).toContain("script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net");
+		expect(csp).toContain("style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net");
+		expect(csp).toContain("connect-src 'self'");
+		// Framing stays forbidden even on the docs page
+		expect(csp).toContain("frame-ancestors 'none'");
+	});
+
+	it("should keep the strict Content-Security-Policy on /doc and API routes", async () => {
+		for (const path of ["/doc", "/health", "/public-key"]) {
+			const response = await makeRequest(path);
+			expect(response.headers.get("Content-Security-Policy")).toBe("default-src 'none'; frame-ancestors 'none'");
+		}
+	});
+
 	it("should set Permissions-Policy", async () => {
 		const response = await makeRequest("/health");
 		expect(response.headers.get("Permissions-Policy")).toBe("geolocation=(), microphone=(), camera=()");

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,10 @@ app.route(
 app.doc("/doc", openApiConfig);
 
 // Swagger UI
-app.get("/ui", swaggerUI({ url: "/doc" }));
+// `validatorUrl: "none"` disables Swagger UI's online validator badge, which
+// otherwise loads an <img> from validator.swagger.io — blocked by the docs CSP
+// (rendering a broken "Error" image) and leaking the spec URL to a third party.
+app.get("/ui", swaggerUI({ url: "/doc", validatorUrl: "none" }));
 
 // 404 handler
 app.notFound((c) => {

--- a/src/middleware/security.ts
+++ b/src/middleware/security.ts
@@ -6,6 +6,33 @@ import { HEADERS, HTTP, TIME } from "#types";
 import { logger } from "#utils/logger";
 
 /**
+ * Default CSP: every API route returns JSON, so nothing may be loaded at all.
+ */
+export const DEFAULT_CSP = "default-src 'none'; frame-ancestors 'none'";
+
+/**
+ * CSP for the Swagger UI page. It loads its stylesheet and bundle from jsDelivr,
+ * boots through an inline script and fetches the spec from /doc — all blocked by
+ * the default policy, which left the page blank.
+ *
+ * `'unsafe-inline'` for scripts is unavoidable: @hono/swagger-ui emits the
+ * bootstrap as a bare inline <script> with no nonce hook. It is scoped to the
+ * docs page, which renders no user input.
+ */
+export const DOCS_CSP = [
+	"default-src 'none'",
+	"script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://static.cloudflareinsights.com",
+	"style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+	"img-src 'self' data:",
+	"font-src 'self' data: https://cdn.jsdelivr.net",
+	"connect-src 'self' https://cloudflareinsights.com",
+	"frame-ancestors 'none'",
+].join("; ");
+
+/** Paths that render the interactive API documentation. */
+const DOCS_UI_PATHS = new Set(["/ui"]);
+
+/**
  * Security headers middleware for production hardening
  */
 export const securityHeaders: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
@@ -15,7 +42,7 @@ export const securityHeaders: MiddlewareHandler<{ Bindings: Env }> = async (c, n
 	c.header("X-Content-Type-Options", "nosniff");
 	c.header("X-Frame-Options", "DENY");
 	c.header("Referrer-Policy", "strict-origin-when-cross-origin");
-	c.header("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'");
+	c.header("Content-Security-Policy", DOCS_UI_PATHS.has(c.req.path) ? DOCS_CSP : DEFAULT_CSP);
 	c.header("Permissions-Policy", "geolocation=(), microphone=(), camera=()");
 	// HSTS: enforce HTTPS for 1 year, include subdomains
 	c.header("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");

--- a/src/middleware/security.ts
+++ b/src/middleware/security.ts
@@ -27,6 +27,10 @@ export const DOCS_CSP = [
 	"font-src 'self' data: https://cdn.jsdelivr.net",
 	"connect-src 'self' https://cloudflareinsights.com",
 	"frame-ancestors 'none'",
+	// Neither of these falls back to default-src, so they must be stated to
+	// stop an injected <base>/<form> from redirecting the page's requests.
+	"base-uri 'none'",
+	"form-action 'none'",
 ].join("; ");
 
 /** Paths that render the interactive API documentation. */


### PR DESCRIPTION
Fixes #25.

`securityHeaders` is registered globally (`src/index.ts:26`), so `default-src 'none'; frame-ancestors 'none'` was served on `GET /ui` too. With no other directives the browser blocks all four things the Swagger UI page needs:

1. the jsDelivr stylesheet — no `style-src`
2. the jsDelivr bundle — no `script-src`
3. the inline `SwaggerUIBundle(...)` bootstrap — no `'unsafe-inline'`
4. `fetch('/doc')` for the spec — no `connect-src`

The HTML arrives intact, `SwaggerUIBundle` is never defined, and `<div id="swagger-ui">` stays empty — which matches the view-source in the issue exactly. `/doc` was never affected; it is plain JSON.

## Change

The strict policy stays everywhere (the API only ever returns JSON); `/ui` gets a narrow docs-only policy. `frame-ancestors 'none'` and `X-Frame-Options: DENY` are preserved, so the page still cannot be embedded.

`'unsafe-inline'` in `script-src` is unavoidable — `@hono/swagger-ui` emits its bootstrap as a bare inline `<script>` with no nonce hook. It is scoped to `/ui`, which renders no user input, so there is no injection surface. The `cloudflareinsights.com` entries cover the beacon Cloudflare injects into the page.

## Tests

- `index.test.ts` — `/doc` serves a valid 3.x spec with non-empty `paths`; `/ui` serves the UI HTML with a CSP permitting its assets.
- `middleware.test.ts` — the relaxation applies to `/ui` **only**; `/doc`, `/health` and `/public-key` keep the strict default.

Authored by the `@claude` workflow on issue #25; reviewed and opened separately. Note the commit is unsigned — the signing failure it hit is diagnosed and fixed in #29.
