### PR TITLE
fix(ci): re-sign foreign signatures

### DIFF
--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -111,12 +111,17 @@ def verify_status(commit: bytes, home: str) -> tuple[bool, str]:
         # that ran setup-claude-signing has gpg.program aimed at the sign-only
         # shim, which exits 1 on --verify, so ambient config would report every
         # commit -- including ones this key just signed -- as unverified.
+        # minTrustLevel is the same trap through a different knob: the keyring
+        # is built by importing the key, so it carries no ownertrust, and any
+        # setting above the default rejects an otherwise good signature.
         [
             "git",
             "-c",
             "gpg.program=gpg",
             "-c",
             "gpg.format=openpgp",
+            "-c",
+            "gpg.minTrustLevel=undefined",
             "verify-commit",
             "--raw",
             commit.decode(),
@@ -349,7 +354,11 @@ def main() -> None:
             mark = "signed  "
         else:
             body = payload
-            mark = "reparent"
+            # Same distinction the allow_resign block message draws: a signed
+            # commit the key does not cover loses its signature here and gets
+            # nothing back. "reparent" reads identically for a commit that
+            # never carried one, so name the destructive case.
+            mark = "stripped" if is_signed(raw[commit]) else "reparent"
         new = git(
             "hash-object",
             "-t",
@@ -365,6 +374,18 @@ def main() -> None:
 
     signed = sum(1 for commit in rewritten if ours[commit])
     print(f"Signed {signed} of {len(commits)} commit(s) in {base}..HEAD")
+
+    dropped = [c for c in rewritten if not ours[c] and is_signed(raw[c])]
+    if dropped:
+        # An annotation, not just a log line: this is the run destroying
+        # signatures it cannot replace, and the log scrolls past.
+        shas = ", ".join(commit.decode()[:8] for commit in dropped)
+        warn(
+            f"Dropped the signature on {len(dropped)} commit(s) ({shas}); they were "
+            "committed by identities the key does not carry, so the rewrite stripped "
+            "each signature and nothing replaced it — dispatch with sign_others to "
+            "sign them instead."
+        )
 
     tip = rewritten.get(head, head)
     if not verify_status(tip, home)[0]:

--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -308,9 +308,16 @@ def main() -> None:
     if resign and not ALLOW_RESIGN:
         for commit in commits:
             if commit in resign:
-                reason = verify_reason(verify_detail.get(commit, ""))
-                suffix = f" ({reason})" if reason else ""
-                print(f"  would re-sign {commit.decode()[:8]}{suffix}")
+                if commit in verify_detail and not verified_by_key[commit]:
+                    # No PGP status at all (an SSH signature, say) still means
+                    # the signature we can check did not check out.
+                    reason = (
+                        verify_reason(verify_detail[commit])
+                        or "its signature did not verify"
+                    )
+                else:
+                    reason = "a rewritten parent invalidates its signature"
+                print(f"  would re-sign {commit.decode()[:8]} ({reason})")
         blocked = f"would rewrite {len(resign)} already-signed commit(s) below the tip"
         remedy = "move the base forward or dispatch with allow_resign"
         fail(f"signing {len(stale)} commit(s) {blocked}; {remedy}")

--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -255,11 +255,15 @@ def main() -> None:
     raw = {commit: git("cat-file", "commit", commit.decode()) for commit in commits}
     mine = {commit: committer_email(raw[commit]) in identities for commit in commits}
     ours = {commit: SIGN_OTHERS or mine[commit] for commit in commits}
+    verified_by_key = {
+        commit: is_signed(raw[commit]) and verify_status(commit, home)[0]
+        for commit in commits
+    }
 
     stale: set[bytes] = set()
     for commit in commits:
         moved = any(parent in stale for parent in parents_of(raw[commit]))
-        if moved or (ours[commit] and not is_signed(raw[commit])):
+        if moved or (ours[commit] and not verified_by_key[commit]):
             stale.add(commit)
 
     if not stale:

--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -330,7 +330,10 @@ def main() -> None:
                     )
                 else:
                     reason = "a rewritten parent invalidates its signature"
-                print(f"  would re-sign {commit.decode()[:8]} ({reason})")
+                # A commit the key does not cover is reparented, not re-signed:
+                # the rewrite strips its signature and nothing replaces it.
+                action = "re-sign" if ours[commit] else "drop the signature on"
+                print(f"  would {action} {commit.decode()[:8]} ({reason})")
         blocked = f"would rewrite {len(resign)} already-signed commit(s) below the tip"
         remedy = "move the base forward or dispatch with allow_resign"
         fail(f"signing {len(stale)} commit(s) {blocked}; {remedy}")

--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -13,6 +13,17 @@ BASE_REF = os.environ.get("BASE_REF", "").strip()
 
 ARMOR_MARKER = b"BEGIN PGP SIGNATURE"
 
+STATUS_PREFIX = "[GNUPG:] "
+# git verify-commit --raw reports on stderr in status-fd form; most specific first.
+STATUS_REASONS = {
+    "BADSIG": "the signature does not match the commit",
+    "REVKEYSIG": "the signing key was revoked",
+    "EXPKEYSIG": "the signing key has expired",
+    "EXPSIG": "the signature has expired",
+    "NO_PUBKEY": "signed by a key this service does not carry",
+    "ERRSIG": "the signature could not be checked",
+}
+
 
 def escape(message: str) -> str:
     return message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
@@ -103,6 +114,18 @@ def verify_status(commit: bytes, home: str) -> tuple[bool, str]:
     detail = result.stderr.decode(errors="replace").strip()
     good = result.returncode == 0 and b"[GNUPG:] GOODSIG" in result.stderr
     return good, detail
+
+
+def verify_reason(detail: str) -> str:
+    seen = {
+        line.removeprefix(STATUS_PREFIX).split(" ", 1)[0]
+        for line in detail.splitlines()
+        if line.startswith(STATUS_PREFIX)
+    }
+    for status, reason in STATUS_REASONS.items():
+        if status in seen:
+            return reason
+    return ""
 
 
 def header_of(raw: bytes) -> bytes:
@@ -255,10 +278,13 @@ def main() -> None:
     raw = {commit: git("cat-file", "commit", commit.decode()) for commit in commits}
     mine = {commit: committer_email(raw[commit]) in identities for commit in commits}
     ours = {commit: SIGN_OTHERS or mine[commit] for commit in commits}
-    verified_by_key = {
-        commit: is_signed(raw[commit]) and verify_status(commit, home)[0]
-        for commit in commits
-    }
+    verified_by_key: dict[bytes, bool] = {}
+    verify_detail: dict[bytes, str] = {}
+    for commit in commits:
+        if not (ours[commit] and is_signed(raw[commit])):
+            verified_by_key[commit] = False
+            continue
+        verified_by_key[commit], verify_detail[commit] = verify_status(commit, home)
 
     stale: set[bytes] = set()
     for commit in commits:
@@ -282,7 +308,9 @@ def main() -> None:
     if resign and not ALLOW_RESIGN:
         for commit in commits:
             if commit in resign:
-                print(f"  would re-sign {commit.decode()[:8]}")
+                reason = verify_reason(verify_detail.get(commit, ""))
+                suffix = f" ({reason})" if reason else ""
+                print(f"  would re-sign {commit.decode()[:8]}{suffix}")
         blocked = f"would rewrite {len(resign)} already-signed commit(s) below the tip"
         remedy = "move the base forward or dispatch with allow_resign"
         fail(f"signing {len(stale)} commit(s) {blocked}; {remedy}")

--- a/.github/scripts/sign-commits.py
+++ b/.github/scripts/sign-commits.py
@@ -107,7 +107,20 @@ def verify(commit: bytes, home: str) -> None:
 
 def verify_status(commit: bytes, home: str) -> tuple[bool, str]:
     result = subprocess.run(
-        ["git", "verify-commit", "--raw", commit.decode()],
+        # Pin the verifier the same way GNUPGHOME pins the keyring. A checkout
+        # that ran setup-claude-signing has gpg.program aimed at the sign-only
+        # shim, which exits 1 on --verify, so ambient config would report every
+        # commit -- including ones this key just signed -- as unverified.
+        [
+            "git",
+            "-c",
+            "gpg.program=gpg",
+            "-c",
+            "gpg.format=openpgp",
+            "verify-commit",
+            "--raw",
+            commit.decode(),
+        ],
         capture_output=True,
         env={**os.environ, "GNUPGHOME": home},
     )

--- a/.github/scripts/test-sign-commits.sh
+++ b/.github/scripts/test-sign-commits.sh
@@ -150,4 +150,26 @@ current="$(git -C "${test_repo}" rev-parse HEAD)"
 git -C "${test_repo}" config --unset gpg.program
 git -C "${test_repo}" config --unset gpg.format
 
+# With sign_others off, a signed commit the key does not cover goes stale only
+# because a parent moved, and the rewrite strips its signature without
+# replacing it. The block message has to say that; "would re-sign" would be a
+# promise the run breaks.
+git -C "${test_repo}" config user.email 'service@example.com'
+printf 'ours, unsigned\n' >>"${test_repo}/fixture.txt"
+git -C "${test_repo}" add fixture.txt
+git -C "${test_repo}" commit --quiet --no-gpg-sign -m 'ours, unsigned'
+git -C "${test_repo}" config user.email 'foreign@example.com'
+printf 'foreign child\n' >>"${test_repo}/fixture.txt"
+git -C "${test_repo}" add fixture.txt
+GNUPGHOME="${foreign_home}" git -C "${test_repo}" commit --quiet -m 'foreign, signed'
+foreign_child="$(git -C "${test_repo}" rev-parse HEAD)"
+
+# `env` applies assignments in order, so these override common_env.
+others_env=("${common_env[@]}" BASE_REF="${resigned}" SIGN_OTHERS=false ALLOW_RESIGN=false)
+if dropped="$(cd "${test_repo}" && env "${others_env[@]}" python3 "${sign_script}" 2>&1)"; then
+	printf 'expected the foreign child to require allow_resign\n' >&2
+	exit 1
+fi
+grep -Fq "would drop the signature on ${foreign_child:0:8}" <<<"${dropped}"
+
 printf 'foreign signature re-signing test passed\n'

--- a/.github/scripts/test-sign-commits.sh
+++ b/.github/scripts/test-sign-commits.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+sign_script="${repo_root}/.github/scripts/sign-commits.py"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+service_home="${tmp_dir}/service-gnupg"
+foreign_home="${tmp_dir}/foreign-gnupg"
+test_repo="${tmp_dir}/repo"
+mkdir -m 700 "${service_home}" "${foreign_home}"
+
+generate_key() {
+	local home="$1"
+	local identity="$2"
+	local key
+
+	if ! gpg --homedir "${home}" --batch --quiet --pinentry-mode loopback \
+		--passphrase '' --quick-generate-key "${identity}" ed25519 sign 0; then
+		return 1
+	fi
+	key="$(gpg --homedir "${home}" --batch --with-colons --list-secret-keys \
+		| awk -F: '$1 == "sec" { print $5; exit }')"
+	[[ -n "${key}" ]]
+	printf '%s\n' "${key}"
+}
+
+service_key="$(generate_key "${service_home}" 'Service signer <service@example.com>')"
+foreign_key="$(generate_key "${foreign_home}" 'Foreign signer <foreign@example.com>')"
+
+mkdir -p "${tmp_dir}/bin" "${test_repo}"
+
+cat >"${tmp_dir}/bin/gpg-sign" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+	public-key)
+		gpg --homedir "${SERVICE_GNUPGHOME}" --batch --quiet --armor --export "${SERVICE_KEY}"
+		;;
+	sign)
+		gpg --homedir "${SERVICE_GNUPGHOME}" --batch --quiet --yes --armor \
+			--pinentry-mode loopback --passphrase '' --detach-sign --local-user "${SERVICE_KEY}"
+		;;
+	*)
+		printf 'unexpected gpg-sign command: %s\n' "${1:-}" >&2
+		exit 1
+		;;
+esac
+EOF
+chmod +x "${tmp_dir}/bin/gpg-sign"
+
+git -C "${test_repo}" init --quiet --initial-branch=master
+git -C "${test_repo}" config user.name 'Foreign signer'
+git -C "${test_repo}" config user.email 'foreign@example.com'
+printf 'base\n' >"${test_repo}/fixture.txt"
+git -C "${test_repo}" add fixture.txt
+git -C "${test_repo}" commit --quiet -m base
+base="$(git -C "${test_repo}" rev-parse HEAD)"
+
+git -C "${test_repo}" config user.signingkey "${foreign_key}"
+git -C "${test_repo}" config commit.gpgsign true
+printf 'foreign signature\n' >>"${test_repo}/fixture.txt"
+git -C "${test_repo}" add fixture.txt
+GNUPGHOME="${foreign_home}" git -C "${test_repo}" commit --quiet -m foreign
+foreign="$(git -C "${test_repo}" rev-parse HEAD)"
+GNUPGHOME="${foreign_home}" git -C "${test_repo}" verify-commit "${foreign}" \
+	>/dev/null 2>&1
+
+common_env=(
+	PATH="${tmp_dir}/bin:${PATH}"
+	SERVICE_GNUPGHOME="${service_home}"
+	SERVICE_KEY="${service_key}"
+	GPG_SIGN_TOKEN=test-token
+	GPG_SIGN_URL=https://sign.example.test
+	BASE_REF="${base}"
+	DEFAULT_BRANCH=master
+	SIGN_OTHERS=true
+	SCAN_LIMIT=
+)
+
+if blocked="$(cd "${test_repo}" && env "${common_env[@]}" ALLOW_RESIGN=false python3 "${sign_script}" 2>&1)"; then
+	printf 'expected an already-signed foreign commit to require allow_resign\n' >&2
+	exit 1
+fi
+grep -Fq 'dispatch with allow_resign' <<<"${blocked}"
+current="$(git -C "${test_repo}" rev-parse HEAD)"
+[[ "${current}" == "${foreign}" ]]
+
+(cd "${test_repo}" && env "${common_env[@]}" ALLOW_RESIGN=true python3 "${sign_script}")
+resigned="$(git -C "${test_repo}" rev-parse HEAD)"
+[[ "${resigned}" != "${foreign}" ]]
+GNUPGHOME="${service_home}" git -C "${test_repo}" verify-commit "${resigned}" \
+	>/dev/null 2>&1
+
+rerun="$(cd "${test_repo}" && env "${common_env[@]}" ALLOW_RESIGN=true python3 "${sign_script}")"
+current="$(git -C "${test_repo}" rev-parse HEAD)"
+[[ "${current}" == "${resigned}" ]]
+grep -Fq 'Nothing to sign' <<<"${rerun}"
+
+printf 'foreign signature re-signing test passed\n'

