### PR TITLE
fix(ci): harden automated commit signing

### DIFF
--- a/.github/actions/setup-claude-signing/action.yml
+++ b/.github/actions/setup-claude-signing/action.yml
@@ -71,6 +71,7 @@ runs:
         # only settings.env is guaranteed to reach Claude Code's Bash tools.
         # Use neutral names so the runner-provided ACTIONS_* credentials do not
         # cross that process boundary under reserved names.
+        printf '::add-mask::%s\n' "${oidc_request_url}"
         printf '::add-mask::%s\n' "${oidc_request_token}"
 
         {

--- a/.github/actions/setup-claude-signing/action.yml
+++ b/.github/actions/setup-claude-signing/action.yml
@@ -13,6 +13,15 @@ inputs:
   service-url:
     description: Base URL of the signing service (e.g. vars.SIGNING_SERVICE_URL)
     required: true
+  claude-settings:
+    description: Existing Claude Code settings JSON or path to a settings file
+    required: false
+    default: "{}"
+
+outputs:
+  settings-file:
+    description: Path to Claude settings extended with the signing environment
+    value: ${{ steps.configure.outputs.settings-file }}
 
 runs:
   using: composite
@@ -20,25 +29,81 @@ runs:
     # Repo-root action: downloads a released gpg-sign binary onto PATH
     - uses: ./
 
-    - shell: bash
-      env: { SERVICE_URL: "${{ inputs.service-url }}" }
+    - id: configure
+      shell: bash
+      env:
+        CLAUDE_SETTINGS: "${{ inputs.claude-settings }}"
+        SERVICE_URL: "${{ inputs.service-url }}"
       run: |
-        shim="${GITHUB_WORKSPACE}/.github/scripts/gpg-sign-git-program.sh"
+        set -Eeuo pipefail
+
+        readonly github_workspace="${GITHUB_WORKSPACE-}"
+        readonly github_env="${GITHUB_ENV-}"
+        readonly github_output="${GITHUB_OUTPUT-}"
+        readonly runner_temp="${RUNNER_TEMP-}"
+        readonly service_url="${SERVICE_URL-}"
+        readonly claude_settings="${CLAUDE_SETTINGS-}"
+        readonly oidc_request_url="${ACTIONS_ID_TOKEN_REQUEST_URL-}"
+        readonly oidc_request_token="${ACTIONS_ID_TOKEN_REQUEST_TOKEN-}"
+
+        if [[ -z "${github_workspace}" || -z "${github_env}" || -z "${github_output}" || -z "${runner_temp}" ]]; then
+          printf '%s\n' '::error title=Commit signing unavailable::Required GitHub Actions paths are missing'
+          exit 1
+        fi
+
+        readonly shim="${github_workspace}/.github/scripts/gpg-sign-git-program.sh"
+
+        if [[ -z "${service_url}" ]]; then
+          printf '%s\n' '::error title=Commit signing unavailable::service-url is empty'
+          exit 1
+        fi
+        if [[ -z "${oidc_request_url}" || -z "${oidc_request_token}" ]]; then
+          printf '%s\n' '::error title=Commit signing unavailable::The job must grant id-token: write'
+          exit 1
+        fi
 
         chmod +x "${shim}"
         git config --local gpg.program "${shim}"
+        git config --local gpg.format openpgp
         git config --local commit.gpgsign true
 
-        # Re-export the runner-provided OIDC request credentials so they remain
-        # available to the signing shim when invoked from the Claude Bash tool.
-        # https://github.com/kjanat/gpg-signing-service/issues/37
-        printf '::add-mask::%s\n' "${ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
+        # The regular action environment reaches claude-code-action itself, but
+        # only settings.env is guaranteed to reach Claude Code's Bash tools.
+        # Use neutral names so the runner-provided ACTIONS_* credentials do not
+        # cross that process boundary under reserved names.
+        printf '::add-mask::%s\n' "${oidc_request_token}"
 
         {
-          printf 'GPG_SIGN_URL=%s\n'                       "${SERVICE_URL}"
-          printf 'ACTIONS_ID_TOKEN_REQUEST_URL=%s\n'       "${ACTIONS_ID_TOKEN_REQUEST_URL}"
-          printf 'ACTIONS_ID_TOKEN_REQUEST_TOKEN=%s\n'     "${ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
-        } >>"${GITHUB_ENV}"
+          printf 'GPG_SIGN_URL=%s\n' "${service_url}"
+          printf 'GPG_OIDC_REQUEST_URL=%s\n' "${oidc_request_url}"
+          printf 'GPG_OIDC_REQUEST_TOKEN=%s\n' "${oidc_request_token}"
+        } >>"${github_env}"
+
+        if [[ -z "${claude_settings}" ]]; then
+          settings='{}'
+        elif [[ -f "${claude_settings}" ]]; then
+          settings="$(<"${claude_settings}")"
+        else
+          settings="${claude_settings}"
+        fi
+
+        if ! jq -e 'type == "object"' >/dev/null <<<"${settings}"; then
+          printf '%s\n' '::error title=Invalid Claude settings::claude-settings must be a JSON object or a path to one'
+          exit 1
+        fi
+
+        umask 077
+        settings_file="$(mktemp "${runner_temp}/claude-signing-settings.XXXXXX")"
+        jq \
+          --arg service_url "${service_url}" \
+          --arg oidc_url "${oidc_request_url}" \
+          --arg oidc_token "${oidc_request_token}" \
+          '.env = ((.env // {}) + {
+            "GPG_SIGN_URL": $service_url,
+            "GPG_OIDC_REQUEST_URL": $oidc_url,
+            "GPG_OIDC_REQUEST_TOKEN": $oidc_token
+          })' <<<"${settings}" >"${settings_file}"
+        printf 'settings-file=%s\n' "${settings_file}" >>"${github_output}"
 
         # GitHub will show commits as "Unverified" unless the service's public key
         # (/public-key) is uploaded to a GitHub account whose email matches the

