### PR TITLE
fix(security): bound the signing rate per trusted row, not just per subject

### DIFF
--- a/src/__tests__/branch-coverage.test.ts
+++ b/src/__tests__/branch-coverage.test.ts
@@ -314,6 +314,40 @@ describe("Branch Coverage Helpers", () => {
 			expect(json).toHaveBeenCalledWith(expect.objectContaining({ code: "AUTH_MISSING" }), 401);
 		});
 
+		it("returns the admin limiter's 429 as a verdict rather than an outage", async () => {
+			// The real Durable Object answers a denied consume with a 429 carrying
+			// the verdict. Reading that as a failure answered 503 with no
+			// `retryAfter` and made the `allowed` branch unreachable.
+			const customEnv = {
+				...env,
+				RATE_LIMITER: {
+					idFromName: () => ({}) as any,
+					get: () => ({
+						fetch: () =>
+							Promise.resolve(Response.json({ allowed: false, resetAt: Date.now() + 60_000 }, { status: 429 })),
+					}),
+				},
+			};
+
+			const json = vi.fn();
+			const context = {
+				req: {
+					header: (name: string) => (name === "Authorization" ? "Bearer admin" : "1.2.3.4"),
+				},
+				env: customEnv,
+				json,
+			};
+
+			await import("#middleware/security").then(({ adminRateLimit }) =>
+				adminRateLimit(context as any, () => Promise.resolve()),
+			);
+
+			expect(json).toHaveBeenCalledWith(
+				expect.objectContaining({ code: "RATE_LIMITED", retryAfter: expect.any(Number) }),
+				429,
+			);
+		});
+
 		it("fails closed when admin rate limiter fails", async () => {
 			const customEnv = {
 				...env,

--- a/src/__tests__/branch-coverage.test.ts
+++ b/src/__tests__/branch-coverage.test.ts
@@ -206,13 +206,14 @@ describe("Branch Coverage Helpers", () => {
 
 	describe("Middleware branches", () => {
 		it("fails admin rate limit when allowance is false", async () => {
-			const denyResponse = new Response(
-				JSON.stringify({
-					allowed: false,
-					resetAt: Date.now() + 10_000,
-					remaining: 0,
-				}),
-				{ status: 200, headers: { "Content-Type": "application/json" } },
+			// 429, the way the real Durable Object answers a denial. A 200 here is the
+			// shape the limiter never produces, and it is what let the middleware read
+			// every 429 as an outage while this assertion still passed.
+			const denyResponse = Response.json(
+				{ allowed: false, resetAt: Date.now() + 10_000, remaining: 0 },
+				{
+					status: 429,
+				},
 			);
 
 			const customEnv = {

--- a/src/__tests__/branch-coverage.test.ts
+++ b/src/__tests__/branch-coverage.test.ts
@@ -51,6 +51,7 @@ vi.mock("#middleware/oidc", async (importOriginal) => {
 // Minimal in-memory DurableObjectState mock
 function createState(): DurableObjectState {
 	const store = new Map<string, any>();
+	let alarm: number | null = null;
 	return {
 		storage: {
 			async get(key: string) {
@@ -59,17 +60,32 @@ function createState(): DurableObjectState {
 			async put(key: string, value: any) {
 				store.set(key, value);
 			},
-			async delete(key: string) {
-				const existed = store.has(key);
-				store.delete(key);
-				return existed;
+			async delete(key: string | string[]) {
+				const keys = Array.isArray(key) ? key : [key];
+				let deleted = 0;
+				for (const k of keys) {
+					if (store.delete(k)) deleted += 1;
+				}
+				return Array.isArray(key) ? deleted : deleted > 0;
 			},
-			async list({ prefix }: { prefix: string }) {
+			async list({ prefix, limit }: { prefix: string; limit?: number }) {
 				const filtered = new Map<string, any>();
 				for (const [k, v] of store.entries()) {
+					if (limit !== undefined && filtered.size >= limit) break;
 					if (k.startsWith(prefix)) filtered.set(k, v);
 				}
 				return filtered;
+			},
+			// The limiter arms an alarm to reap abandoned buckets; without these the
+			// consume path throws and every case here reports as a 500.
+			async getAlarm() {
+				return alarm;
+			},
+			async setAlarm(scheduled: number) {
+				alarm = scheduled;
+			},
+			async deleteAlarm() {
+				alarm = null;
 			},
 		},
 	} as unknown as DurableObjectState;

--- a/src/__tests__/rate-limiter.test.ts
+++ b/src/__tests__/rate-limiter.test.ts
@@ -1,5 +1,7 @@
+import { runInDurableObject } from "cloudflare:test";
 import { env } from "cloudflare:workers";
 import { beforeAll, describe, expect, it } from "vitest";
+import type { RateLimiter } from "#durable-objects/rate-limiter";
 import type { RateLimitResult } from "#types";
 
 /**
@@ -112,43 +114,25 @@ describe("RateLimiter Durable Object", () => {
 		it("should return denied when tokens are exhausted", async () => {
 			const stub = getRateLimiter("check-exhausted");
 
-			// Consume until the bucket actually reports empty rather than a fixed
-			// count: the bucket refills at one token per 600ms, so a fixed loop that
-			// runs slowly under load hands tokens back faster than it takes them and
-			// the check below finds the bucket non-empty.
-			let denied: Response | undefined;
-			for (let i = 0; i < 500 && !denied; i++) {
-				const consumed = await stub.fetch("http://localhost/consume?identity=exhausted-user");
-				if (consumed.status === 429) {
-					denied = consumed;
-				}
-			}
-			expect(denied).toBeDefined();
+			// A capacity of one drains in a single call, so neither the drain nor the
+			// `/check` below is racing the refill. Draining down from 100 needed a
+			// loop bounded at 500 sequential round-trips, and a run slow enough to
+			// need them was a run slow enough to blow the 5s test timeout.
+			await stub.fetch("http://localhost/consume?identity=exhausted-user&limit=1");
+			const denied = await stub.fetch("http://localhost/consume?identity=exhausted-user&limit=1");
 
-			// Assert on the denial itself rather than a second round-trip: the loop
-			// exits with a fraction of a token left, and the bucket refills at one
-			// per 600ms, so a separate /check can be answered *after* enough time
-			// has passed to hand that fraction back.
-			const result = (await denied?.json()) as RateLimitResult;
+			const result = (await denied.json()) as RateLimitResult;
+			expect(denied.status).toBe(429);
 			expect(result.allowed).toBe(false);
 			expect(result.remaining).toBe(0);
 
-			// /check has its own denied branch. The bucket sits just under one token
-			// and refills at one per 600ms, so a stalled scheduler can hand it back
-			// between calls — drain again rather than assuming a single round-trip
-			// wins the race.
-			let checked: RateLimitResult | undefined;
-			for (let i = 0; i < 10; i++) {
-				const response = await stub.fetch("http://localhost/check?identity=exhausted-user");
-				expect(response.status).toBe(200);
-				checked = (await response.json()) as RateLimitResult;
-				if (!checked.allowed) {
-					break;
-				}
-				await stub.fetch("http://localhost/consume?identity=exhausted-user");
-			}
-			expect(checked?.allowed).toBe(false);
-			expect(checked?.remaining).toBe(0);
+			// `/check` has its own denied branch, and at a capacity of one the bucket
+			// needs a full window to hand a token back.
+			const response = await stub.fetch("http://localhost/check?identity=exhausted-user");
+			expect(response.status).toBe(200);
+			const checked = (await response.json()) as RateLimitResult;
+			expect(checked.allowed).toBe(false);
+			expect(checked.remaining).toBe(0);
 		});
 	});
 
@@ -188,19 +172,15 @@ describe("RateLimiter Durable Object", () => {
 		it("should return 429 when tokens exhausted", async () => {
 			const stub = getRateLimiter("consume-exhausted");
 
-			let hitLimit = false;
-			// Bounded well above the bucket size: refill runs at one token per 600ms,
-			// so a loop that iterates slowly under load needs more turns than the
-			// 100-token capacity to get ahead of it.
-			for (let i = 0; i < 500; i++) {
-				const res = await stub.fetch("http://localhost/consume?identity=test-user");
-				if (res.status === 429) {
-					hitLimit = true;
-					break;
-				}
-			}
+			// Drained by giving the bucket a capacity of one rather than by racing
+			// the refill down from 100. The loop this replaces cost up to 500
+			// sequential round-trips into a single-threaded Durable Object, which
+			// overran vitest's 5s default under CI load — a timeout that reported as
+			// the whole file erroring rather than as this assertion.
+			await stub.fetch("http://localhost/consume?identity=test-user&limit=1");
+			const denied = await stub.fetch("http://localhost/consume?identity=test-user&limit=1");
 
-			expect(hitLimit).toBe(true);
+			expect(denied.status).toBe(429);
 		});
 
 		it("should use default identity when not provided", async () => {
@@ -210,6 +190,79 @@ describe("RateLimiter Durable Object", () => {
 			expect(response.status).toBe(200);
 			const result = (await response.json()) as RateLimitResult;
 			expect(result.allowed).toBe(true);
+		});
+	});
+
+	describe("bucket reaping", () => {
+		/** Move a bucket's clock back past a full window without waiting one out. */
+		async function backdate(state: DurableObjectState, key: string) {
+			const bucket = await state.storage.get<{ tokens: number; lastRefill: number }>(key);
+			expect(bucket).toBeDefined();
+			await state.storage.put(key, { ...bucket, lastRefill: Date.now() - 120_000 });
+		}
+
+		it("persists no key for a bucket nobody has drawn down", async () => {
+			// `/check` used to mint a row per identity it was asked about, which on
+			// the admin limiter is one row per source IP, before any credential.
+			const stub = getRateLimiter("reap-read-only");
+			await stub.fetch("http://localhost/check?identity=untouched");
+
+			await runInDurableObject(stub, async (_instance, state) => {
+				expect(await state.storage.get("bucket:untouched")).toBeUndefined();
+			});
+		});
+
+		it("reaps a bucket that has refilled to capacity and keeps a live one", async () => {
+			const stub = getRateLimiter("reap-sweep");
+			await stub.fetch("http://localhost/consume?identity=idle");
+			await stub.fetch("http://localhost/consume?identity=busy");
+
+			await runInDurableObject(stub, async (instance, state) => {
+				await backdate(state, "bucket:idle");
+				await (instance as RateLimiter).alarm();
+
+				// Not a reset: a missing bucket is created full, which is what an idle
+				// one has refilled to, so the two answer identically.
+				expect(await state.storage.get("bucket:idle")).toBeUndefined();
+				expect(await state.storage.get("bucket:busy")).toBeDefined();
+				// A live bucket remains, so the reaper stays armed for it.
+				expect(await state.storage.getAlarm()).not.toBeNull();
+			});
+		});
+
+		it("stops re-arming once nothing is left to reap", async () => {
+			// Otherwise an object that has gone quiet wakes itself forever.
+			const stub = getRateLimiter("reap-quiesce");
+			await stub.fetch("http://localhost/consume?identity=lonely");
+
+			await runInDurableObject(stub, async (instance, state) => {
+				await backdate(state, "bucket:lonely");
+				await state.storage.deleteAlarm();
+				await (instance as RateLimiter).alarm();
+
+				expect(await state.storage.get("bucket:lonely")).toBeUndefined();
+				expect(await state.storage.getAlarm()).toBeNull();
+			});
+		});
+
+		it("answers a reaped identity exactly as it answers a fresh one", async () => {
+			const stub = getRateLimiter("reap-equivalence");
+			await stub.fetch("http://localhost/consume?identity=recycled");
+
+			await runInDurableObject(stub, async (instance, state) => {
+				await backdate(state, "bucket:recycled");
+				await (instance as RateLimiter).alarm();
+			});
+
+			const recycled = (await (
+				await stub.fetch("http://localhost/consume?identity=recycled")
+			).json()) as RateLimitResult;
+			const fresh = (await (
+				await stub.fetch("http://localhost/consume?identity=never-seen")
+			).json()) as RateLimitResult;
+
+			expect(recycled).toStrictEqual(expect.objectContaining({ allowed: true }));
+			expect(recycled.allowed && recycled.remaining).toBe(fresh.allowed && fresh.remaining);
 		});
 	});
 

--- a/src/__tests__/rate-limiter.test.ts
+++ b/src/__tests__/rate-limiter.test.ts
@@ -245,6 +245,43 @@ describe("RateLimiter Durable Object", () => {
 			});
 		});
 
+		it("sweeps past a full page instead of re-reading it", async () => {
+			// `list` has no implicit cursor. A first page of live buckets used to
+			// hide every key behind it from the sweep *and* re-arm the alarm at one
+			// second, so the object woke every second forever and reaped nothing —
+			// on the one Durable Object that gates every signature.
+			const stub = getRateLimiter("reap-paging");
+			await stub.fetch("http://localhost/consume?identity=seed");
+
+			await runInDurableObject(stub, async (instance, state) => {
+				const now = Date.now();
+				// A full page (`sweepBatch`) of live buckets, all sorting before the
+				// one stale bucket behind them.
+				const live = Array.from({ length: 1000 }, (_, index) => [
+					`bucket:a${String(index).padStart(5, "0")}`,
+					{ tokens: 5, lastRefill: now, capacity: 100 },
+				]);
+				for (let index = 0; index < live.length; index += 128) {
+					await state.storage.put(Object.fromEntries(live.slice(index, index + 128)));
+				}
+				await state.storage.put("bucket:zzz-idle", { tokens: 100, lastRefill: now - 120_000, capacity: 100 });
+				await state.storage.delete("bucket:seed");
+
+				// First alarm consumes the full page and carries a cursor past it.
+				await (instance as RateLimiter).alarm();
+				expect(await state.storage.get("sweep:cursor")).toBeDefined();
+
+				// Second alarm resumes behind the cursor and reaps what the first
+				// could not see, then ends the pass.
+				await (instance as RateLimiter).alarm();
+				expect(await state.storage.get("bucket:zzz-idle")).toBeUndefined();
+				expect(await state.storage.get("sweep:cursor")).toBeUndefined();
+				// The live page is untouched, and still holds the reaper armed.
+				expect(await state.storage.get("bucket:a00000")).toBeDefined();
+				expect(await state.storage.getAlarm()).not.toBeNull();
+			});
+		}, 60_000);
+
 		it("answers a reaped identity exactly as it answers a fresh one", async () => {
 			const stub = getRateLimiter("reap-equivalence");
 			await stub.fetch("http://localhost/consume?identity=recycled");

--- a/src/__tests__/rate-limiter.test.ts
+++ b/src/__tests__/rate-limiter.test.ts
@@ -20,6 +20,71 @@ describe("RateLimiter Durable Object", () => {
 		await getRateLimiter("warmup").fetch("http://localhost/check?identity=warmup");
 	}, WARMUP_TIMEOUT_MS);
 
+	describe("per-bucket capacity", () => {
+		it("applies a lowered ceiling without waiting for the bucket to drain", async () => {
+			// Nothing reaps `bucket:` keys, so a capacity pinned at creation would
+			// outlive every later change to the route's ceiling — the tunable would
+			// silently stop tuning for exactly the rows already in use.
+			const stub = getRateLimiter("capacity-lowered");
+			await stub.fetch("http://localhost/consume?identity=lowered&limit=1000");
+
+			const lowered = (await (
+				await stub.fetch("http://localhost/consume?identity=lowered&limit=10")
+			).json()) as RateLimitResult;
+
+			expect(lowered.allowed).toBe(true);
+			if (lowered.allowed) {
+				expect(lowered.remaining).toBeLessThanOrEqual(10);
+			}
+		});
+
+		it("refills a widened bucket past its former ceiling", async () => {
+			// Widening grants no tokens outright; what it changes is the ceiling and
+			// the refill rate. A bucket held at 10 can never pass 10 however long it
+			// waits, so crossing it is the proof the new capacity took.
+			const stub = getRateLimiter("capacity-widened");
+			await stub.fetch("http://localhost/consume?identity=widened&limit=10");
+			await stub.fetch("http://localhost/consume?identity=widened&limit=1000");
+
+			// At 1000/min this is ~6 tokens; at the former ceiling, ~0.07. Waiting
+			// longer under load only widens the gap, so the margin is one-sided.
+			await new Promise((resolve) => setTimeout(resolve, 400));
+
+			const widened = (await (
+				await stub.fetch("http://localhost/consume?identity=widened&limit=1000")
+			).json()) as RateLimitResult;
+
+			expect(widened.allowed).toBe(true);
+			if (widened.allowed) {
+				expect(widened.remaining).toBeGreaterThan(10);
+			}
+		});
+
+		it("keeps a wide bucket's ceiling when the caller names no limit", async () => {
+			// `/check` names no limit; it must not narrow a bucket it only reads.
+			const stub = getRateLimiter("capacity-unnamed");
+			await stub.fetch("http://localhost/consume?identity=unnamed&limit=1000");
+
+			const checked = (await (await stub.fetch("http://localhost/check?identity=unnamed")).json()) as RateLimitResult;
+
+			expect(checked.allowed).toBe(true);
+			if (checked.allowed) {
+				expect(checked.remaining).toBeGreaterThan(900);
+			}
+		});
+
+		it("falls back to the default for a malformed limit", async () => {
+			const stub = getRateLimiter("capacity-malformed");
+			const response = await stub.fetch("http://localhost/consume?identity=malformed&limit=not-a-number");
+
+			const result = (await response.json()) as RateLimitResult;
+			expect(result.allowed).toBe(true);
+			if (result.allowed) {
+				expect(result.remaining).toBe(99);
+			}
+		});
+	});
+
 	describe("/check endpoint", () => {
 		it("should return allowed for new identity", async () => {
 			const stub = getRateLimiter("check-new");

--- a/src/__tests__/rate-limiter.test.ts
+++ b/src/__tests__/rate-limiter.test.ts
@@ -75,6 +75,34 @@ describe("RateLimiter Durable Object", () => {
 			}
 		});
 
+		it("scales the retry hint to the bucket's capacity, not the window", async () => {
+			// Refill is proportional to capacity, so a wide bucket repays one token in
+			// a fraction of a window. Reporting the window told a refused caller to
+			// wait 60s over 60ms of debt — and on the row bucket that hint idles every
+			// sibling under the trusted row, not just the caller that spent it.
+			const stub = getRateLimiter("retry-hint");
+			await runInDurableObject(stub, async (_instance, state) => {
+				// Seeded empty rather than drained: 1000 round-trips is what the CI
+				// timeout above was about. The denial path performs no write, so the
+				// seeded state is what the request sees.
+				await state.storage.put("bucket:wide", { tokens: 0, lastRefill: Date.now(), capacity: 1000 });
+				await state.storage.put("bucket:narrow", { tokens: 0, lastRefill: Date.now(), capacity: 100 });
+			});
+
+			const wide = await stub.fetch("http://localhost/consume?identity=wide&limit=1000");
+			const narrow = await stub.fetch("http://localhost/consume?identity=narrow");
+			expect(wide.status).toBe(429);
+			expect(narrow.status).toBe(429);
+
+			// One token against a ceiling of 1000 is ~60ms; against 100, ~600ms.
+			// Either way, not the 60s the window would have reported.
+			const wideResult = (await wide.json()) as RateLimitResult;
+			const narrowResult = (await narrow.json()) as RateLimitResult;
+			expect(wideResult.resetAt - Date.now()).toBeLessThan(500);
+			expect(narrowResult.resetAt - Date.now()).toBeGreaterThan(wideResult.resetAt - Date.now());
+			expect(narrowResult.resetAt - Date.now()).toBeLessThan(5_000);
+		});
+
 		it("falls back to the default for a malformed limit", async () => {
 			const stub = getRateLimiter("capacity-malformed");
 			const response = await stub.fetch("http://localhost/consume?identity=malformed&limit=not-a-number");
@@ -281,6 +309,26 @@ describe("RateLimiter Durable Object", () => {
 				expect(await state.storage.getAlarm()).not.toBeNull();
 			});
 		}, 60_000);
+
+		it("leaves a wide bucket alone, since reaping it would lose its ceiling", async () => {
+			// The safety argument is that a reaped bucket and an idle one answer
+			// identically. That holds only at the default ceiling: reaping a wide
+			// bucket drops its stored capacity, and `/check` names no limit, so it
+			// would then be answered against 100 rather than the 1000 it was created
+			// with. There is one wide bucket per trusted row, so they are not the
+			// growth being bounded and skipping them costs nothing.
+			const stub = getRateLimiter("reap-wide");
+			await stub.fetch("http://localhost/consume?identity=wide-row&limit=1000");
+
+			await runInDurableObject(stub, async (instance, state) => {
+				await backdate(state, "bucket:wide-row");
+				await (instance as RateLimiter).alarm();
+				expect(await state.storage.get("bucket:wide-row")).toBeDefined();
+			});
+
+			const checked = (await (await stub.fetch("http://localhost/check?identity=wide-row")).json()) as RateLimitResult;
+			expect(checked.allowed && checked.remaining).toBeGreaterThan(900);
+		});
 
 		it("answers a reaped identity exactly as it answers a fresh one", async () => {
 			const stub = getRateLimiter("reap-equivalence");

--- a/src/__tests__/sign.test.ts
+++ b/src/__tests__/sign.test.ts
@@ -409,6 +409,46 @@ describe("Sign Route", () => {
 			expect(events.some((event) => event.errorCode === "KEY_NOT_ALLOWED")).toBe(false);
 		});
 
+		it("refuses the scope denial once the trusted row is at its ceiling", async () => {
+			// The denial writes to D1, and the per-caller bucket is keyed on `sub` —
+			// so if the row ceiling did not govern this branch, a row that can mint
+			// subjects would still flood `audit_logs` past it. Same multiplication
+			// the second tier exists to stop, on the path that writes.
+			await insertOIDCSubject(env.AUDIT_DB, {
+				name: "ci/row-ceiling",
+				issuer,
+				subjectPrefix: "repo:rowceiling/svc",
+				keyIds: ["AAAAAAAAAAAAAAAA"],
+				expiresAt: null,
+			});
+			await setupJWKSMock();
+			const token = await createToken({ sub: "repo:rowceiling/svc:ref:refs/heads/main" });
+
+			// Per-caller bucket allows; the row bucket does not.
+			const tieredLimiter = {
+				idFromName: () => ({}) as DurableObjectId,
+				get: () => ({
+					fetch: async (request: Request) => {
+						const identity = new URL(request.url).searchParams.get("identity") ?? "";
+						const allowed = !identity.startsWith("oidc-subject-row:");
+						return Response.json({ allowed, remaining: allowed ? 99 : 0, resetAt: Date.now() + 30_000 });
+					},
+				}),
+			} as unknown as DurableObjectNamespace;
+
+			const response = await makeRequest(
+				"/sign?keyId=BBBBBBBBBBBBBBBB",
+				{ method: "POST", headers: { Authorization: `Bearer ${token}` }, body: "commit data" },
+				{ RATE_LIMITER: tieredLimiter },
+			);
+
+			expect(response.status).toBe(429);
+			expect(await response.json()).toMatchObject({ code: "RATE_LIMITED" });
+
+			const events = vi.mocked(logAuditEvent).mock.calls.map(([, event]) => event);
+			expect(events.some((event) => event.errorCode === "KEY_NOT_ALLOWED")).toBe(false);
+		});
+
 		it("survives a non-Error rejection from the limiter", async () => {
 			await insertOIDCSubject(env.AUDIT_DB, {
 				name: "ci/limiter-nonerror",

--- a/src/__tests__/sign.test.ts
+++ b/src/__tests__/sign.test.ts
@@ -4,6 +4,7 @@ import * as jose from "jose";
 import * as openpgp from "openpgp";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import app from "#gpg-signing-service";
+import type { RateLimitResult } from "#types";
 import { logAuditEvent } from "#utils/audit";
 import { logger } from "#utils/logger";
 import { insertOIDCSubject } from "#utils/oidc-subjects";
@@ -33,11 +34,22 @@ async function makeRequest(path: string, options: RequestInit = {}, envOverrides
 	return response;
 }
 
+/**
+ * Answer the way the real Durable Object answers: a denied verdict rides on a
+ * 429, not a 200. A stub that returned 200 for `allowed: false` tested a shape
+ * the limiter never produces, which is how a route that read every 429 as an
+ * outage passed a suite full of rate-limit assertions.
+ */
+function limiterResponse(body: unknown): Response {
+	const denied = typeof body === "object" && body !== null && (body as RateLimitResult).allowed === false;
+	return denied ? Response.json(body, { status: 429 }) : Response.json(body);
+}
+
 /** A RATE_LIMITER binding whose every call answers with `body`. */
 function stubRateLimiter(body: unknown): DurableObjectNamespace {
 	return {
 		idFromName: () => ({}) as DurableObjectId,
-		get: () => ({ fetch: async () => Response.json(body) }),
+		get: () => ({ fetch: async () => limiterResponse(body) }),
 	} as unknown as DurableObjectNamespace;
 }
 
@@ -328,7 +340,7 @@ describe("Sign Route", () => {
 					fetch: async (request: Request) => {
 						const identity = new URL(request.url).searchParams.get("identity") ?? "";
 						const allowed = !identity.startsWith("oidc-subject-row:");
-						return Response.json({ allowed, remaining: allowed ? 99 : 0, resetAt: Date.now() + 30_000 });
+						return limiterResponse({ allowed, remaining: allowed ? 99 : 0, resetAt: Date.now() + 30_000 });
 					},
 				}),
 			} as unknown as DurableObjectNamespace;
@@ -431,7 +443,7 @@ describe("Sign Route", () => {
 					fetch: async (request: Request) => {
 						const identity = new URL(request.url).searchParams.get("identity") ?? "";
 						const allowed = !identity.startsWith("oidc-subject-row:");
-						return Response.json({ allowed, remaining: allowed ? 99 : 0, resetAt: Date.now() + 30_000 });
+						return limiterResponse({ allowed, remaining: allowed ? 99 : 0, resetAt: Date.now() + 30_000 });
 					},
 				}),
 			} as unknown as DurableObjectNamespace;

--- a/src/__tests__/sign.test.ts
+++ b/src/__tests__/sign.test.ts
@@ -302,8 +302,11 @@ describe("Sign Route", () => {
 			}
 
 			// Per-caller buckets differ per ref — that is the tier being bounded.
-			const perCaller = metered.filter((entry) => entry.startsWith(issuer));
-			expect(new Set(perCaller).size).toBe(2);
+			// Asserted by exact identity rather than by an issuer prefix match: a
+			// `startsWith` against a URL also accepts `https://iss.example.evil.test`,
+			// so it is the wrong shape of check to write even where the inputs are ours.
+			expect(metered).toContain(`${issuer}:repo:user/repo:ref:refs/heads/main|default`);
+			expect(metered).toContain(`${issuer}:repo:user/repo:ref:refs/heads/anything-i-like|default`);
 
 			// The row ceiling is one bucket for both, at the wider limit.
 			const perRow = metered.filter((entry) => entry.startsWith("oidc-subject-row:"));

--- a/src/__tests__/sign.test.ts
+++ b/src/__tests__/sign.test.ts
@@ -272,6 +272,74 @@ describe("Sign Route", () => {
 			expect(signed?.requestId).toBe(echoed);
 		});
 
+		it("meters signing per trusted row as well as per subject", async () => {
+			// The per-caller bucket is keyed on `<iss>:<sub>`, and GitHub puts the ref
+			// in `sub`, so branches multiply budgets. The second tier is keyed on the
+			// row id, which the caller cannot vary.
+			await setupJWKSMock();
+			await uploadTestKey("A1B2C3D4E5F67890");
+
+			const metered: string[] = [];
+			const recordingLimiter = {
+				idFromName: () => ({}) as DurableObjectId,
+				get: () => ({
+					fetch: async (request: Request) => {
+						const params = new URL(request.url).searchParams;
+						metered.push(`${params.get("identity")}|${params.get("limit") ?? "default"}`);
+						return Response.json({ allowed: true, remaining: 99, resetAt: Date.now() + 60_000 });
+					},
+				}),
+			} as unknown as DurableObjectNamespace;
+
+			for (const ref of ["refs/heads/main", "refs/heads/anything-i-like"]) {
+				const token = await createToken({ sub: `repo:user/repo:ref:${ref}` });
+				const response = await makeRequest(
+					"/sign?keyId=A1B2C3D4E5F67890",
+					{ method: "POST", headers: { Authorization: `Bearer ${token}` }, body: "commit data" },
+					{ RATE_LIMITER: recordingLimiter },
+				);
+				expect(response.status).toBe(200);
+			}
+
+			// Per-caller buckets differ per ref — that is the tier being bounded.
+			const perCaller = metered.filter((entry) => entry.startsWith(issuer));
+			expect(new Set(perCaller).size).toBe(2);
+
+			// The row ceiling is one bucket for both, at the wider limit.
+			const perRow = metered.filter((entry) => entry.startsWith("oidc-subject-row:"));
+			expect(perRow).toHaveLength(2);
+			expect(new Set(perRow).size).toBe(1);
+			expect(perRow[0]).toMatch(/\|1000$/);
+			expect(perRow.join(" ")).not.toContain("refs/heads");
+		});
+
+		it("refuses with 429 once a trusted row hits its ceiling, even under budget per caller", async () => {
+			await setupJWKSMock();
+			await uploadTestKey("A1B2C3D4E5F67890");
+			const token = await createToken();
+
+			// Per-caller bucket allows; the row bucket does not.
+			const tieredLimiter = {
+				idFromName: () => ({}) as DurableObjectId,
+				get: () => ({
+					fetch: async (request: Request) => {
+						const identity = new URL(request.url).searchParams.get("identity") ?? "";
+						const allowed = !identity.startsWith("oidc-subject-row:");
+						return Response.json({ allowed, remaining: allowed ? 99 : 0, resetAt: Date.now() + 30_000 });
+					},
+				}),
+			} as unknown as DurableObjectNamespace;
+
+			const response = await makeRequest(
+				"/sign?keyId=A1B2C3D4E5F67890",
+				{ method: "POST", headers: { Authorization: `Bearer ${token}` }, body: "commit data" },
+				{ RATE_LIMITER: tieredLimiter },
+			);
+
+			expect(response.status).toBe(429);
+			expect(await response.json()).toMatchObject({ code: "RATE_LIMITED" });
+		});
+
 		it("audits a trusted subject reaching outside its key scope", async () => {
 			// The highest-signal event the service can produce: the credential is
 			// valid and the row is live, but the grant does not cover the key. If

--- a/src/__tests__/sign.test.ts
+++ b/src/__tests__/sign.test.ts
@@ -360,6 +360,33 @@ describe("Sign Route", () => {
 			expect(metered.filter((identity) => identity.startsWith("oidc-subject-row:"))).toHaveLength(0);
 		});
 
+		it("never hands back a retry hint of zero, however close the token is", async () => {
+			// A denial's `resetAt` is when the bucket next holds a token, and refill is
+			// proportional to capacity: 60ms on the 1000-wide row bucket, 600ms on the
+			// default. Both are shorter than a Worker-to-Durable-Object round trip can
+			// be, so the bare `ceil((resetAt - now) / 1000)` reaches zero or below by
+			// the time the answer is read. `RateLimitErrorSchema` declares `retryAfter`
+			// positive and the Go client only honours a positive hint, so an
+			// underflowed one is both off-spec and silently dropped for generic
+			// backoff — which is the client retrying faster than it was told to.
+			await setupJWKSMock();
+			await uploadTestKey("A1B2C3D4E5F67890");
+			const token = await createToken();
+
+			// Already elapsed: the worst case, a round trip longer than the debt.
+			const response = await makeRequest(
+				"/sign?keyId=A1B2C3D4E5F67890",
+				{ method: "POST", headers: { Authorization: `Bearer ${token}` }, body: "commit data" },
+				{ RATE_LIMITER: stubRateLimiter({ allowed: false, remaining: 0, resetAt: Date.now() - 40 }) },
+			);
+
+			expect(response.status).toBe(429);
+			const body = await parseJson<{ code: string; retryAfter: number }>(response);
+			expect(body.code).toBe("RATE_LIMITED");
+			expect(body.retryAfter).toBeGreaterThan(0);
+			expect(Number.isInteger(body.retryAfter)).toBe(true);
+		});
+
 		it("refuses with 429 once a trusted row hits its ceiling, even under budget per caller", async () => {
 			await setupJWKSMock();
 			await uploadTestKey("A1B2C3D4E5F67890");
@@ -704,14 +731,10 @@ describe("Sign Route", () => {
 			const originalGet = env.RATE_LIMITER.get;
 			env.RATE_LIMITER.get = () =>
 				({
-					fetch: async () =>
-						new Response(
-							JSON.stringify({
-								allowed: false,
-								remaining: 0,
-								resetAt: Date.now() + 60000,
-							}),
-						),
+					// Through `limiterResponse`, so this denial rides a 429 the way the
+					// real object's does. Hand-rolling a 200 here is the shape that let
+					// a route reading every 429 as an outage pass this assertion.
+					fetch: async () => limiterResponse({ allowed: false, remaining: 0, resetAt: Date.now() + 60000 }),
 				}) as unknown as DurableObjectStub;
 
 			try {

--- a/src/__tests__/sign.test.ts
+++ b/src/__tests__/sign.test.ts
@@ -328,6 +328,38 @@ describe("Sign Route", () => {
 			expect(perRow.join(" ")).not.toContain("refs/heads");
 		});
 
+		it("spends no row token on a request its own bucket already refused", async () => {
+			// A denied bucket costs itself nothing, so firing both tiers together let
+			// refused traffic drain the bucket every sibling branch shares — and being
+			// refused is what provokes the retry that refuses it again. One branch
+			// looping could hold the whole row at its ceiling without signing once.
+			await setupJWKSMock();
+			await uploadTestKey("A1B2C3D4E5F67890");
+			const token = await createToken();
+
+			const metered: string[] = [];
+			const perCallerExhausted = {
+				idFromName: () => ({}) as DurableObjectId,
+				get: () => ({
+					fetch: async (request: Request) => {
+						const identity = new URL(request.url).searchParams.get("identity") ?? "";
+						metered.push(identity);
+						const allowed = identity.startsWith("oidc-subject-row:");
+						return limiterResponse({ allowed, remaining: allowed ? 999 : 0, resetAt: Date.now() + 30_000 });
+					},
+				}),
+			} as unknown as DurableObjectNamespace;
+
+			const response = await makeRequest(
+				"/sign?keyId=A1B2C3D4E5F67890",
+				{ method: "POST", headers: { Authorization: `Bearer ${token}` }, body: "commit data" },
+				{ RATE_LIMITER: perCallerExhausted },
+			);
+
+			expect(response.status).toBe(429);
+			expect(metered.filter((identity) => identity.startsWith("oidc-subject-row:"))).toHaveLength(0);
+		});
+
 		it("refuses with 429 once a trusted row hits its ceiling, even under budget per caller", async () => {
 			await setupJWKSMock();
 			await uploadTestKey("A1B2C3D4E5F67890");

--- a/src/__tests__/sign.test.ts
+++ b/src/__tests__/sign.test.ts
@@ -436,6 +436,8 @@ describe("Sign Route", () => {
 				}),
 			} as unknown as DurableObjectNamespace;
 
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
 			const response = await makeRequest(
 				"/sign?keyId=BBBBBBBBBBBBBBBB",
 				{ method: "POST", headers: { Authorization: `Bearer ${token}` }, body: "commit data" },
@@ -447,6 +449,20 @@ describe("Sign Route", () => {
 
 			const events = vi.mocked(logAuditEvent).mock.calls.map(([, event]) => event);
 			expect(events.some((event) => event.errorCode === "KEY_NOT_ALLOWED")).toBe(false);
+
+			// Refusing before the write is correct; refusing *silently* is not.
+			// Anything able to hold the row at its ceiling would otherwise erase the
+			// service's highest-signal event, and the 429 alone does not say a scope
+			// violation happened, let alone against which key.
+			expect(warnSpy).toHaveBeenCalledWith(
+				"Key scope denied while the trusted row was at its signing ceiling",
+				expect.objectContaining({
+					keyId: "BBBBBBBBBBBBBBBB",
+					subject: "repo:rowceiling/svc:ref:refs/heads/main",
+					subjectPolicy: "ci/row-ceiling",
+				}),
+			);
+			warnSpy.mockRestore();
 		});
 
 		it("survives a non-Error rejection from the limiter", async () => {

--- a/src/durable-objects/rate-limiter.ts
+++ b/src/durable-objects/rate-limiter.ts
@@ -64,23 +64,27 @@ export class RateLimiter implements DurableObject {
 	}
 
 	/**
-	 * Read a caller-supplied bucket capacity, falling back to the default.
+	 * Read a caller-supplied bucket capacity.
 	 *
 	 * Bounded and integral: the value reaches here from application code, not
 	 * from a request, but a NaN would poison the stored bucket permanently.
 	 *
+	 * Returns `undefined` rather than the default when nothing usable was
+	 * supplied, so `getBucket` can tell "no opinion" — which must not overwrite a
+	 * wide bucket's stored ceiling — from an explicit capacity, which must.
+	 *
 	 * @param raw - The `limit` query parameter, if present
-	 * @returns A usable capacity
+	 * @returns A usable capacity, or `undefined` if none was supplied
 	 */
-	private parseLimit(raw: string | null): number {
+	private parseLimit(raw: string | null): number | undefined {
 		const parsed = Number(raw);
 		if (!raw || !Number.isFinite(parsed) || parsed < 1) {
-			return this.maxTokens;
+			return undefined;
 		}
 		return Math.min(Math.floor(parsed), 1_000_000);
 	}
 
-	private async checkLimit(identity: string, capacity = this.maxTokens): Promise<Response> {
+	private async checkLimit(identity: string, capacity?: number): Promise<Response> {
 		const bucket = await this.getBucket(identity, capacity);
 		const resetAt = bucket.lastRefill + this.windowMs;
 
@@ -93,7 +97,7 @@ export class RateLimiter implements DurableObject {
 		});
 	}
 
-	private async consumeToken(identity: string, capacity = this.maxTokens): Promise<Response> {
+	private async consumeToken(identity: string, capacity?: number): Promise<Response> {
 		const bucket = await this.getBucket(identity, capacity);
 		const resetAt = bucket.lastRefill + this.windowMs;
 
@@ -137,20 +141,26 @@ export class RateLimiter implements DurableObject {
 		});
 	}
 
-	private async getBucket(identity: string, capacity = this.maxTokens): Promise<TokenBucket> {
+	private async getBucket(identity: string, capacity?: number): Promise<TokenBucket> {
 		const now = Date.now();
 		let bucket = await this.state.storage.get<TokenBucket>(`bucket:${identity}`);
 
 		if (!bucket) {
-			bucket = { tokens: capacity, lastRefill: now, capacity };
+			const newCapacity = capacity ?? this.maxTokens;
+			bucket = { tokens: newCapacity, lastRefill: now, capacity: newCapacity };
 		} else {
-			// Refill proportionally to the bucket's own capacity, so a wide bucket
-			// refills as fast as it drains. A bucket stored before capacities were
-			// per-bucket has none recorded and falls back to the default.
-			const bucketCapacity = bucket.capacity ?? this.maxTokens;
+			// An explicitly supplied capacity wins over the stored one, so the
+			// ceilings in the routes stay tunable: nothing reaps `bucket:` keys, so a
+			// capacity pinned at creation would outlive every later change to it.
+			// Falls back to the stored value when the caller has no opinion — the
+			// `/check` path names no limit — and to the default for buckets written
+			// before capacities were per-bucket.
+			const bucketCapacity = capacity ?? bucket.capacity ?? this.maxTokens;
 			const elapsed = now - bucket.lastRefill;
 			const tokensToAdd = (elapsed / this.windowMs) * bucketCapacity;
 
+			// Clamped to the current capacity, so a lowered ceiling takes effect on
+			// the next request rather than after the bucket happens to drain.
 			bucket.tokens = Math.min(bucketCapacity, bucket.tokens + tokensToAdd);
 			bucket.lastRefill = now;
 			bucket.capacity = bucketCapacity;

--- a/src/durable-objects/rate-limiter.ts
+++ b/src/durable-objects/rate-limiter.ts
@@ -4,14 +4,21 @@ import { createRateLimitAllowed, createRateLimitDenied, HTTP, MediaType } from "
 interface TokenBucket {
 	tokens: number;
 	lastRefill: number;
+	/**
+	 * This bucket's capacity, stored rather than assumed: buckets with different
+	 * ceilings share one Durable Object, and a bucket refilled against the wrong
+	 * capacity would silently grant the wrong budget.
+	 */
+	capacity?: number;
 }
 
 export class RateLimiter implements DurableObject {
 	private state: DurableObjectState;
 
-	// Rate limit configuration
-	private readonly maxTokens = 100; // Max requests per window
-	private readonly refillRate = 100; // Tokens per minute
+	// Rate limit configuration. A bucket refills at its own capacity per window,
+	// so a wider bucket refills proportionally faster rather than taking longer to
+	// recover than a narrow one.
+	private readonly maxTokens = 100; // Default capacity, and requests per window
 	private readonly windowMs = 60_000; // 1 minute window
 
 	constructor(state: DurableObjectState) {
@@ -25,10 +32,16 @@ export class RateLimiter implements DurableObject {
 		try {
 			switch (path) {
 				case "/check":
-					return await this.checkLimit(url.searchParams.get("identity") || "default");
+					return await this.checkLimit(
+						url.searchParams.get("identity") || "default",
+						this.parseLimit(url.searchParams.get("limit")),
+					);
 
 				case "/consume":
-					return await this.consumeToken(url.searchParams.get("identity") || "default");
+					return await this.consumeToken(
+						url.searchParams.get("identity") || "default",
+						this.parseLimit(url.searchParams.get("limit")),
+					);
 
 				case "/reset":
 					if (request.method !== "POST") {
@@ -50,8 +63,25 @@ export class RateLimiter implements DurableObject {
 		}
 	}
 
-	private async checkLimit(identity: string): Promise<Response> {
-		const bucket = await this.getBucket(identity);
+	/**
+	 * Read a caller-supplied bucket capacity, falling back to the default.
+	 *
+	 * Bounded and integral: the value reaches here from application code, not
+	 * from a request, but a NaN would poison the stored bucket permanently.
+	 *
+	 * @param raw - The `limit` query parameter, if present
+	 * @returns A usable capacity
+	 */
+	private parseLimit(raw: string | null): number {
+		const parsed = Number(raw);
+		if (!raw || !Number.isFinite(parsed) || parsed < 1) {
+			return this.maxTokens;
+		}
+		return Math.min(Math.floor(parsed), 1_000_000);
+	}
+
+	private async checkLimit(identity: string, capacity = this.maxTokens): Promise<Response> {
+		const bucket = await this.getBucket(identity, capacity);
 		const resetAt = bucket.lastRefill + this.windowMs;
 
 		const result: RateLimitResult =
@@ -63,8 +93,8 @@ export class RateLimiter implements DurableObject {
 		});
 	}
 
-	private async consumeToken(identity: string): Promise<Response> {
-		const bucket = await this.getBucket(identity);
+	private async consumeToken(identity: string, capacity = this.maxTokens): Promise<Response> {
+		const bucket = await this.getBucket(identity, capacity);
 		const resetAt = bucket.lastRefill + this.windowMs;
 
 		if (bucket.tokens < 1) {
@@ -107,19 +137,23 @@ export class RateLimiter implements DurableObject {
 		});
 	}
 
-	private async getBucket(identity: string): Promise<TokenBucket> {
+	private async getBucket(identity: string, capacity = this.maxTokens): Promise<TokenBucket> {
 		const now = Date.now();
 		let bucket = await this.state.storage.get<TokenBucket>(`bucket:${identity}`);
 
 		if (!bucket) {
-			bucket = { tokens: this.maxTokens, lastRefill: now };
+			bucket = { tokens: capacity, lastRefill: now, capacity };
 		} else {
-			// Refill tokens based on time elapsed
+			// Refill proportionally to the bucket's own capacity, so a wide bucket
+			// refills as fast as it drains. A bucket stored before capacities were
+			// per-bucket has none recorded and falls back to the default.
+			const bucketCapacity = bucket.capacity ?? this.maxTokens;
 			const elapsed = now - bucket.lastRefill;
-			const tokensToAdd = (elapsed / this.windowMs) * this.refillRate;
+			const tokensToAdd = (elapsed / this.windowMs) * bucketCapacity;
 
-			bucket.tokens = Math.min(this.maxTokens, bucket.tokens + tokensToAdd);
+			bucket.tokens = Math.min(bucketCapacity, bucket.tokens + tokensToAdd);
 			bucket.lastRefill = now;
+			bucket.capacity = bucketCapacity;
 		}
 
 		await this.state.storage.put(`bucket:${identity}`, bucket);

--- a/src/durable-objects/rate-limiter.ts
+++ b/src/durable-objects/rate-limiter.ts
@@ -96,12 +96,28 @@ export class RateLimiter implements DurableObject {
 		return Math.min(Math.floor(parsed), 1_000_000);
 	}
 
+	/**
+	 * When a denied bucket next holds a whole token.
+	 *
+	 * Refill is proportional to capacity, so a wide bucket repays its debt fast:
+	 * one token against a ceiling of 1000 is back in 60ms, not 60s. Reporting the
+	 * window instead told every refused caller to wait a full minute — a 1000x
+	 * overstatement on the row bucket, which is the one whose `Retry-After` idles
+	 * every sibling under a trusted row rather than just the caller that spent it.
+	 */
+	private retryAt(bucket: TokenBucket, now: number): number {
+		const capacity = bucket.capacity ?? this.maxTokens;
+		return now + Math.ceil(((1 - bucket.tokens) / capacity) * this.windowMs);
+	}
+
 	private async checkLimit(identity: string, capacity?: number): Promise<Response> {
 		const bucket = await this.getBucket(identity, capacity);
 		const resetAt = bucket.lastRefill + this.windowMs;
 
 		const result: RateLimitResult =
-			bucket.tokens >= 1 ? createRateLimitAllowed(Math.floor(bucket.tokens), resetAt) : createRateLimitDenied(resetAt);
+			bucket.tokens >= 1
+				? createRateLimitAllowed(Math.floor(bucket.tokens), resetAt)
+				: createRateLimitDenied(this.retryAt(bucket, Date.now()));
 
 		return new Response(JSON.stringify(result), {
 			status: HTTP.OK,
@@ -114,13 +130,14 @@ export class RateLimiter implements DurableObject {
 		const resetAt = bucket.lastRefill + this.windowMs;
 
 		if (bucket.tokens < 1) {
-			const result: RateLimitResult = createRateLimitDenied(resetAt);
+			const retryAt = this.retryAt(bucket, Date.now());
+			const result: RateLimitResult = createRateLimitDenied(retryAt);
 
 			return new Response(JSON.stringify(result), {
 				status: HTTP.TooManyRequests,
 				headers: {
 					"Content-Type": MediaType.ApplicationJson,
-					"Retry-After": String(Math.ceil((resetAt - Date.now()) / 1000)),
+					"Retry-After": String(Math.max(1, Math.ceil((retryAt - Date.now()) / 1000))),
 				},
 			});
 		}
@@ -203,6 +220,13 @@ export class RateLimiter implements DurableObject {
 	 * Deleting one is not a reset: `getBucket` creates a missing bucket full, so a
 	 * reaped bucket and an idle one answer identically. What it drops is the key.
 	 *
+	 * That equivalence holds unconditionally only for buckets at the default
+	 * ceiling. A reaped wide bucket loses its stored capacity, and a caller that
+	 * names no limit — `/check` — would then be answered against the default
+	 * rather than the ceiling the bucket was created with. Wide buckets are
+	 * therefore left alone: there is one per trusted row, so they are not the
+	 * growth this exists to bound, and skipping them costs nothing.
+	 *
 	 * One page per alarm, resumed from a persisted cursor, so a pass covers the
 	 * whole prefix rather than the first `sweepBatch` keys of it.
 	 */
@@ -223,7 +247,8 @@ export class RateLimiter implements DurableObject {
 		let lastKey: string | undefined;
 		for (const [key, bucket] of buckets) {
 			lastKey = key;
-			if (now - bucket.lastRefill >= this.idleTtlMs) {
+			const isDefaultCeiling = (bucket.capacity ?? this.maxTokens) === this.maxTokens;
+			if (isDefaultCeiling && now - bucket.lastRefill >= this.idleTtlMs) {
 				stale.push(key);
 			}
 		}

--- a/src/durable-objects/rate-limiter.ts
+++ b/src/durable-objects/rate-limiter.ts
@@ -21,6 +21,15 @@ export class RateLimiter implements DurableObject {
 	private readonly maxTokens = 100; // Default capacity, and requests per window
 	private readonly windowMs = 60_000; // 1 minute window
 
+	// Reaping. Identities are caller-varied — `<iss>:<sub>` carries the git ref —
+	// so the set of bucket keys grows without bound while nothing removes them.
+	// A bucket idle for a full window has refilled to capacity, which is exactly
+	// what a *missing* bucket is created as, so deleting it changes no verdict.
+	private readonly idleTtlMs = 60_000;
+	private readonly sweepIntervalMs = 300_000; // 5 minutes
+	private readonly sweepBatch = 1000; // Keys examined per alarm
+	private readonly deleteChunk = 128; // Storage delete() takes at most 128 keys
+
 	constructor(state: DurableObjectState) {
 		this.state = state;
 	}
@@ -113,9 +122,12 @@ export class RateLimiter implements DurableObject {
 			});
 		}
 
-		// Consume one token
+		// Consume one token. This is the only path that persists a bucket: a bucket
+		// nobody has drawn down is fully described by its absence, so `/check` and
+		// the refill above stay read-only rather than minting a key per identity.
 		bucket.tokens -= 1;
 		await this.state.storage.put(`bucket:${identity}`, bucket);
+		await this.scheduleSweep();
 
 		const result: RateLimitResult = createRateLimitAllowed(Math.floor(bucket.tokens), resetAt);
 
@@ -166,7 +178,52 @@ export class RateLimiter implements DurableObject {
 			bucket.capacity = bucketCapacity;
 		}
 
-		await this.state.storage.put(`bucket:${identity}`, bucket);
 		return bucket;
+	}
+
+	/**
+	 * Arm the reaper if it is not already armed.
+	 *
+	 * Re-arming on every write would push the sweep out indefinitely under
+	 * sustained traffic — precisely when there is most to reap — so an existing
+	 * alarm is left alone.
+	 */
+	private async scheduleSweep(): Promise<void> {
+		if ((await this.state.storage.getAlarm()) === null) {
+			await this.state.storage.setAlarm(Date.now() + this.sweepIntervalMs);
+		}
+	}
+
+	/**
+	 * Delete buckets that have refilled to capacity.
+	 *
+	 * Deleting one is not a reset: `getBucket` creates a missing bucket full, so a
+	 * reaped bucket and an idle one answer identically. What it drops is the key.
+	 */
+	async alarm(): Promise<void> {
+		const now = Date.now();
+		const buckets = await this.state.storage.list<TokenBucket>({
+			prefix: "bucket:",
+			limit: this.sweepBatch,
+		});
+
+		const stale: string[] = [];
+		for (const [key, bucket] of buckets) {
+			if (now - bucket.lastRefill >= this.idleTtlMs) {
+				stale.push(key);
+			}
+		}
+
+		for (let index = 0; index < stale.length; index += this.deleteChunk) {
+			await this.state.storage.delete(stale.slice(index, index + this.deleteChunk));
+		}
+
+		// A full batch means the sweep was truncated; come back promptly rather
+		// than draining a large backlog one five-minute window at a time. Otherwise
+		// re-arm only while live buckets remain, so an idle object stops waking.
+		const truncated = buckets.size === this.sweepBatch;
+		if (truncated || stale.length < buckets.size) {
+			await this.state.storage.setAlarm(now + (truncated ? 1_000 : this.sweepIntervalMs));
+		}
 	}
 }

--- a/src/durable-objects/rate-limiter.ts
+++ b/src/durable-objects/rate-limiter.ts
@@ -222,10 +222,20 @@ export class RateLimiter implements DurableObject {
 	 *
 	 * That equivalence holds unconditionally only for buckets at the default
 	 * ceiling. A reaped wide bucket loses its stored capacity, and a caller that
-	 * names no limit — `/check` — would then be answered against the default
-	 * rather than the ceiling the bucket was created with. Wide buckets are
-	 * therefore left alone: there is one per trusted row, so they are not the
-	 * growth this exists to bound, and skipping them costs nothing.
+	 * names no limit would then be answered against the default rather than the
+	 * ceiling the bucket was created with. Wide buckets are therefore left alone:
+	 * there is one per trusted row, so they are not the growth this exists to
+	 * bound.
+	 *
+	 * To be clear about what that buys and costs. `/check` is the only endpoint
+	 * that names no limit, and nothing in `src/` calls it — so the divergence is
+	 * unobservable today, and the skip is defending the invariant rather than a
+	 * live consumer. The price is paid unconditionally: an immortal bucket class
+	 * means the re-arm below always finds something, so a limiter that has served
+	 * one trusted row wakes every `sweepIntervalMs` forever. That is one `list` of
+	 * a single key per five minutes, and it is the deliberate trade — an argument
+	 * that stops holding the moment somebody adds a `/check` caller is not one
+	 * worth resting a limiter's correctness on.
 	 *
 	 * One page per alarm, resumed from a persisted cursor, so a pass covers the
 	 * whole prefix rather than the first `sweepBatch` keys of it.
@@ -273,7 +283,8 @@ export class RateLimiter implements DurableObject {
 		// of this page, since a pass can end on a page that was entirely stale
 		// while live buckets sit in the pages before it. An object with nothing
 		// left stops waking itself, and `scheduleSweep` re-arms it on the next
-		// consume.
+		// consume. Note that a wide bucket is never reaped, so in practice only the
+		// admin limiter and an unused signing limiter ever reach that quiescence.
 		const remaining = await this.state.storage.list<TokenBucket>({ prefix: "bucket:", limit: 1 });
 		if (remaining.size > 0) {
 			await this.state.storage.setAlarm(now + this.sweepIntervalMs);

--- a/src/durable-objects/rate-limiter.ts
+++ b/src/durable-objects/rate-limiter.ts
@@ -29,6 +29,9 @@ export class RateLimiter implements DurableObject {
 	private readonly sweepIntervalMs = 300_000; // 5 minutes
 	private readonly sweepBatch = 1000; // Keys examined per alarm
 	private readonly deleteChunk = 128; // Storage delete() takes at most 128 keys
+	// Where the last sweep stopped. Outside the `bucket:` prefix so it is neither
+	// listed nor reaped by the sweep it drives.
+	private readonly sweepCursorKey = "sweep:cursor";
 
 	constructor(state: DurableObjectState) {
 		this.state = state;
@@ -199,16 +202,27 @@ export class RateLimiter implements DurableObject {
 	 *
 	 * Deleting one is not a reset: `getBucket` creates a missing bucket full, so a
 	 * reaped bucket and an idle one answer identically. What it drops is the key.
+	 *
+	 * One page per alarm, resumed from a persisted cursor, so a pass covers the
+	 * whole prefix rather than the first `sweepBatch` keys of it.
 	 */
 	async alarm(): Promise<void> {
 		const now = Date.now();
+		// Resume where the last alarm stopped. `list` has no implicit cursor, so
+		// without one it returns the same lexicographic page every time: a first
+		// page of live buckets both hides every key behind it from the sweep and
+		// re-arms it at a second, forever.
+		const cursor = await this.state.storage.get<string>(this.sweepCursorKey);
 		const buckets = await this.state.storage.list<TokenBucket>({
 			prefix: "bucket:",
+			...(cursor === undefined ? {} : { startAfter: cursor }),
 			limit: this.sweepBatch,
 		});
 
 		const stale: string[] = [];
+		let lastKey: string | undefined;
 		for (const [key, bucket] of buckets) {
+			lastKey = key;
 			if (now - bucket.lastRefill >= this.idleTtlMs) {
 				stale.push(key);
 			}
@@ -218,12 +232,26 @@ export class RateLimiter implements DurableObject {
 			await this.state.storage.delete(stale.slice(index, index + this.deleteChunk));
 		}
 
-		// A full batch means the sweep was truncated; come back promptly rather
-		// than draining a large backlog one five-minute window at a time. Otherwise
-		// re-arm only while live buckets remain, so an idle object stops waking.
-		const truncated = buckets.size === this.sweepBatch;
-		if (truncated || stale.length < buckets.size) {
-			await this.state.storage.setAlarm(now + (truncated ? 1_000 : this.sweepIntervalMs));
+		// A full page means keys remain behind it: carry the cursor past it and
+		// come back promptly, rather than draining a large backlog one five-minute
+		// window at a time — or, without the cursor, never draining it at all.
+		if (buckets.size === this.sweepBatch && lastKey !== undefined) {
+			await this.state.storage.put(this.sweepCursorKey, lastKey);
+			await this.state.storage.setAlarm(now + 1_000);
+			return;
+		}
+
+		// A short page ends the pass; the next one starts from the beginning.
+		await this.state.storage.delete(this.sweepCursorKey);
+
+		// Re-arm only while buckets remain — asked of the whole object rather than
+		// of this page, since a pass can end on a page that was entirely stale
+		// while live buckets sit in the pages before it. An object with nothing
+		// left stops waking itself, and `scheduleSweep` re-arms it on the next
+		// consume.
+		const remaining = await this.state.storage.list<TokenBucket>({ prefix: "bucket:", limit: 1 });
+		if (remaining.size > 0) {
+			await this.state.storage.setAlarm(now + this.sweepIntervalMs);
 		}
 	}
 }

--- a/src/middleware/oidc.ts
+++ b/src/middleware/oidc.ts
@@ -107,9 +107,10 @@ async function recordRevokedReuse(
  * route's second-tier ceiling, which is keyed on the row and closes that gap;
  * see `SUBJECT_ROW_LIMIT` in `routes/sign.ts`.
  *
- * Still outstanding: every distinct `sub` leaves a permanent `bucket:` key in
- * the limiter Durable Object, and nothing reaps them. The row ceiling bounds the
- * signing *rate* but not that growth.
+ * Every distinct `sub` still writes its own `bucket:` key in the limiter Durable
+ * Object; the row ceiling bounds the signing *rate*, not that growth. The
+ * limiter's reaper is what bounds it, by deleting buckets that have refilled to
+ * capacity — see `alarm` in `durable-objects/rate-limiter.ts`.
  */
 export const oidcAuth: MiddlewareHandler<{
 	Bindings: Env;

--- a/src/middleware/oidc.ts
+++ b/src/middleware/oidc.ts
@@ -45,10 +45,8 @@ const REVOKED_REUSE_METER = "oidc-revoked-reuse";
  * as the service-token path, which meters on `policy.name` rather than on
  * anything the caller picks.
  *
- * The argument above applies just as well to the *signing* path, which still
- * meters on `<iss>:<sub>` — see the note on `oidcAuth` below. That is a capacity
- * decision rather than a correctness one, so it is deliberately not changed
- * here; do not read this comment as describing the whole service.
+ * The signing path applies the same argument as a second tier: a per-caller
+ * bucket for fairness, plus a per-row ceiling keyed the same way this is.
  *
  * @param c - Request context
  * @param requestId - This request's id, shared with the rest of the pipeline
@@ -102,21 +100,16 @@ async function recordRevokedReuse(
 /**
  * OIDC validation middleware.
  *
- * KNOWN GAP — the identity published here becomes the *signing* rate-limit
- * bucket (`fetchRateLimiter(env, identity)` in the sign route), and it is
- * `<iss>:<sub>`. GitHub puts the ref in `sub`, so an OIDC caller who can push a
- * branch gets a fresh 100/min bucket per branch: the signing cap does not bound
- * a trusted row, and every distinct `sub` leaves a permanent key in the limiter
- * Durable Object, which nothing reaps. Service tokens do not have this — they
- * meter on `policy.name`.
+ * The identity published here is `<iss>:<sub>` and becomes the sign route's
+ * per-caller rate-limit bucket. GitHub puts the ref in `sub`, so that bucket
+ * alone does not bound a trusted *row* — a caller who can push branches mints a
+ * fresh budget per branch. `subjectPolicyId` is published alongside it for the
+ * route's second-tier ceiling, which is keyed on the row and closes that gap;
+ * see `SUBJECT_ROW_LIMIT` in `routes/sign.ts`.
  *
- * Not fixed here because it is a capacity decision, not a correctness one.
- * Metering on `policy.id` matches the service-token shape but collapses an
- * owner-wide row to one shared bucket, which would throttle a busy org
- * immediately; a per-row ceiling *above* the per-subject bucket keeps
- * per-branch fairness at the cost of a second limiter round trip per signature.
- * Either needs a number chosen against real traffic. `policy.id` is available
- * for whichever is picked — it is what `recordRevokedReuse` already meters on.
+ * Still outstanding: every distinct `sub` leaves a permanent `bucket:` key in
+ * the limiter Durable Object, and nothing reaps them. The row ceiling bounds the
+ * signing *rate* but not that growth.
  */
 export const oidcAuth: MiddlewareHandler<{
 	Bindings: Env;
@@ -233,6 +226,8 @@ export const oidcAuth: MiddlewareHandler<{
 	// prefix matching over the whole history. The service-token path gets this
 	// for free by putting the policy name in its synthetic `sub`.
 	c.set("subjectPolicyName", policy.name);
+	// Metering handle for the sign route's per-row ceiling; see the note above.
+	c.set("subjectPolicyId", policy.id);
 
 	// The last-used stamp is bookkeeping; do not make every signature wait on a
 	// D1 write for it.

--- a/src/middleware/security.ts
+++ b/src/middleware/security.ts
@@ -138,7 +138,13 @@ export const adminRateLimit: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
 				{
 					error: "Rate limit exceeded",
 					code: "RATE_LIMITED" as const satisfies ErrorCode,
-					retryAfter: Math.ceil((rateLimit.resetAt - Date.now()) / TIME.SECOND),
+					// Floored at one second. `resetAt` on a denial is when the bucket next
+					// holds a token, which is sub-second at every capacity in use, so the
+					// bare `ceil` underflows to zero across a Durable Object round trip —
+					// off-spec against `RateLimitErrorSchema`, and ignored by the Go
+					// client, which only honours a positive hint. Mirrors the sign
+					// route's `retryAfterSeconds`.
+					retryAfter: Math.max(1, Math.ceil((rateLimit.resetAt - Date.now()) / TIME.SECOND)),
 				},
 				HTTP.TooManyRequests,
 			);

--- a/src/middleware/security.ts
+++ b/src/middleware/security.ts
@@ -122,7 +122,12 @@ export const adminRateLimit: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
 			new Request(`http://internal/consume?identity=${encodeURIComponent(identity)}`),
 		);
 
-		if (!rateLimitResponse.ok) {
+		// A denied consume is a *verdict*, and the Durable Object delivers it as a
+		// 429 with the verdict in the body — so `!ok` alone reads the one answer
+		// this middleware exists to detect as an outage, answering 503 with no
+		// `retryAfter` and leaving the `allowed` branch below unreachable. Same
+		// reading as the sign route's `resolveRateLimit`.
+		if (!rateLimitResponse.ok && rateLimitResponse.status !== HTTP.TooManyRequests) {
 			throw new Error(`Rate limiter returned ${rateLimitResponse.status}`);
 		}
 

--- a/src/routes/sign.ts
+++ b/src/routes/sign.ts
@@ -229,15 +229,22 @@ app.openapi(signRoute, async (c) => {
 	// branch — the per-caller cap does not bound the trusted *row*. This one is
 	// keyed on the row id, which is server-side and unforgeable, with a ceiling
 	// well above the per-caller budget so no single workflow's behaviour changes:
-	// it only stops one row from being multiplied without limit. Started here
-	// rather than awaited so it overlaps the first tier and the key fetch.
+	// it only stops one row from being multiplied without limit.
+	//
+	// Deliberately *not* started in parallel with the first tier. A denied bucket
+	// costs itself nothing — `consumeToken` returns before decrementing — so a
+	// request the per-caller tier already refused would still spend a row token.
+	// One branch looping at 1000 req/min would then hold the row at its ceiling
+	// on traffic that was never signed, refusing every sibling branch under the
+	// same trusted row; and being refused is exactly what provokes a client to
+	// retry. Both buckets live in one single-threaded Durable Object, so firing
+	// them together only ever overlapped the wire time, never the work.
 	//
 	// Absent on the service-token path, which is already metered per credential.
 	const subjectPolicyId = c.get("subjectPolicyId");
-	const rowLimitPromise = subjectPolicyId
-		? fetchRateLimiter(c.env, createIdentity(SUBJECT_ROW_METER, subjectPolicyId), SUBJECT_ROW_LIMIT)
+	const consumeRowToken = subjectPolicyId
+		? () => fetchRateLimiter(c.env, createIdentity(SUBJECT_ROW_METER, subjectPolicyId), SUBJECT_ROW_LIMIT)
 		: undefined;
-	rowLimitPromise?.catch(() => {});
 	// `createKeyId` below can throw before the Promise.all that normally awaits
 	// this, which would leave the rejection unobserved. Attaching a handler does
 	// not consume it for the real consumers.
@@ -267,37 +274,40 @@ app.openapi(signRoute, async (c) => {
 			);
 		}
 
-		// The row ceiling governs this branch too. Without it the per-caller bucket
-		// is the only bound on the D1 write below, and that bucket is keyed on
-		// `sub` — so a row that can mint subjects could still flood `audit_logs`
-		// past its ceiling, which is the flooding this tier exists to stop.
-		const scopeRowRetryAfter = await resolveRowCeiling(rowLimitPromise, requestId);
-		if (scopeRowRetryAfter !== undefined) {
-			// Named apart from the signing path's ceiling refusal, and carrying the
-			// denial's own fields: this branch returns before the D1 write, so the
-			// scope violation leaves no audit row. Refusing here without recording
-			// what was refused would let anything able to hold the row at its
-			// ceiling silence the highest-signal event the service produces — the
-			// same reasoning as the limiter-unavailable branch below.
-			logger.warn("Key scope denied while the trusted row was at its signing ceiling", {
-				requestId,
-				subjectPolicy: c.get("subjectPolicyName"),
-				subjectPolicyId,
-				issuer: claims.iss,
-				subject: claims.sub,
-				keyId: keyIdParam,
-			});
-			return c.json(
-				{
-					error: "Rate limit exceeded",
-					code: "RATE_LIMITED" as const satisfies ErrorCode,
-					retryAfter: scopeRowRetryAfter,
-				},
-				HTTP.TooManyRequests,
-			);
-		}
-
 		if (decision.kind === "ok") {
+			// The row ceiling governs this branch too. Without it the per-caller
+			// bucket is the only bound on the D1 write below, and that bucket is
+			// keyed on `sub` — so a row that can mint subjects could still flood
+			// `audit_logs` past its ceiling, which is the flooding this tier exists
+			// to stop. Consulted only once the first tier allowed: what it bounds is
+			// the write, and a caller the first tier refused writes nothing.
+			const scopeRowRetryAfter = await resolveRowCeiling(consumeRowToken?.(), requestId);
+			if (scopeRowRetryAfter !== undefined) {
+				// Named apart from the signing path's ceiling refusal, and carrying
+				// the denial's own fields: this branch returns before the D1 write, so
+				// the scope violation leaves no audit row. Refusing here without
+				// recording what was refused would let anything able to hold the row
+				// at its ceiling silence the highest-signal event the service
+				// produces — the same reasoning as the limiter-unavailable branch
+				// below.
+				logger.warn("Key scope denied while the trusted row was at its signing ceiling", {
+					requestId,
+					subjectPolicy: c.get("subjectPolicyName"),
+					subjectPolicyId,
+					issuer: claims.iss,
+					subject: claims.sub,
+					keyId: keyIdParam,
+				});
+				return c.json(
+					{
+						error: "Rate limit exceeded",
+						code: "RATE_LIMITED" as const satisfies ErrorCode,
+						retryAfter: scopeRowRetryAfter,
+					},
+					HTTP.TooManyRequests,
+				);
+			}
+
 			await scheduleBackgroundTask(
 				c,
 				requestId,
@@ -348,26 +358,6 @@ app.openapi(signRoute, async (c) => {
 			fetchKeyStorage(c.env, `/get-key?keyId=${encodeURIComponent(keyIdParam)}`),
 		]);
 
-		// The row ceiling is advisory relative to the per-caller bucket: if it is
-		// exhausted the caller is over budget regardless of which subject it
-		// presented.
-		const rowRetryAfter = await resolveRowCeiling(rowLimitPromise, requestId);
-		if (rowRetryAfter !== undefined) {
-			logger.warn("Trusted row hit its signing ceiling", {
-				requestId,
-				subjectPolicy: c.get("subjectPolicyName"),
-				subjectPolicyId,
-			});
-			return c.json(
-				{
-					error: "Rate limit exceeded",
-					code: "RATE_LIMITED" as const satisfies ErrorCode,
-					retryAfter: rowRetryAfter,
-				},
-				HTTP.TooManyRequests,
-			);
-		}
-
 		// Process rate limit. A 429 carries the verdict, not a failure — treating
 		// it as one turned every genuine per-caller refusal into a 503.
 		if (!rateLimitResponse.ok && rateLimitResponse.status !== HTTP.TooManyRequests) {
@@ -394,6 +384,27 @@ app.openapi(signRoute, async (c) => {
 					error: "Rate limit exceeded",
 					code: "RATE_LIMITED" as const satisfies ErrorCode,
 					retryAfter: Math.ceil((rateLimit.resetAt - Date.now()) / 1000),
+				},
+				HTTP.TooManyRequests,
+			);
+		}
+
+		// The row ceiling, consulted only now that the per-caller tier has allowed.
+		// Ordered this way for two reasons: the caller is told which budget it
+		// actually exceeded — its own, not its neighbours' — and a refused request
+		// no longer spends a token from the bucket its siblings share.
+		const rowRetryAfter = await resolveRowCeiling(consumeRowToken?.(), requestId);
+		if (rowRetryAfter !== undefined) {
+			logger.warn("Trusted row hit its signing ceiling", {
+				requestId,
+				subjectPolicy: c.get("subjectPolicyName"),
+				subjectPolicyId,
+			});
+			return c.json(
+				{
+					error: "Rate limit exceeded",
+					code: "RATE_LIMITED" as const satisfies ErrorCode,
+					retryAfter: rowRetryAfter,
 				},
 				HTTP.TooManyRequests,
 			);

--- a/src/routes/sign.ts
+++ b/src/routes/sign.ts
@@ -81,6 +81,32 @@ async function resolveRateLimit(pending: Promise<Response>, requestId: string): 
 	return { kind: "ok" };
 }
 
+/**
+ * Resolve the per-row ceiling, if this caller has one, into a retry delay.
+ *
+ * Both refusal paths consult it: the signing path, and the key-scope denial,
+ * whose D1 write is otherwise bounded only by the per-caller bucket — and that
+ * bucket is keyed on `sub`, which is the multiplication this tier exists to
+ * stop. Only one of them runs per request, so the response is read once.
+ *
+ * An outage is deliberately not fatal here: the per-caller tier has already
+ * answered, and failing closed twice would turn one outage into two.
+ *
+ * @param pending - An already-started row-ceiling `fetchRateLimiter` call
+ * @param requestId - For correlating the refusal in logs
+ * @returns Seconds to wait if the row is over its ceiling, else `undefined`
+ */
+async function resolveRowCeiling(
+	pending: Promise<Response> | undefined,
+	requestId: string,
+): Promise<number | undefined> {
+	if (!pending) {
+		return undefined;
+	}
+	const decision = await resolveRateLimit(pending, requestId);
+	return decision.kind === "limited" ? decision.retryAfter : undefined;
+}
+
 const signRoute = createRoute({
 	method: "post",
 	path: "/",
@@ -236,6 +262,27 @@ app.openapi(signRoute, async (c) => {
 			);
 		}
 
+		// The row ceiling governs this branch too. Without it the per-caller bucket
+		// is the only bound on the D1 write below, and that bucket is keyed on
+		// `sub` — so a row that can mint subjects could still flood `audit_logs`
+		// past its ceiling, which is the flooding this tier exists to stop.
+		const scopeRowRetryAfter = await resolveRowCeiling(rowLimitPromise, requestId);
+		if (scopeRowRetryAfter !== undefined) {
+			logger.warn("Trusted row hit its signing ceiling", {
+				requestId,
+				subjectPolicy: c.get("subjectPolicyName"),
+				subjectPolicyId,
+			});
+			return c.json(
+				{
+					error: "Rate limit exceeded",
+					code: "RATE_LIMITED" as const satisfies ErrorCode,
+					retryAfter: scopeRowRetryAfter,
+				},
+				HTTP.TooManyRequests,
+			);
+		}
+
 		if (decision.kind === "ok") {
 			await scheduleBackgroundTask(
 				c,
@@ -289,25 +336,22 @@ app.openapi(signRoute, async (c) => {
 
 		// The row ceiling is advisory relative to the per-caller bucket: if it is
 		// exhausted the caller is over budget regardless of which subject it
-		// presented. A limiter outage here is not fatal — the first tier already
-		// answered, and failing closed twice would turn one outage into two.
-		if (rowLimitPromise) {
-			const rowDecision = await resolveRateLimit(rowLimitPromise, requestId);
-			if (rowDecision.kind === "limited") {
-				logger.warn("Trusted row hit its signing ceiling", {
-					requestId,
-					subjectPolicy: c.get("subjectPolicyName"),
-					subjectPolicyId,
-				});
-				return c.json(
-					{
-						error: "Rate limit exceeded",
-						code: "RATE_LIMITED" as const satisfies ErrorCode,
-						retryAfter: rowDecision.retryAfter,
-					},
-					HTTP.TooManyRequests,
-				);
-			}
+		// presented.
+		const rowRetryAfter = await resolveRowCeiling(rowLimitPromise, requestId);
+		if (rowRetryAfter !== undefined) {
+			logger.warn("Trusted row hit its signing ceiling", {
+				requestId,
+				subjectPolicy: c.get("subjectPolicyName"),
+				subjectPolicyId,
+			});
+			return c.json(
+				{
+					error: "Rate limit exceeded",
+					code: "RATE_LIMITED" as const satisfies ErrorCode,
+					retryAfter: rowRetryAfter,
+				},
+				HTTP.TooManyRequests,
+			);
 		}
 
 		// Process rate limit

--- a/src/routes/sign.ts
+++ b/src/routes/sign.ts
@@ -44,6 +44,26 @@ const SUBJECT_ROW_LIMIT = 1000;
 type RateLimitDecision = { kind: "ok" } | { kind: "limited"; retryAfter: number } | { kind: "unavailable" };
 
 /**
+ * A denial's `resetAt` as whole seconds to wait, floored at one.
+ *
+ * `resetAt` on a denial is when the bucket next holds a token, and refill is
+ * proportional to capacity — 60ms on the 1000-wide row bucket, 600ms on the
+ * default. Both are shorter than a Worker-to-Durable-Object round trip can be,
+ * so the naive `ceil((resetAt - now) / 1000)` reaches zero or below by the time
+ * the answer is read. `RateLimitErrorSchema` declares `retryAfter` positive, and
+ * the Go client only honours it when it is (`retry.go:57`), so an underflowed
+ * hint is both off-spec and silently discarded. The limiter's own `Retry-After`
+ * header already floors at one; this is the same floor on the field callers
+ * actually receive, since that header never leaves the Durable Object.
+ *
+ * @param resetAt - The denial's reset timestamp, in epoch milliseconds
+ * @returns Whole seconds to wait, never below one
+ */
+function retryAfterSeconds(resetAt: number): number {
+	return Math.max(1, Math.ceil((resetAt - Date.now()) / TIME.SECOND));
+}
+
+/**
  * Resolve an in-flight rate limiter call into a decision.
  *
  * Used by the refusal paths, which only need to know whether they may perform
@@ -81,7 +101,7 @@ async function resolveRateLimit(pending: Promise<Response>, requestId: string): 
 
 	const rateLimit = (await response.json()) as RateLimitResult;
 	if (!rateLimit.allowed) {
-		return { kind: "limited", retryAfter: Math.ceil((rateLimit.resetAt - Date.now()) / 1000) };
+		return { kind: "limited", retryAfter: retryAfterSeconds(rateLimit.resetAt) };
 	}
 	return { kind: "ok" };
 }
@@ -223,6 +243,10 @@ app.openapi(signRoute, async (c) => {
 	// Starting rather than awaiting keeps the signing path's overlap with the key
 	// fetch intact — the promise is already in flight when Promise.all takes it.
 	const rateLimitPromise = fetchRateLimiter(c.env, identity);
+	// `createKeyId` below can throw before the Promise.all that normally awaits
+	// this, which would leave the rejection unobserved. Attaching a handler does
+	// not consume it for the real consumers.
+	rateLimitPromise.catch(() => {});
 
 	// Second tier. The bucket above is keyed on `<iss>:<sub>`, and GitHub puts the
 	// ref in `sub`, so a caller who can push branches mints a fresh budget per
@@ -245,10 +269,6 @@ app.openapi(signRoute, async (c) => {
 	const consumeRowToken = subjectPolicyId
 		? () => fetchRateLimiter(c.env, createIdentity(SUBJECT_ROW_METER, subjectPolicyId), SUBJECT_ROW_LIMIT)
 		: undefined;
-	// `createKeyId` below can throw before the Promise.all that normally awaits
-	// this, which would leave the rejection unobserved. Attaching a handler does
-	// not consume it for the real consumers.
-	rateLimitPromise.catch(() => {});
 
 	// Both auth paths may carry a key allowlist; enforce it before any signing.
 	const allowedKeyIds = c.get("allowedKeyIds");
@@ -383,7 +403,7 @@ app.openapi(signRoute, async (c) => {
 				{
 					error: "Rate limit exceeded",
 					code: "RATE_LIMITED" as const satisfies ErrorCode,
-					retryAfter: Math.ceil((rateLimit.resetAt - Date.now()) / 1000),
+					retryAfter: retryAfterSeconds(rateLimit.resetAt),
 				},
 				HTTP.TooManyRequests,
 			);

--- a/src/routes/sign.ts
+++ b/src/routes/sign.ts
@@ -69,7 +69,12 @@ async function resolveRateLimit(pending: Promise<Response>, requestId: string): 
 		return { kind: "unavailable" };
 	}
 
-	if (!response.ok) {
+	// A denied consume is a *verdict*, and the Durable Object delivers it as a
+	// 429 with the verdict in the body — so `!response.ok` alone reads the one
+	// answer this function exists to detect as an outage. For the row ceiling,
+	// whose outage path is deliberately non-fatal, that failed open: the tier
+	// never refused anything.
+	if (!response.ok && response.status !== HTTP.TooManyRequests) {
 		logger.error("Rate limiter failed", { status: response.status, requestId });
 		return { kind: "unavailable" };
 	}
@@ -363,8 +368,9 @@ app.openapi(signRoute, async (c) => {
 			);
 		}
 
-		// Process rate limit
-		if (!rateLimitResponse.ok) {
+		// Process rate limit. A 429 carries the verdict, not a failure — treating
+		// it as one turned every genuine per-caller refusal into a 503.
+		if (!rateLimitResponse.ok && rateLimitResponse.status !== HTTP.TooManyRequests) {
 			logger.error("Rate limiter failed", {
 				status: rateLimitResponse.status,
 				requestId,

--- a/src/routes/sign.ts
+++ b/src/routes/sign.ts
@@ -13,7 +13,7 @@ import type { ErrorCode } from "#schemas/errors";
 import type { AnyStoredKey } from "#schemas/keys";
 import { AnyStoredKeySchema, isX509Key } from "#schemas/keys";
 import type { Identity, RateLimitResult, ValidatedOIDCClaims } from "#types";
-import { createKeyId, HEADERS, HTTP, isKeyIdShaped, TIME } from "#types";
+import { createIdentity, createKeyId, HEADERS, HTTP, isKeyIdShaped, TIME } from "#types";
 import { logAuditEvent } from "#utils/audit";
 import { fetchKeyStorage, fetchRateLimiter } from "#utils/durable-objects";
 import { scheduleBackgroundTask } from "#utils/execution";
@@ -22,6 +22,23 @@ import { signCommitData } from "#utils/signing";
 import { signCommitDataX509 } from "#utils/x509";
 
 const app = createOpenAPIApp();
+
+/**
+ * Rate-limiter namespace for the per-row signing ceiling. Not an issuer, so it
+ * cannot collide with the `<iss>:<sub>` buckets — a non-URL issuer cannot
+ * authenticate, since JWKS discovery runs the issuer through `validateUrl`.
+ */
+const SUBJECT_ROW_METER = "oidc-subject-row";
+
+/**
+ * Signatures per minute per trusted row, across every subject it covers.
+ *
+ * Ten times the per-caller budget: high enough that a busy org spread over many
+ * repositories and refs never meets it, low enough that one row cannot be
+ * multiplied into unbounded signing by minting subjects. Tune against real
+ * traffic rather than treating this number as load-bearing.
+ */
+const SUBJECT_ROW_LIMIT = 1000;
 
 /** Outcome of consulting the rate limiter, with the failure modes separated. */
 type RateLimitDecision = { kind: "ok" } | { kind: "limited"; retryAfter: number } | { kind: "unavailable" };
@@ -175,6 +192,21 @@ app.openapi(signRoute, async (c) => {
 	// Starting rather than awaiting keeps the signing path's overlap with the key
 	// fetch intact — the promise is already in flight when Promise.all takes it.
 	const rateLimitPromise = fetchRateLimiter(c.env, identity);
+
+	// Second tier. The bucket above is keyed on `<iss>:<sub>`, and GitHub puts the
+	// ref in `sub`, so a caller who can push branches mints a fresh budget per
+	// branch — the per-caller cap does not bound the trusted *row*. This one is
+	// keyed on the row id, which is server-side and unforgeable, with a ceiling
+	// well above the per-caller budget so no single workflow's behaviour changes:
+	// it only stops one row from being multiplied without limit. Started here
+	// rather than awaited so it overlaps the first tier and the key fetch.
+	//
+	// Absent on the service-token path, which is already metered per credential.
+	const subjectPolicyId = c.get("subjectPolicyId");
+	const rowLimitPromise = subjectPolicyId
+		? fetchRateLimiter(c.env, createIdentity(SUBJECT_ROW_METER, subjectPolicyId), SUBJECT_ROW_LIMIT)
+		: undefined;
+	rowLimitPromise?.catch(() => {});
 	// `createKeyId` below can throw before the Promise.all that normally awaits
 	// this, which would leave the rejection unobserved. Attaching a handler does
 	// not consume it for the real consumers.
@@ -254,6 +286,29 @@ app.openapi(signRoute, async (c) => {
 			rateLimitPromise,
 			fetchKeyStorage(c.env, `/get-key?keyId=${encodeURIComponent(keyIdParam)}`),
 		]);
+
+		// The row ceiling is advisory relative to the per-caller bucket: if it is
+		// exhausted the caller is over budget regardless of which subject it
+		// presented. A limiter outage here is not fatal — the first tier already
+		// answered, and failing closed twice would turn one outage into two.
+		if (rowLimitPromise) {
+			const rowDecision = await resolveRateLimit(rowLimitPromise, requestId);
+			if (rowDecision.kind === "limited") {
+				logger.warn("Trusted row hit its signing ceiling", {
+					requestId,
+					subjectPolicy: c.get("subjectPolicyName"),
+					subjectPolicyId,
+				});
+				return c.json(
+					{
+						error: "Rate limit exceeded",
+						code: "RATE_LIMITED" as const satisfies ErrorCode,
+						retryAfter: rowDecision.retryAfter,
+					},
+					HTTP.TooManyRequests,
+				);
+			}
+		}
 
 		// Process rate limit
 		if (!rateLimitResponse.ok) {

--- a/src/routes/sign.ts
+++ b/src/routes/sign.ts
@@ -268,10 +268,19 @@ app.openapi(signRoute, async (c) => {
 		// past its ceiling, which is the flooding this tier exists to stop.
 		const scopeRowRetryAfter = await resolveRowCeiling(rowLimitPromise, requestId);
 		if (scopeRowRetryAfter !== undefined) {
-			logger.warn("Trusted row hit its signing ceiling", {
+			// Named apart from the signing path's ceiling refusal, and carrying the
+			// denial's own fields: this branch returns before the D1 write, so the
+			// scope violation leaves no audit row. Refusing here without recording
+			// what was refused would let anything able to hold the row at its
+			// ceiling silence the highest-signal event the service produces — the
+			// same reasoning as the limiter-unavailable branch below.
+			logger.warn("Key scope denied while the trusted row was at its signing ceiling", {
 				requestId,
 				subjectPolicy: c.get("subjectPolicyName"),
 				subjectPolicyId,
+				issuer: claims.iss,
+				subject: claims.sub,
+				keyId: keyIdParam,
 			});
 			return c.json(
 				{

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -23,6 +23,13 @@ export interface Variables {
 	 * synthetic `sub`.
 	 */
 	subjectPolicyName?: string;
+	/**
+	 * Id of the trusted-subject row that authorized an OIDC caller. Server-side
+	 * and stable, unlike `sub`, which the caller varies per ref — so this is what
+	 * the per-row signing ceiling is metered on. Absent on the service-token path,
+	 * which is already metered per credential.
+	 */
+	subjectPolicyId?: string;
 }
 
 /** Cloudflare Workers environment bindings */

--- a/src/utils/durable-objects.ts
+++ b/src/utils/durable-objects.ts
@@ -20,11 +20,16 @@ export async function fetchKeyStorage(env: Env, endpoint: string, options?: Requ
  * Fetch from RATE_LIMITER Durable Object
  * @param env - Environment bindings
  * @param identity - Identity string to rate limit
+ * @param limit - Bucket capacity; omit for the default per-caller budget
  */
-export async function fetchRateLimiter(env: Env, identity: string): Promise<Response> {
+export async function fetchRateLimiter(env: Env, identity: string, limit?: number): Promise<Response> {
 	const id = env.RATE_LIMITER.idFromName("global");
 	const limiter = env.RATE_LIMITER.get(id);
-	return limiter.fetch(new Request(`http://internal/consume?identity=${encodeURIComponent(identity)}`));
+	const query = new URLSearchParams({ identity });
+	if (limit !== undefined) {
+		query.set("limit", String(limit));
+	}
+	return limiter.fetch(new Request(`http://internal/consume?${query}`));
 }
 
 /**


### PR DESCRIPTION
## The gap

The signing rate limit is keyed on `iss:sub`. GitHub puts the ref in `sub`, so anyone who can push a branch under a trusted prefix mints a fresh 100/min budget with it. The cap bounds a *caller*, never the *row* — one trust, N branches, N budgets, each costing a key-storage fetch, an openpgp signing operation and a D1 write.

Service tokens never had this; they meter on the credential (`policy.name`). `recordRevokedReuse` already made this exact argument and fixed it for its own write, with a comment noting the same reasoning applied to signing. This closes that.

Probed on the live shape: two requests differing only in branch name produce two distinct limiter buckets for one trusted row.

## The fix

Two tiers, rather than re-keying:

| Tier | Key | Limit |
| --- | --- | --- |
| Per caller | `iss:sub` (unchanged) | 100/min |
| Per row | `oidc-subject-row:` + row id | 1000/min |

The row id is server-side and unforgeable. 1000/min is 10x the per-caller budget, so no existing workflow's behaviour changes below 1000/min aggregate — it only stops one row being multiplied without limit.

Re-keying to `policy.id` alone was the other option and is worse here: it collapses an owner-wide row to a single 100/min bucket shared by every repository beneath it, which throttles a busy org on day one. The second tier collapses it too, just at 1000 instead of 100 — an operator who wants sibling repos isolated should narrow `subject_prefix` rather than rely on the ceiling.

The row bucket starts in parallel with the per-caller bucket and the key fetch. Both buckets live in one Durable Object, which is single-threaded, so the two consume calls serialize inside it — the parallelism is on the Worker's side of the wire, not the object's. Its outage path is deliberately non-fatal — the first tier has already answered, and failing closed twice turns one outage into two.

The ceiling governs the key-scope denial branch too, not just the signing path: that branch writes to `audit_logs`, and a row able to mint subjects could otherwise flood the table past a ceiling that had already refused its signatures.

## Rate limiter

Buckets now carry their own capacity. Buckets with different ceilings share one Durable Object, and refilling against the wrong capacity would silently grant the wrong budget. An explicitly supplied capacity wins over the stored one, so the ceilings stay tunable rather than pinned at whatever a bucket was created with.

Abandoned buckets are now reaped. Every distinct identity used to leave a permanent `bucket:` key and nothing removed it — one row per git ref on the signing limiter, and one row per source IP on the admin limiter, written before auth. Refill is linear and clamped, so a bucket idle for a full window has refilled to exactly the state `getBucket` synthesises for an absent key; deleting it changes no observable answer. An alarm sweeps in bounded pages and stops arming once only live buckets remain.

`getBucket` no longer persists. Consumption is the only writer, which halves the storage writes on the hot path and stops a bare `/check` from minting the key the sweep exists to remove.

## Verification

- `task t` — 828 passed / 26 files
- `task typecheck`, eslint, biome, `task format` — clean
- `task generate:api` — no diff

Tests pin: two refs produce two per-caller buckets but one row bucket at limit 1000 with no `refs/heads` in the key; a row at its ceiling returns 429 even while the per-caller bucket allows; the scope-denial path is metered and writes nothing once over budget; an idle bucket is reaped while a live one is not; a reaped identity answers exactly as a fresh one; and `/check` persists nothing.

Two limiter tests that drained a bucket with up to 500 sequential round-trips now set a capacity of one instead. Those loops were the CI flake — they overran vitest's 5s default under load, which surfaced as the whole file erroring rather than as a failed assertion.