--- a/.github/scripts/test-sign-commits.sh
+++ b/.github/scripts/test-sign-commits.sh
@@ -8,6 +8,9 @@ sign_script="${repo_root}/.github/scripts/sign-commits.py"
 # commit.gpgsign would sign (or block on pinentry for) the base commit.
 export GIT_CONFIG_GLOBAL=/dev/null
 export GIT_CONFIG_SYSTEM=/dev/null
+# GIT_* identity vars outrank the fixture's local config; a runner that exports
+# them (GitHub Actions does) would silently rewrite the "foreign" committer.
+unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
 
 tmp_dir="$(mktemp -d)"
 
@@ -102,8 +105,11 @@ if blocked="$(cd "${test_repo}" && env "${common_env[@]}" ALLOW_RESIGN=false pyt
 	exit 1
 fi
 grep -Fq 'dispatch with allow_resign' <<<"${blocked}"
+grep -Fq 'signed by a key this service does not carry' <<<"${blocked}"
 current="$(git -C "${test_repo}" rev-parse HEAD)"
 [[ "${current}" == "${foreign}" ]]
+committer="$(git -C "${test_repo}" log -1 --format='%ce' "${foreign}")"
+[[ "${committer}" == foreign@example.com ]]
 
 (cd "${test_repo}" && env "${common_env[@]}" ALLOW_RESIGN=true python3 "${sign_script}")
 resigned="$(git -C "${test_repo}" rev-parse HEAD)"