--- a/.github/scripts/gpg-sign-git-program.sh
+++ b/.github/scripts/gpg-sign-git-program.sh
@@ -11,34 +11,41 @@
 # `gpg-sign sign` prints exactly the armored detached signature (fmt.Print in
 # client/cmd/gpg-sign/main.go), so we pipe stdin straight through.
 #
-# A fresh OIDC token is fetched per invocation: GitHub's job-level OIDC tokens
-# expire after ~5 minutes, while a Claude session can run much longer. The
-# ACTIONS_ID_TOKEN_REQUEST_* vars are present in the environment of any job
-# with `id-token: write`, and are inherited by every child process, including
-# Claude's Bash tool.
+# A fresh OIDC token is fetched per invocation: minted identity tokens expire
+# quickly, while the job-scoped request credential remains usable throughout a
+# long Claude session. setup-claude-signing forwards that credential through
+# Claude settings under GPG_OIDC_REQUEST_* because Claude Bash tools do not
+# inherit the runner's ACTIONS_ID_TOKEN_REQUEST_* variables directly.
 set -euo pipefail
 
 signing=false
 for arg in "$@"; do
-	case "$arg" in
+	case "${arg}" in
 		-bsau | -bsa | --detach-sign) signing=true ;;
+		*) ;;
 	esac
 done
-if ! "$signing"; then
+if [[ "${signing}" != true ]]; then
 	# git also calls gpg.program with --verify when showing signatures; we only
 	# sign. Fail loudly rather than pretending to verify.
-	echo "gpg-sign-git-program: unsupported invocation (sign-only shim): $*" >&2
+	printf 'gpg-sign-git-program: unsupported invocation (sign-only shim): %s\n' "$*" >&2
 	exit 1
 fi
 
 : "${GPG_SIGN_URL:?GPG_SIGN_URL must point at the signing service}"
-: "${ACTIONS_ID_TOKEN_REQUEST_URL:?job needs 'id-token: write' permission}"
-: "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:?job needs 'id-token: write' permission}"
+
+oidc_url="${GPG_OIDC_REQUEST_URL:-${ACTIONS_ID_TOKEN_REQUEST_URL:-}}"
+oidc_token="${GPG_OIDC_REQUEST_TOKEN:-${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}}"
+if [[ -z "${oidc_url}" || -z "${oidc_token}" ]]; then
+	printf '%s\n' 'gpg-sign-git-program: OIDC request credentials are unavailable.' >&2
+	printf '  %s\n' "Grant id-token: write and use setup-claude-signing's settings-file output." >&2
+	exit 1
+fi
 
 GPG_SIGN_TOKEN="$(
 	curl -sSf \
-		-H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-		"${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=gpg-signing-service" \
+		--header "Authorization: bearer ${oidc_token}" \
+		"${oidc_url}&audience=gpg-signing-service" \
 		| jq -r '.value'
 )"
 export GPG_SIGN_TOKEN