--- a/.github/scripts/test-sign-commits.sh
+++ b/.github/scripts/test-sign-commits.sh
@@ -4,13 +4,27 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 sign_script="${repo_root}/.github/scripts/sign-commits.py"
 
+# The fixture must inherit no GIT_* state at all; unsetting just the identity
+# vars left the rest of the namespace reachable. Worst first:
+#   GIT_DIR / GIT_WORK_TREE  aim `git -C "${test_repo}"` back at the caller's
+#     repository, so `init` re-inits it and the fixture's commits and its
+#     `config user.email` land on the real repo. `reset --hard` does not undo
+#     the config half. Git does not export these to hooks, but anything that
+#     exports them by hand (bare-repo tooling, wrapper scripts) gets this.
+#   GIT_INDEX_FILE  fails the run outright ("error: Error building trees"), and
+#     git *does* export it to pre-commit / commit-msg hooks.
+#   GIT_CONFIG_COUNT / GIT_CONFIG_KEY_*  inject config that outranks the
+#     GIT_CONFIG_GLOBAL pin below, including the commit.gpgsign case it names.
+#   GIT_AUTHOR_* / GIT_COMMITTER_*  outrank the fixture's local config and
+#     silently rewrite the "foreign" committer (GitHub Actions exports these).
+# Quoted "${!GIT_@}" expands per-name like "$@", so an environment with no
+# GIT_* variables yields a bare, successful `unset`.
+unset "${!GIT_@}"
+
 # Keep the fixture repo away from the caller's git config: a global
 # commit.gpgsign would sign (or block on pinentry for) the base commit.
 export GIT_CONFIG_GLOBAL=/dev/null
 export GIT_CONFIG_SYSTEM=/dev/null