--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -8,12 +8,14 @@ DEFAULT_BRANCH = os.environ.get("DEFAULT_BRANCH") or "master"
 ALLOW_RESIGN = os.environ.get("ALLOW_RESIGN") == "true"
 SIGN_OTHERS = os.environ.get("SIGN_OTHERS") == "true"
 SCAN_LIMIT = os.environ.get("SCAN_LIMIT", "").strip()
+BASE_REF = os.environ.get("BASE_REF", "").strip()
 
 ARMOR_MARKER = b"BEGIN PGP SIGNATURE"
 
 
 def warn(message: str) -> None:
-    print(f"::warning::{message}")
+    data = message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    print(f"::warning::{data}")
 
 
 def git(*args: str, stdin: bytes | None = None) -> bytes:
@@ -190,13 +192,12 @@ def last_signed(home: str) -> str:
 
 
 def resolve_base(branch: str, home: str) -> str:
-    base = os.environ.get("BASE_REF", "").strip()
-    if base:
+    if BASE_REF:
         if SCAN_LIMIT:
-            discarded = f"scan_limit={SCAN_LIMIT} was discarded because base={base}"
+            discarded = f"scan_limit={SCAN_LIMIT} was discarded because base={BASE_REF}"
             reason = "the scan for the last signed commit only runs when base is blank"
             warn(f"{discarded} pins the range; {reason}")
-        return git("rev-parse", "--verify", f"{base}^{{commit}}").strip().decode()
+        return git("rev-parse", "--verify", f"{BASE_REF}^{{commit}}").strip().decode()
     if branch == DEFAULT_BRANCH:
         return last_signed(home)
     return git("merge-base", "HEAD", f"origin/{DEFAULT_BRANCH}").strip().decode()
@@ -215,16 +216,23 @@ def main() -> None:
     base = resolve_base(branch, home)
     commits = git("rev-list", "--reverse", "--topo-order", f"{base}..HEAD").split()
     if not commits:
-        if base == head.decode():
-            remedy = "pass the commit *before* the first one you want signed"
-            warn(
-                f"base resolved to {base}, which is HEAD itself; base is an "
-                f"exclusive lower bound, so the range is empty — {remedy}."
-            )
-        else:
+        if base != head.decode():
             warn(
                 f"No commits in {base}..HEAD; nothing was signed. Check that base "
                 "is an ancestor of HEAD on the branch you dispatched."
+            )
+        elif BASE_REF:
+            remedy = "pass the commit before the first one you want signed"
+            warn(
+                f"base={BASE_REF} resolved to {base}, which is HEAD itself; base is "
+                f"an exclusive lower bound, so the range is empty — {remedy}."
+            )
+        elif branch == DEFAULT_BRANCH:
+            print(f"Nothing to sign; HEAD ({base}) is already signed and verified.")
+        else:
+            print(
+                f"Nothing to sign; {branch} adds no commits on top of "
+                f"origin/{DEFAULT_BRANCH} ({base})."
             )
         return
 

--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -12,6 +12,10 @@ SCAN_LIMIT = os.environ.get("SCAN_LIMIT", "").strip()
 ARMOR_MARKER = b"BEGIN PGP SIGNATURE"
 
 
+def warn(message: str) -> None:
+    print(f"::warning::{message}")
+
+
 def git(*args: str, stdin: bytes | None = None) -> bytes:
     result = subprocess.run(["git", *args], input=stdin, capture_output=True)
     if result.returncode != 0:
@@ -188,6 +192,10 @@ def last_signed(home: str) -> str:
 def resolve_base(branch: str, home: str) -> str:
     base = os.environ.get("BASE_REF", "").strip()
     if base:
+        if SCAN_LIMIT:
+            discarded = f"scan_limit={SCAN_LIMIT} was discarded because base={base}"
+            reason = "the scan for the last signed commit only runs when base is blank"
+            warn(f"{discarded} pins the range; {reason}")
         return git("rev-parse", "--verify", f"{base}^{{commit}}").strip().decode()
     if branch == DEFAULT_BRANCH:
         return last_signed(home)
@@ -203,10 +211,21 @@ def main() -> None:
     identities = key_identities(armored)
     home = keyring(armored)
 
+    head = git("rev-parse", "HEAD").strip()
     base = resolve_base(branch, home)
     commits = git("rev-list", "--reverse", "--topo-order", f"{base}..HEAD").split()
     if not commits:
-        print(f"No commits in {base}..HEAD; nothing to sign.")
+        if base == head.decode():
+            remedy = "pass the commit *before* the first one you want signed"
+            warn(
+                f"base resolved to {base}, which is HEAD itself; base is an "
+                f"exclusive lower bound, so the range is empty — {remedy}."
+            )
+        else:
+            warn(
+                f"No commits in {base}..HEAD; nothing was signed. Check that base "
+                "is an ancestor of HEAD on the branch you dispatched."
+            )
         return
 
     raw = {commit: git("cat-file", "commit", commit.decode()) for commit in commits}
@@ -223,7 +242,14 @@ def main() -> None:
 
     if not stale:
         others = sum(1 for commit in commits if not ours[commit])
-        print(f"Nothing to sign in {base}..HEAD ({others} commit(s) by others).")
+        if others == len(commits):
+            warn(
+                f"Nothing was signed: all {others} commit(s) in {base}..HEAD were "
+                "committed by identities the key does not carry — dispatch with "
+                "sign_others to include them."
+            )
+        else:
+            print(f"Nothing to sign in {base}..HEAD ({others} commit(s) by others).")
         return
 
     resign = [commit for commit in stale if is_signed(raw[commit])]
@@ -260,7 +286,6 @@ def main() -> None:
         rewritten[commit] = new
         print(f"  {mark} {commit.decode()[:8]} -> {new.decode()[:8]}")
 
-    head = git("rev-parse", "HEAD").strip()
     signed = sum(1 for commit in rewritten if ours[commit])
     print(f"Signed {signed} of {len(commits)} commit(s) in {base}..HEAD")
     _ = git("update-ref", "HEAD", rewritten.get(head, head).decode())

--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import tempfile
+from typing import NoReturn
 
 DEFAULT_BRANCH = os.environ.get("DEFAULT_BRANCH") or "master"
 ALLOW_RESIGN = os.environ.get("ALLOW_RESIGN") == "true"
@@ -13,16 +14,23 @@ BASE_REF = os.environ.get("BASE_REF", "").strip()
 ARMOR_MARKER = b"BEGIN PGP SIGNATURE"
 
 
+def escape(message: str) -> str:
+    return message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
 def warn(message: str) -> None:
-    data = message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
-    print(f"::warning::{data}")
+    print(f"::warning::{escape(message)}")
+
+
+def fail(message: str) -> NoReturn:
+    sys.exit(f"::error::{escape(message)}")
 
 
 def git(*args: str, stdin: bytes | None = None) -> bytes:
     result = subprocess.run(["git", *args], input=stdin, capture_output=True)
     if result.returncode != 0:
         detail = result.stderr.decode(errors="replace").strip()
-        sys.exit(f"::error::git {' '.join(args)} failed: {detail}")
+        fail(f"git {' '.join(args)} failed: {detail}")
     return result.stdout
 
 
@@ -30,7 +38,7 @@ def gpg_sign(*args: str, stdin: bytes | None = None) -> bytes:
     result = subprocess.run(["gpg-sign", *args], input=stdin, capture_output=True)
     if result.returncode != 0:
         detail = result.stderr.decode(errors="replace").strip()
-        sys.exit(f"::error::gpg-sign {' '.join(args)} failed: {detail}")
+        fail(f"gpg-sign {' '.join(args)} failed: {detail}")
     return result.stdout
 
 
@@ -38,14 +46,14 @@ def gpg(*args: str, stdin: bytes | None = None) -> bytes:
     result = subprocess.run(["gpg", *args], input=stdin, capture_output=True)
     if result.returncode != 0:
         detail = result.stderr.decode(errors="replace").strip()
-        sys.exit(f"::error::gpg {' '.join(args)} failed: {detail}")
+        fail(f"gpg {' '.join(args)} failed: {detail}")
     return result.stdout
 
 
 def request_signature(payload: bytes) -> bytes:
     signature = gpg_sign("sign", stdin=payload)
     if ARMOR_MARKER not in signature:
-        sys.exit(f"::error::signing service returned no signature: {signature!r}")
+        fail(f"signing service returned no signature: {signature!r}")
     return signature.strip(b"\n")
 
 