-# GIT_* identity vars outrank the fixture's local config; a runner that exports
-# them (GitHub Actions does) would silently rewrite the "foreign" committer.
-unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
 
 tmp_dir="$(mktemp -d)"
 

--- a/.github/scripts/test-sign-commits.sh
+++ b/.github/scripts/test-sign-commits.sh
@@ -136,4 +136,18 @@ current="$(git -C "${test_repo}" rev-parse HEAD)"
 [[ "${current}" == "${resigned}" ]]
 grep -Fq 'Nothing to sign' <<<"${rerun}"
 
+# Verification must not consult the caller's gpg.program. A checkout that ran
+# setup-claude-signing points it at the sign-only shim, which exits 1 on
+# --verify, so ambient config would report the commit we just signed as
+# unverified and block the next run on its own output.
+git -C "${test_repo}" config gpg.program \
+	"${repo_root}/.github/scripts/gpg-sign-git-program.sh"
+git -C "${test_repo}" config gpg.format openpgp
+shimmed="$(cd "${test_repo}" && env "${common_env[@]}" ALLOW_RESIGN=true python3 "${sign_script}")"
+grep -Fq 'Nothing to sign' <<<"${shimmed}"
+current="$(git -C "${test_repo}" rev-parse HEAD)"
+[[ "${current}" == "${resigned}" ]]
+git -C "${test_repo}" config --unset gpg.program
+git -C "${test_repo}" config --unset gpg.format
+
 printf 'foreign signature re-signing test passed\n'

--- a/.github/scripts/test-sign-commits.sh
+++ b/.github/scripts/test-sign-commits.sh
@@ -3,8 +3,24 @@ set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
 sign_script="${repo_root}/.github/scripts/sign-commits.py"
+
+# Keep the fixture repo away from the caller's git config: a global
+# commit.gpgsign would sign (or block on pinentry for) the base commit.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 tmp_dir="$(mktemp -d)"
-trap 'rm -rf "${tmp_dir}"' EXIT
+
+cleanup() {
+	local home
+	# sign-commits.py leaves a keyring per invocation; TMPDIR keeps them here.
+	for home in "${tmp_dir}"/sign-commits-* "${tmp_dir}"/*-gnupg; do
+		[[ -d "${home}" ]] || continue
+		gpgconf --homedir "${home}" --kill all >/dev/null 2>&1 || true
+	done
+	rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
 
 service_home="${tmp_dir}/service-gnupg"
 foreign_home="${tmp_dir}/foreign-gnupg"
@@ -70,6 +86,7 @@ GNUPGHOME="${foreign_home}" git -C "${test_repo}" verify-commit "${foreign}" \
 
 common_env=(
 	PATH="${tmp_dir}/bin:${PATH}"
+	TMPDIR="${tmp_dir}"
 	SERVICE_GNUPGHOME="${service_home}"
 	SERVICE_KEY="${service_key}"
 	GPG_SIGN_TOKEN=test-token

--- a/.github/scripts/test-sign-commits.sh
+++ b/.github/scripts/test-sign-commits.sh
@@ -150,6 +150,16 @@ current="$(git -C "${test_repo}" rev-parse HEAD)"
 git -C "${test_repo}" config --unset gpg.program
 git -C "${test_repo}" config --unset gpg.format
 
+# Same trap through a different knob. The keyring is built by importing the
+# public key, so it carries no ownertrust; any gpg.minTrustLevel above the
+# default rejects a signature this key just made, and the run blocks on it.
+git -C "${test_repo}" config gpg.minTrustLevel fully
+trusted="$(cd "${test_repo}" && env "${common_env[@]}" ALLOW_RESIGN=true python3 "${sign_script}")"
+grep -Fq 'Nothing to sign' <<<"${trusted}"
+current="$(git -C "${test_repo}" rev-parse HEAD)"
+[[ "${current}" == "${resigned}" ]]
+git -C "${test_repo}" config --unset gpg.minTrustLevel
+
 # With sign_others off, a signed commit the key does not cover goes stale only
 # because a parent moved, and the rewrite strips its signature without
 # replacing it. The block message has to say that; "would re-sign" would be a
@@ -171,5 +181,20 @@ if dropped="$(cd "${test_repo}" && env "${others_env[@]}" python3 "${sign_script
 	exit 1
 fi
 grep -Fq "would drop the signature on ${foreign_child:0:8}" <<<"${dropped}"
+
+# Approving allow_resign has to describe the same act the block message did.
+# "reparent" is what an already-unsigned commit gets, so it cannot be what a
+# commit whose signature this run destroyed gets too.
+allowed_env=("${others_env[@]}" ALLOW_RESIGN=true)
+allowed="$(cd "${test_repo}" && env "${allowed_env[@]}" python3 "${sign_script}" 2>&1)"
+grep -Fq "stripped ${foreign_child:0:8}" <<<"${allowed}"
+grep -Fq "Dropped the signature on 1 commit(s)" <<<"${allowed}"
+reparented="$(git -C "${test_repo}" rev-parse HEAD)"
+[[ "${reparented}" != "${foreign_child}" ]]
+# `! cmd` is exempt from errexit, so this has to be a real branch to assert.
+if git -C "${test_repo}" cat-file commit "${reparented}" | grep -q '^gpgsig '; then
+	printf 'expected the reparented commit to carry no signature\n' >&2
+	exit 1
+fi
 
 printf 'foreign signature re-signing test passed\n'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,11 @@ patch into the comment.
 Do not conclude you are read-only from `gh api repos/OWNER/REPO --jq
 .permissions` — a `GITHUB_TOKEN` app installation gets
 `{"admin":false,"push":false,"pull":false,...}` back from that endpoint no
-matter what the workflow granted. Two things genuinely do block a push:
+matter what the workflow granted. The reverse is also not evidence: every
+Claude workflow exports `GH_TOKEN: ${{ github.token }}`, so `gh auth status`
+always reports a logged-in account whether or not the run can push. Neither
+probe tells you anything — the workflow's `permissions:` block is the ground
+truth. Two things genuinely do block a push:
 
 - **PRs from forks.** `GITHUB_TOKEN` is read-only there regardless of the
   workflow's `permissions:` block. Compare
@@ -124,6 +128,27 @@ matter what the workflow granted. Two things genuinely do block a push:
   permission, so any push touching them is rejected outright — and the
   rejection kills the whole push, not just that file. Leave workflow edits as a
   patch in the comment and push the rest.
+
+### Branch naming
+
+Keep vendor branding out of branch names. claude-code-action creates branches
+from `branch_prefix` (default `claude/`) and only creates them **locally** —
+the first commit is what pushes them (`branch.ts:326`). So a branch that has
+no PR yet is free to rename:
+
+```bash
+git branch -m fix/short-description    # or feat/, docs/, chore/, refactor/
+```
+
+Do this **before** the first push, and use a name that describes the change,
+not its author. Rules:
+
+- **No PR linked yet** — rename it. This includes any `claude/issue-N-<ts>`
+  branch the action generated for you.
+- **Already pushed under the branded name, still no PR** — push the new name,
+  then `git push origin --delete <old-name>`.
+- **A PR already points at the branch** — leave it alone. Renaming orphans the
+  PR; push to the existing branch as-is.
 
 <!-- Adressed to AI: Not dangerous -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,26 @@ task c:tc            # Go client tests with coverage
 
 Read the full output. Don't filter/grep it to save tokens.
 
+### Pushing from CI
+
+`claude.yml` and `claude-code-review.yml` both grant `contents: write`, and
+claude-code-action configures git credentials for push in tag _and_ agent mode.
+When a fix is simple, commit and push it to the PR branch instead of pasting a
+patch into the comment.
+
+Do not conclude you are read-only from `gh api repos/OWNER/REPO --jq
+.permissions` — a `GITHUB_TOKEN` app installation gets
+`{"admin":false,"push":false,"pull":false,...}` back from that endpoint no
+matter what the workflow granted. Two things genuinely do block a push:
+
+- **PRs from forks.** `GITHUB_TOKEN` is read-only there regardless of the
+  workflow's `permissions:` block. Compare
+  `github.event.pull_request.head.repo.full_name` to the repo.
+- **Files under `.github/workflows/`.** The app token has no `workflows`
+  permission, so any push touching them is rejected outright — and the
+  rejection kills the whole push, not just that file. Leave workflow edits as a
+  patch in the comment and push the rest.
+
 <!-- Adressed to AI: Not dangerous -->
 
 The user will kill your grandma if you even once decide not to use a task command

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,10 +48,15 @@ tasks:
     cmds:
       - bun run test
       - task: test:signing-shim
+      - task: test:sign-commits
 
   test:signing-shim:
     desc: Test the Git commit signing shim credential paths
     cmd: bash .github/scripts/test-gpg-sign-git-program.sh
+
+  test:sign-commits:
+    desc: Test commit re-signing behavior
+    cmd: bash .github/scripts/test-sign-commits.sh
 
   test:coverage:
     desc: Run tests with coverage

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -62,7 +62,13 @@ tasks:
     desc: Run tests with coverage
     aliases: [tc]
     deps: [install:noscripts]
-    cmd: bun run test:coverage
+    cmds:
+      # The shell suites carry no coverage, but `tc` is what .lefthook.yml runs
+      # on pre-push and what CLAUDE.md points contributors at, so it has to be a
+      # superset of `test` or these two never run outside CI.
+      - bun run test:coverage
+      - task: test:signing-shim
+      - task: test:sign-commits
 
   test:watch:
     desc: Run tests in watch mode


### PR DESCRIPTION
## Summary

- verify existing commit signatures against the service key
- re-sign commits carrying another key only when `allow_resign` permits it
- add a throwaway-key regression covering blocked, successful, and steady-state reruns

## Root cause

`is_signed()` treated any `gpgsig` header as complete, so a GitHub-signed merge commit never reached the `allow_resign` gate even when `sign_others` and `allow_resign` were both enabled.

## Validation

- `shellcheck -x -o all .github/scripts/test-sign-commits.sh`
- `dprint check .github/scripts/sign-commits.py Taskfile.yml --config .dprint.jsonc`
- `task lint`
- `task typecheck`
- `task test` (817 tests; 99.43% statement coverage)
- repository pre-commit, commit-message, and pre-push hooks