@@ -62,7 +70,7 @@ def keyring(armored: bytes) -> str:
     )
     if not listing.stdout.startswith(b"pub:") and b"\npub:" not in listing.stdout:
         detail = imported.stderr.decode(errors="replace").strip()
-        sys.exit(f"::error::could not import the public key: {detail}")
+        fail(f"could not import the public key: {detail}")
     return home
 
 
@@ -76,14 +84,14 @@ def key_identities(armored: bytes) -> set[str]:
             emails.add(fields[9].rsplit("<", 1)[1].rstrip(">").lower())
 
     if not emails:
-        sys.exit("::error::the signing key carries no user ID with an email address")
+        fail("the signing key carries no user ID with an email address")
     return emails
 
 
 def verify(commit: bytes, home: str) -> None:
     ok, detail = verify_status(commit, home)
     if not ok:
-        sys.exit(f"::error::{commit.decode()} did not verify: {detail}")
+        fail(f"{commit.decode()} did not verify: {detail}")
 
 
 def verify_status(commit: bytes, home: str) -> tuple[bool, str]:
@@ -100,7 +108,7 @@ def verify_status(commit: bytes, home: str) -> tuple[bool, str]:
 def header_of(raw: bytes) -> bytes:
     header, separator, _ = raw.partition(b"\n\n")
     if not separator:
-        sys.exit("::error::malformed commit object: no header/message separator")
+        fail("malformed commit object: no header/message separator")
     return header
 
 
@@ -163,7 +171,7 @@ def scan_bound() -> list[str]:
     if not SCAN_LIMIT:
         return []
     if not (SCAN_LIMIT.isascii() and SCAN_LIMIT.isdecimal() and SCAN_LIMIT.strip("0")):
-        sys.exit(f"::error::scan_limit must be a positive integer, got {SCAN_LIMIT!r}")
+        fail(f"scan_limit must be a positive integer, got {SCAN_LIMIT!r}")
     return [f"--max-count={SCAN_LIMIT}"]
 
 
@@ -175,7 +183,7 @@ def last_signed(home: str) -> str:
     )
     if objects.returncode != 0:
         detail = objects.stderr.decode(errors="replace").strip()
-        sys.exit(f"::error::git cat-file --batch failed: {detail}")
+        fail(f"git cat-file --batch failed: {detail}")
 
     data = objects.stdout
     offset = 0
@@ -188,7 +196,7 @@ def last_signed(home: str) -> str:
         offset += int(size) + 1
 
     scope = f"the last {SCAN_LIMIT} commit(s) on HEAD" if SCAN_LIMIT else "HEAD"
-    sys.exit(f"::error::no verified commit in {scope}; pass base explicitly")
+    fail(f"no verified commit in {scope}; pass base explicitly")
 
 
 def resolve_base(branch: str, home: str) -> str:
@@ -206,7 +214,7 @@ def resolve_base(branch: str, home: str) -> str:
 def main() -> None:
     branch = git("rev-parse", "--abbrev-ref", "HEAD").strip().decode()
     if branch == "HEAD":
-        sys.exit("::error::HEAD is detached; check out the branch you want signed")
+        fail("HEAD is detached; check out the branch you want signed")
 
     armored = gpg_sign("public-key")
     identities = key_identities(armored)
@@ -237,10 +245,8 @@ def main() -> None:
         return
 
     raw = {commit: git("cat-file", "commit", commit.decode()) for commit in commits}
-    ours = {
-        commit: SIGN_OTHERS or committer_email(raw[commit]) in identities
-        for commit in commits
-    }
+    mine = {commit: committer_email(raw[commit]) in identities for commit in commits}
+    ours = {commit: SIGN_OTHERS or mine[commit] for commit in commits}
 
     stale: set[bytes] = set()
     for commit in commits:
@@ -249,8 +255,8 @@ def main() -> None:
             stale.add(commit)
 
     if not stale:
-        others = sum(1 for commit in commits if not ours[commit])
-        if others == len(commits):
+        others = sum(1 for commit in commits if not mine[commit])
+        if others == len(commits) and not SIGN_OTHERS:
             warn(
                 f"Nothing was signed: all {others} commit(s) in {base}..HEAD were "
                 "committed by identities the key does not carry — dispatch with "
@@ -267,7 +273,7 @@ def main() -> None:
                 print(f"  would re-sign {commit.decode()[:8]}")
         blocked = f"would rewrite {len(resign)} already-signed commit(s) below the tip"
         remedy = "move the base forward or dispatch with allow_resign"
-        sys.exit(f"::error::signing {len(stale)} commit(s) {blocked}; {remedy}")
+        fail(f"signing {len(stale)} commit(s) {blocked}; {remedy}")
 
     rewritten: dict[bytes, bytes] = {}
     for commit in commits:

--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -200,14 +200,22 @@ def last_signed(home: str) -> str:
 
 
 def resolve_base(branch: str, home: str) -> str:
-    if BASE_REF:
-        if SCAN_LIMIT:
-            discarded = f"scan_limit={SCAN_LIMIT} was discarded because base={BASE_REF}"
-            reason = "the scan for the last signed commit only runs when base is blank"
-            warn(f"{discarded} pins the range; {reason}")
-        return git("rev-parse", "--verify", f"{BASE_REF}^{{commit}}").strip().decode()
-    if branch == DEFAULT_BRANCH:
+    if not BASE_REF and branch == DEFAULT_BRANCH:
         return last_signed(home)
+
+    if SCAN_LIMIT:
+        _ = scan_bound()
+        pinned = (
+            f"base={BASE_REF} pins the range"
+            if BASE_REF
+            else f"{branch} is not {DEFAULT_BRANCH}, so the range starts at the "
+            "merge base"
+        )
+        reason = "the scan for the last signed commit only runs when base is blank"
+        warn(f"scan_limit={SCAN_LIMIT} was discarded because {pinned}; {reason}")
+
+    if BASE_REF:
+        return git("rev-parse", "--verify", f"{BASE_REF}^{{commit}}").strip().decode()
     return git("merge-base", "HEAD", f"origin/{DEFAULT_BRANCH}").strip().decode()
 
 
@@ -302,7 +310,16 @@ def main() -> None:
 
     signed = sum(1 for commit in rewritten if ours[commit])
     print(f"Signed {signed} of {len(commits)} commit(s) in {base}..HEAD")
-    _ = git("update-ref", "HEAD", rewritten.get(head, head).decode())
+
+    tip = rewritten.get(head, head)
+    if not verify_status(tip, home)[0]:
+        warn(
+            f"Signed {signed} commit(s), but the tip {tip.decode()[:8]} still carries "
+            "no signature this key can verify; it was committed by an identity the "
+            "key does not carry — dispatch with sign_others to include it."
+        )
+
+    _ = git("update-ref", "HEAD", tip.decode())
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test-gpg-sign-git-program.sh
+++ b/.github/scripts/test-gpg-sign-git-program.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+shim="${repo_root}/.github/scripts/gpg-sign-git-program.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+mkdir "${tmp_dir}/bin"
+
+cat >"${tmp_dir}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+header=''
+url=''
+while (($#)); do
+	case "$1" in
+		--header | -H)
+			header="$2"
+			shift 2
+			;;
+		-sSf)
+			shift
+			;;
+		*)
+			url="$1"
+			shift
+			;;
+	esac
+done
+
+test "${header}" = "Authorization: bearer ${EXPECTED_OIDC_TOKEN}"
+test "${url}" = "${EXPECTED_OIDC_URL}&audience=gpg-signing-service"
+printf '{"value":"minted-token"}\n'
+EOF
+
+cat >"${tmp_dir}/bin/jq" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+test "$1" = '-r'
+test "$2" = '.value'
+cat >/dev/null
+printf 'minted-token\n'
+EOF
+
+cat >"${tmp_dir}/bin/gpg-sign" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+test "$1" = 'sign'
+test "${GPG_SIGN_TOKEN}" = 'minted-token'
+test "$(cat)" = 'commit object'
+printf '%s\n' '-----BEGIN PGP SIGNATURE-----' 'test' '-----END PGP SIGNATURE-----'
+EOF
+
+chmod +x "${tmp_dir}/bin/curl" "${tmp_dir}/bin/jq" "${tmp_dir}/bin/gpg-sign"
+
+run_signing_case() {
+	local output_file="$1"
+	local status_file="$2"
+	shift 2
+
+	printf 'commit object' | env \
+		-u GPG_SIGN_TOKEN \
+		PATH="${tmp_dir}/bin:${PATH}" \
+		GPG_SIGN_URL='https://sign.example.test' \
+		"$@" \
+		"${shim}" --status-fd=2 -bsau test-key \
+		>"${output_file}" 2>"${status_file}"
+
+	grep -q '^-----BEGIN PGP SIGNATURE-----$' "${output_file}"
+	grep -q '^\[GNUPG:\] SIG_CREATED $' "${status_file}"
+}
+
+run_signing_case "${tmp_dir}/alias-output" "${tmp_dir}/alias-status" \
+	EXPECTED_OIDC_URL='https://oidc.example.test/token?api-version=2.0' \
+	EXPECTED_OIDC_TOKEN='aliased-request-token' \
+	GPG_OIDC_REQUEST_URL='https://oidc.example.test/token?api-version=2.0' \
+	GPG_OIDC_REQUEST_TOKEN='aliased-request-token' \
+	ACTIONS_ID_TOKEN_REQUEST_URL='https://wrong.example.test' \
+	ACTIONS_ID_TOKEN_REQUEST_TOKEN='wrong-token'
+
+run_signing_case "${tmp_dir}/native-output" "${tmp_dir}/native-status" \
+	EXPECTED_OIDC_URL='https://native.example.test/token?api-version=2.0' \
+	EXPECTED_OIDC_TOKEN='native-request-token' \
+	ACTIONS_ID_TOKEN_REQUEST_URL='https://native.example.test/token?api-version=2.0' \
+	ACTIONS_ID_TOKEN_REQUEST_TOKEN='native-request-token'
+
+if printf 'commit object' | env \
+	-u ACTIONS_ID_TOKEN_REQUEST_TOKEN \
+	-u ACTIONS_ID_TOKEN_REQUEST_URL \
+	-u GPG_OIDC_REQUEST_TOKEN \
+	-u GPG_OIDC_REQUEST_URL \
+	-u GPG_SIGN_TOKEN \
+	PATH="${tmp_dir}/bin:${PATH}" \
+	GPG_SIGN_URL='https://sign.example.test' \
+	"${shim}" --status-fd=2 -bsau test-key \
+	>"${tmp_dir}/missing-output" 2>"${tmp_dir}/missing-error"; then
+	echo 'expected missing OIDC credentials to fail' >&2
+	exit 1
+fi
+
+grep -q 'OIDC request credentials are unavailable' "${tmp_dir}/missing-error"
+printf 'signing shim tests passed\n'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - name: Check for Claude token
         env: { CLAUDE_TOKEN: "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}" }
-        run: echo "HAS_CLAUDE_TOKEN=${CLAUDE_TOKEN:+true}" >> "$GITHUB_ENV"
+        run: printf 'HAS_CLAUDE_TOKEN=%s\n' "${CLAUDE_TOKEN:+true}" >> "${GITHUB_ENV}"
       - { uses: actions/checkout@v7, with: { fetch-depth: 0 } }
       - { uses: jdx/mise-action@v4 }
       - { uses: kjanat/install-dprint@v2 }
@@ -15,7 +15,10 @@ jobs:
       - { run: runner install }
       # Dogfood: fixes Claude pushes to PR branches get signed by our own service
       - uses: ./.github/actions/setup-claude-signing
-        with: { service-url: "${{ vars.SIGNING_SERVICE_URL }}" }
+        id: signing
+        with:
+          service-url: "${{ vars.SIGNING_SERVICE_URL }}"
+          claude-settings: "${{ vars.CLAUDE_SETTINGS }}"
       - name: Run Claude Code Review
         id: claude-review
         if: env.HAS_CLAUDE_TOKEN == 'true'
@@ -31,7 +34,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}
-          settings: ${{ vars.CLAUDE_SETTINGS }}
+          settings: ${{ steps.signing.outputs.settings-file }}
           allowed_bots: dependabot[bot],github-actions[bot]
           show_full_output: true
           claude_args: --permission-mode bypassPermissions

--- a/.github/workflows/claude-scheduled.yml
+++ b/.github/workflows/claude-scheduled.yml
@@ -22,7 +22,10 @@ jobs:
       - { run: runner install }
       # Dogfood: any commit this run makes is signed by the service itself
       - uses: ./.github/actions/setup-claude-signing
-        with: { service-url: "${{ vars.SIGNING_SERVICE_URL }}" }
+        id: signing
+        with:
+          service-url: "${{ vars.SIGNING_SERVICE_URL }}"
+          claude-settings: "${{ vars.CLAUDE_SETTINGS }}"
       - uses: anthropics/claude-code-action@v1
         env:
           # gh CLI is preinstalled on ubuntu-latest; used for issue triage
@@ -40,7 +43,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}
-          settings: ${{ vars.CLAUDE_SETTINGS }}
+          settings: ${{ steps.signing.outputs.settings-file }}
           prompt: |
             Run the /verify-live audit for this repository (see
             .claude/commands/verify-live.md) against

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,7 +23,10 @@ jobs:
       # this very service (OIDC-authenticated /sign call per commit). Every
       # @claude run doubles as a live integration test.
       - uses: ./.github/actions/setup-claude-signing
-        with: { service-url: "${{ vars.SIGNING_SERVICE_URL }}" }
+        id: signing
+        with:
+          service-url: "${{ vars.SIGNING_SERVICE_URL }}"
+          claude-settings: "${{ vars.CLAUDE_SETTINGS }}"
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ github.token }}
@@ -50,7 +53,7 @@ jobs:
           # and a CLI --permission-mode flag always outranks a settings-file
           # `permissions.defaultMode`. That's why CLAUDE_SETTINGS' bypassPermissions
           # alone had no effect (see run 30770718579: 7 permission denials).
-          settings: ${{ vars.CLAUDE_SETTINGS }}
+          settings: ${{ steps.signing.outputs.settings-file }}
           # User claude_args are appended AFTER the action's hardcoded flags
           # (src/modes/tag/index.ts: `claudeArgs += \` ${userClaudeArgs}\``), and the
           # parser (base-action/src/parse-sdk-options.ts) treats:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -39,7 +39,13 @@ tasks:
     desc: Run tests
     aliases: [t]
     deps: [install:noscripts]
-    cmd: bun run test
+    cmds:
+      - bun run test
+      - task: test:signing-shim
+
+  test:signing-shim:
+    desc: Test the Git commit signing shim credential paths
+    cmd: bash .github/scripts/test-gpg-sign-git-program.sh
 
   test:coverage:
     desc: Run tests with coverage


### PR DESCRIPTION
Closes the silent-green signing paths behind #31 and fixes the Claude OIDC credential handoff reported in #37.

## What changed

### Sign Commits diagnostics

- Escape `%`, CR, and LF in all workflow annotations, including errors built from refs and subprocess stderr.
- Warn when an explicit `base` resolves to `HEAD`, the selected range is empty, or every candidate belongs to another identity.
- Validate and warn when `scan_limit` is discarded on both explicit-base and feature-branch paths.
- Count foreign commits independently from `sign_others`.
- Verify the rewritten tip before `update-ref` and warn when a partial run would leave an unsigned tip, matching the PR #28 failure shape.

The warning paths keep their existing exit codes; they become visible without changing dispatch semantics.

### Claude-created commit signing

The job already granted `id-token: write`, and the runner exposed `ACTIONS_ID_TOKEN_REQUEST_*` to `claude-code-action`, but Claude's Bash subprocess did not inherit those reserved variables. Re-exporting them through `$GITHUB_ENV` therefore did not solve #37.

`setup-claude-signing` now:

- accepts the existing Claude settings as inline JSON or a file path;
- preserves those settings while merging a private `settings.env` file;
- passes neutral `GPG_OIDC_REQUEST_*` aliases and `GPG_SIGN_URL` into Claude Code;
- validates required runner inputs and keeps the request token masked;
- exposes the merged settings path for the caller.

All three Claude workflows consume that output without changing their explicit `claude_args`. The Git signing shim prefers the neutral aliases and retains the native `ACTIONS_ID_TOKEN_REQUEST_*` fallback for ordinary runner processes.

## Verification

- `task test`: 26 files and 817 tests passed, plus the signing-shim regression test.
- `task test:coverage`: 99.43% statements, 95.53% branches.
- forced `task typecheck`: `node @typescript/native --noEmit` passed.
- `task lint` and `task format:check` passed.
- all workflows pass actionlint with `shellcheck -x -o all`.
- the inline composite-action Bash, signing shim, and regression test pass `shellcheck -x -o all`.
- the regression test covers aliased credentials, native fallback, and the missing-credential failure.
- PR run 31884355284 accepted the generated settings path and completed setup. Anthropic skipped the Claude session because a PR-modified workflow is not identical to the default-branch copy; the actual Claude commit probe therefore becomes available after merge.

This does not rewrite the historical unsigned commits from 2026-08-01 through 2026-08-03.

Refs #31. Fixes #37.
