### PR TITLE
docs: point OpenAPI references at the generated client/openapi.json

### DIFF
--- a/API.md
+++ b/API.md
@@ -719,21 +719,27 @@ sign_commits:
 
 ## OpenAPI Specification
 
-Full OpenAPI 3.1 specification available in `openapi.yaml`. Use with:
+The generated OpenAPI 3.0 specification is served live at `GET /doc` and
+checked in at [`client/openapi.json`](client/openapi.json). Use it with:
 
-- **Swagger UI**: Host openapi.yaml for interactive API explorer
+- **Swagger UI**: Already deployed at <https://gpg.kajkowalski.nl/ui>
 - **Code Generation**: Generate SDKs in multiple languages
 - **Documentation**: Generate beautiful API docs
 - **Testing**: Automated validation against spec
 
-Example hosting:
+> [!NOTE]
+> The spec is pinned to OpenAPI 3.0.0 because `oapi-codegen` does not support
+> 3.1.x yet
+> ([oapi-codegen#373](https://github.com/oapi-codegen/oapi-codegen/issues/373)).
+
+Example hosting of the checked-in contract:
 
 ```bash
 # Using Swagger UI Docker
 docker run \
   -p 8080:8080 \
-  -e SWAGGER_JSON=/openapi.yaml \
-  -v $(pwd)/openapi.yaml:/openapi.yaml \
+  -e SWAGGER_JSON=/openapi.json \
+  -v $(pwd)/client/openapi.json:/openapi.json \
   swaggerapi/swagger-ui
 ```
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -312,9 +312,9 @@ by hand. When the API changes:
 ### Documentation (in root directory)
 
 ```
-API.md                722 lines - Developer guide with examples
-DOCUMENTATION.md      386 lines - Overview and usage
-DEVELOPER_GUIDE.md              - This file
+API.md                - Developer guide with examples
+DOCUMENTATION.md      - Overview and usage
+DEVELOPER_GUIDE.md    - This file
 ```
 
 The OpenAPI specification is generated, not hand-written, and lives at
@@ -342,7 +342,7 @@ gitlab-ci/
 ## Statistics
 
 - **OpenAPI Schema**: `client/openapi.json` (generated)
-- **API Documentation**: 722 lines (markdown)
+- **API Documentation**: API.md, DOCUMENTATION.md, docs/ (markdown)
 - **Complete Examples**: 4 bash scripts, 2 Python modules, 2 CI workflows
 - **Total Documentation**: 3000+ lines of production-ready content
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -12,13 +12,12 @@ the GPG Signing Service.
 
 ### Core Documentation
 
-| File                   | Purpose                                | Audience                              |
-| ---------------------- | -------------------------------------- | ------------------------------------- |
-| **openapi.yaml**       | OpenAPI 3.1 specification (YAML)       | Tools, code generators, API platforms |
-| **openapi.json**       | OpenAPI 3.1 specification (JSON)       | Programmatic access, automation       |
-| **API.md**             | Developer-friendly guide with examples | Software engineers, integrators       |
-| **DOCUMENTATION.md**   | Overview and usage guide               | Everyone                              |
-| **DEVELOPER_GUIDE.md** | This file - navigation and context     | Contributors, API users               |
+| File                      | Purpose                                | Audience                              |
+| ------------------------- | -------------------------------------- | ------------------------------------- |
+| **`client/openapi.json`** | Generated OpenAPI 3.0 specification    | Tools, code generators, API platforms |
+| **API.md**                | Developer-friendly guide with examples | Software engineers, integrators       |
+| **DOCUMENTATION.md**      | Overview and usage guide               | Everyone                              |
+| **DEVELOPER_GUIDE.md**    | This file - navigation and context     | Contributors, API users               |
 
 ### Examples
 
@@ -41,9 +40,10 @@ the GPG Signing Service.
 
 ### For API Integration
 
-1. **OpenAPI Import**: Load `openapi.yaml` into Swagger UI or Postman
-2. **Code Generation**: Use `openapi.json` with code generators
-3. **Documentation**: Host `openapi.yaml` with ReDoc or similar
+1. **OpenAPI Import**: Load `client/openapi.json` into Swagger UI or Postman
+2. **Code Generation**: Use `client/openapi.json` with code generators
+3. **Documentation**: Browse the deployed Swagger UI at `GET /ui`, or host
+   `client/openapi.json` with ReDoc or similar
 4. **Testing**: Use examples as test cases
 
 ### For Administration
@@ -166,7 +166,7 @@ See examples/python/manage_keys.py rotate command for complete implementation.
 
 ## Integration Checklist
 
-- [ ] Import openapi.yaml into API documentation tool
+- [ ] Import `client/openapi.json` into API documentation tool
 - [ ] Setup OIDC token retrieval in CI/CD
 - [ ] Test signing with public key retrieval
 - [ ] Configure admin token as secret
@@ -202,7 +202,7 @@ See examples/python/manage_keys.py rotate command for complete implementation.
 
 ### With Postman
 
-1. Import openapi.yaml as Postman collection
+1. Import `client/openapi.json` as Postman collection
 2. Create environment with variables:
    - `base_url`: https://gpg.kajkowalski.nl
    - `admin_token`: your token value
@@ -211,11 +211,14 @@ See examples/python/manage_keys.py rotate command for complete implementation.
 
 ### With Swagger UI
 
+The deployed service already hosts Swagger UI at
+<https://gpg.kajkowalski.nl/ui>. To run it against the checked-in contract:
+
 ```bash
-# Local Swagger UI pointing to openapi.yaml
+# Local Swagger UI pointing to client/openapi.json
 docker run -p 8080:8080 \
-  -v $(pwd)/openapi.yaml:/openapi.yaml:ro \
-  -e SWAGGER_JSON=/openapi.yaml \
+  -v $(pwd)/client/openapi.json:/openapi.json:ro \
+  -e SWAGGER_JSON=/openapi.json \
   swaggerapi/swagger-ui
 ```
 
@@ -256,7 +259,7 @@ Check:
 
 ## API Specification Format
 
-OpenAPI 3.1.0 with:
+OpenAPI 3.0.0 with:
 
 - Full endpoint documentation
 - Request/response schemas
@@ -265,34 +268,42 @@ OpenAPI 3.1.0 with:
 - Rate limiting headers
 - Audit logging details
 
+> [!NOTE]
+> The spec is pinned to 3.0.0 on purpose: `oapi-codegen` does not support
+> OpenAPI 3.1.x yet
+> ([oapi-codegen#373](https://github.com/oapi-codegen/oapi-codegen/issues/373)).
+> The pin lives in `src/lib/openapi.ts`.
+
 ### Specification Compliance
 
-All endpoints and responses validate against `openapi.yaml` schema.\
+All endpoints and responses validate against the `client/openapi.json` schema.\
 Use tools like:
 
 ```bash
-# Validate response against spec
-swagger-cli validate openapi.yaml
+# Validate the spec
+bunx @redocly/cli lint client/openapi.json
 
 # Generate tests from spec
-dredd openapi.yaml https://gpg.kajkowalski.nl
+dredd client/openapi.json https://gpg.kajkowalski.nl
 ```
 
 ## Keeping Documentation Updated
 
-When API changes:
+The spec is generated from the route definitions in `src/`; it is never edited
+by hand. When the API changes:
 
-1. **Update openapi.yaml** with new endpoints/parameters
-2. **Validate**: `swagger-cli validate openapi.yaml`
-3. **Regenerate JSON**: `yq . openapi.yaml | jq . > openapi.json`
-4. **Update API.md** with new examples
-5. **Update examples/** directory
-6. **Commit and push** documentation changes
+1. **Update the route/schema definitions** in `src/` (`@hono/zod-openapi`
+   registrations plus `src/lib/openapi.ts`)
+2. **Regenerate**: `task gen` (runs `scripts/generate-openapi.ts` and the Go
+   client generator, refreshing `client/openapi.json`)
+3. **Update `docs/api.md`** with new examples
+4. **Update examples/** directory
+5. **Commit and push** the regenerated spec and documentation changes
 
 ## Support
 
 - **Issues/Questions**: GitHub repository issues
-- **Specification**: See `openapi.yaml` for complete definition
+- **Specification**: See `client/openapi.json` for complete definition
 - **Examples**: See `examples/` directory
 - **Troubleshooting**: See DOCUMENTATION.md
 
@@ -301,12 +312,13 @@ When API changes:
 ### Documentation (in root directory)
 
 ```
-openapi.yaml          888 lines - Full OpenAPI 3.1 specification
-openapi.json         1086 lines - Same spec in JSON format
 API.md                722 lines - Developer guide with examples
 DOCUMENTATION.md      386 lines - Overview and usage
 DEVELOPER_GUIDE.md              - This file
 ```
+
+The OpenAPI specification is generated, not hand-written, and lives at
+`client/openapi.json`.
 
 ### Examples (in examples/ directory)
 
@@ -329,7 +341,7 @@ gitlab-ci/
 
 ## Statistics
 
-- **OpenAPI Schema**: 888 lines (YAML), 1086 lines (JSON)
+- **OpenAPI Schema**: `client/openapi.json` (generated)
 - **API Documentation**: 722 lines (markdown)
 - **Complete Examples**: 4 bash scripts, 2 Python modules, 2 CI workflows
 - **Total Documentation**: 3000+ lines of production-ready content
@@ -337,5 +349,5 @@ gitlab-ci/
 ---
 
 Last updated: 2025-11-19\
-OpenAPI Version: `3.1.0`\
+OpenAPI Version: `3.0.0`\
 API Version: `1.0.0`

--- a/DOCS_SUMMARY.txt
+++ b/DOCS_SUMMARY.txt
@@ -2,6 +2,10 @@
   GPG SIGNING SERVICE - API DOCUMENTATION PACKAGE
 ================================================================================
 
+WARNING: This is a historical summary of the original documentation package.
+Use the current documentation index (docs/README.md) and the generated
+contract (client/openapi.json, served at GET /doc).
+
 GENERATED: 2024-01-15
 VERSION: 1.0.0
 LOCATION: /home/kjanat/projects/gpg-signing-service/

--- a/DOCS_SUMMARY.txt
+++ b/DOCS_SUMMARY.txt
@@ -10,21 +10,20 @@ LOCATION: /home/kjanat/projects/gpg-signing-service/
   DOCUMENTATION FILES CREATED
 ================================================================================
 
-ROOT DIRECTORY
---------------
-openapi.yaml (888 lines)
-  - OpenAPI 3.1 specification in YAML format
-  - Machine-readable API contract
+GENERATED SPECIFICATION
+-----------------------
+client/openapi.json
+  - Generated OpenAPI 3.0 specification (regenerate with `task gen`)
+  - Machine-readable API contract, served live at GET /doc
   - Compatible with Swagger UI, ReDoc, code generators
   - Includes all 8 endpoints with full documentation
   - Security schemes, error codes, examples
+  - Pinned to 3.0.0 because oapi-codegen does not support 3.1.x yet
+    (https://github.com/oapi-codegen/oapi-codegen/issues/373)
 
-openapi.json (1086 lines)
-  - Same specification in JSON format
-  - Auto-generated from openapi.yaml
-  - Use with tools preferring JSON input
-
-API.md (722 lines)
+ROOT DIRECTORY
+--------------
+API.md
   - Complete developer guide with working examples
   - Quick start section
   - Authentication flows (GitHub Actions, GitLab CI)
@@ -33,7 +32,7 @@ API.md (722 lines)
   - Integration examples and troubleshooting
   - Security best practices
 
-DOCUMENTATION.md (386 lines)
+DOCUMENTATION.md
   - Overview of all documentation
   - Quick links by use case
   - Common use cases with examples
@@ -51,7 +50,7 @@ DEVELOPER_GUIDE.md
 
 EXAMPLES DIRECTORY
 ------------------
-examples/README.md (800+ lines)
+examples/README.md
   - Quick start examples
   - Complete working code in multiple languages
   - Installation and setup instructions
@@ -71,7 +70,7 @@ Total Lines:          3000+ lines of documentation
 Total Files:          6 main documentation files
 Example Scripts:      Complete implementations (bash, python)
 Coverage:             8 endpoints, 16 error codes, 3 auth methods
-API Spec Format:      OpenAPI 3.1.0 (industry standard)
+API Spec Format:      OpenAPI 3.0.0 (generated from src/)
 Standards Compliance: Full JSON Schema validation
 
 ================================================================================
@@ -134,14 +133,14 @@ Security
 FOR DEVELOPERS
   1. Start with API.md (quick start section)
   2. Check examples/ for your platform (GitHub/GitLab/Shell/Python)
-  3. Reference openapi.yaml for complete endpoint specs
+  3. Reference client/openapi.json for complete endpoint specs
   4. Use DEVELOPER_GUIDE.md for navigation and key concepts
 
 FOR INTEGRATORS
-  1. Import openapi.yaml into Postman or Insomnia
+  1. Import client/openapi.json (or GET /doc) into Postman or Insomnia
   2. Use API.md for authentication setup
   3. Test with curl commands in examples/bash/
-  4. Generate client SDKs from openapi.json if needed
+  4. Generate client SDKs from client/openapi.json if needed
 
 FOR ADMINISTRATION
   1. See examples/bash/manage-keys.sh for key operations
@@ -150,9 +149,10 @@ FOR ADMINISTRATION
   4. Monitor via health endpoint (GET /health)
 
 FOR DOCUMENTATION HOSTING
-  1. Host openapi.yaml with Swagger UI: `docker run ... swaggerapi/swagger-ui`
-  2. Or use ReDoc: Include openapi.yaml in HTML
-  3. Generate static docs from openapi.yaml
+  1. Swagger UI is already deployed at GET /ui; to self-host, mount
+     client/openapi.json: `docker run ... swaggerapi/swagger-ui`
+  2. Or use ReDoc: point spec-url at client/openapi.json or GET /doc
+  3. Generate static docs from client/openapi.json
   4. Update with API.md for context and examples
 
 ================================================================================
@@ -160,7 +160,7 @@ FOR DOCUMENTATION HOSTING
 ================================================================================
 
 Documentation is production-ready:
-  ✓ Complete OpenAPI 3.1 specification
+  ✓ Complete OpenAPI 3.0 specification
   ✓ 100% endpoint coverage
   ✓ Request/response examples for all operations
   ✓ All error codes documented
@@ -199,7 +199,7 @@ See API.md for detailed examples.
   NEXT STEPS
 ================================================================================
 
-1. ✓ Review openapi.yaml for complete specification
+1. ✓ Review client/openapi.json for complete specification
 2. ✓ Import into API documentation tool (Swagger/ReDoc)
 3. ✓ Copy examples/ to your repository
 4. ✓ Setup authentication (OIDC, Bearer token)
@@ -213,8 +213,7 @@ See API.md for detailed examples.
 ================================================================================
 
 Documentation Files:
-  - openapi.yaml: Complete specification
-  - openapi.json: Specification as JSON
+  - client/openapi.json: Complete generated specification
   - API.md: Developer guide
   - DOCUMENTATION.md: Overview
   - DEVELOPER_GUIDE.md: Navigation and context
@@ -234,7 +233,7 @@ For issues or questions:
 ================================================================================
 
 API Version:          1.0.0
-OpenAPI Version:      3.1.0
+OpenAPI Version:      3.0.0
 Documentation Date:   2024-01-15
 Compatibility:        Cloudflare Workers, Hono framework
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,7 +1,7 @@
 # API Documentation Summary
 
 > [!WARNING]
-> This generated summary refers to removed root-level OpenAPI files. Start with
+> This is a historical summary and may not track the current API. Start with
 > the current [documentation index](docs/README.md) and generated
 > [`client/openapi.json`](client/openapi.json).
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -12,44 +12,43 @@ Service:
 
 ### Files
 
-1. **openapi.yaml** - OpenAPI 3.1 specification in YAML format
+1. **`client/openapi.json`** - generated OpenAPI 3.0 specification
    - Machine-readable API contract
    - Compatible with code generators, documentation tools, and testing
      frameworks
    - Includes all endpoints, parameters, request/response schemas
    - Security schemes and error codes defined
+   - Served live at `GET /doc`; regenerate with `task gen`
+   - Pinned to 3.0.0 because `oapi-codegen` does not support 3.1.x yet
+     ([oapi-codegen#373](https://github.com/oapi-codegen/oapi-codegen/issues/373))
 
-2. **openapi.json** - Same specification in JSON format
-   - Generated from openapi.yaml
-   - Easier to parse programmatically
-   - Use with API tools that prefer JSON
-
-3. **API.md** - Developer-friendly API documentation
+2. **API.md** - Developer-friendly API documentation
    - Quick start examples
    - Authentication flows for GitHub Actions and GitLab CI
    - Endpoint documentation with examples
    - Error reference and rate limiting explanation
    - Integration guides and code samples
 
-4. **DOCUMENTATION.md** (this file) - Overview and usage guide
+3. **DOCUMENTATION.md** (this file) - Overview and usage guide
 
 ## Quick Links
 
 ### For Developers
 
 - Start with **API.md** for quick start and examples
-- Reference **openapi.yaml** for detailed specs
+- Reference **`client/openapi.json`** for detailed specs
 - Use integration guides for GitHub Actions or GitLab CI
 
 ### For API Consumers
 
-- Import openapi.yaml into Swagger UI for interactive testing
+- Use the deployed Swagger UI at <https://gpg.kajkowalski.nl/ui>, or import
+  `client/openapi.json` into your own
 - Generate client SDKs in your preferred language
 - Use with Postman, Insomnia, or other API clients
 
 ### For DevOps/Tools
 
-- Use openapi.json with code generation tools
+- Use `client/openapi.json` with code generation tools
 - Reference error codes in monitoring/alerting
 - Query audit logs via GET /admin/audit endpoint
 
@@ -96,18 +95,18 @@ All responses include:
 
 Host the specification with Swagger UI:
 
-```bash
-# Using npm
-bunx swagger-ui-dist --config src/swagger-initializer.js
+The service already deploys Swagger UI at <https://gpg.kajkowalski.nl/ui>. To
+host the checked-in contract yourself:
 
+```bash
 # Using Docker
 docker run -p 8080:8080 \
-  -v $(pwd)/openapi.yaml:/openapi.yaml:ro \
-  -e SWAGGER_JSON=/openapi.yaml \
+  -v $(pwd)/client/openapi.json:/openapi.json:ro \
+  -e SWAGGER_JSON=/openapi.json \
   swaggerapi/swagger-ui
 
 # Using custom HTML
-# Create index.html that loads openapi.yaml with SwaggerUI
+# Create index.html that loads client/openapi.json with SwaggerUI
 ```
 
 ### Postman
@@ -115,7 +114,7 @@ docker run -p 8080:8080 \
 1. File → Import → Enter:
 
    ```text
-   https://gpg.kajkowalski.nl/openapi.yaml
+   https://gpg.kajkowalski.nl/doc
    ```
 
 2. Create environment variables for authentication tokens
@@ -124,7 +123,7 @@ docker run -p 8080:8080 \
 ### ReDoc (Beautiful Documentation)
 
 ```bash
-bunx @redocly/cli build-docs openapi.yaml
+bunx @redocly/cli build-docs client/openapi.json
 ```
 
 or
@@ -142,7 +141,7 @@ or
     </style>
   </head>
   <body>
-    <redoc spec-url="./openapi.yaml"></redoc>
+    <redoc spec-url="https://gpg.kajkowalski.nl/doc"></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js"></script>
   </body>
 </html>
@@ -155,19 +154,19 @@ Generate client libraries in multiple languages:
 ```bash
 # Using openapi-generator-cli
 bunx @openapitools/openapi-generator-cli generate \
-  -i openapi.yaml \
+  -i client/openapi.json \
   -g python \
   -o ./python-client
 
 # JavaScript/TypeScript
 bunx @openapitools/openapi-generator-cli generate \
-  -i openapi.yaml \
+  -i client/openapi.json \
   -g typescript-fetch \
   -o ./typescript-client
 
 # Go
 bunx @openapitools/openapi-generator-cli generate \
-  -i openapi.yaml \
+  -i client/openapi.json \
   -g go \
   -o ./go-client
 ```
@@ -420,7 +419,7 @@ Breaking changes will result in new version. Current approach:
 ## Support Resources
 
 - **Documentation**: See `API.md` for detailed examples
-- **OpenAPI Spec**: Import `openapi.yaml` into API tools
+- **OpenAPI Spec**: Import `client/openapi.json` into API tools
 - **Repository**: https://github.com/kjanat/gpg-signing-service
 - **Issues**: https://github.com/kjanat/gpg-signing-service/issues
 - **Security**: GitHub security advisory process

--- a/docs-index.md
+++ b/docs-index.md
@@ -1,7 +1,7 @@
 # API Documentation Index
 
 > [!WARNING]
-> This historical index refers to generated files that are no longer present.
+> This is a historical index and may not track the current API.
 > Use the current [documentation index](docs/README.md) and generated
 > [`client/openapi.json`](client/openapi.json).
 

--- a/docs-index.md
+++ b/docs-index.md
@@ -20,19 +20,16 @@ Complete, production-ready API documentation for the GPG Signing Service.
 
 ### Specifications
 
-**openapi.yaml** - 🔧 Complete API specification (YAML)
+**`client/openapi.json`** - 🔧 Complete API specification
 
-- OpenAPI 3.1.0 format (industry standard)
+- OpenAPI 3.0.0 format, generated from the routes in `src/` via `task gen`
+- Served live at `GET /doc`, with Swagger UI at `GET /ui`
 - Machine-readable endpoint definitions
 - All request/response schemas
 - Error codes and security schemes
-- Import into Swagger UI, ReDoc, Postman
-
-**openapi.json** - 🔧 Same specification in JSON format
-
-- Auto-generated from openapi.yaml
-- Use with code generators and tools
-- Programmatic access via JSON parsers
+- Import into Swagger UI, ReDoc, Postman; use with code generators
+- Pinned to 3.0.0 because `oapi-codegen` does not support 3.1.x yet
+  ([oapi-codegen#373](https://github.com/oapi-codegen/oapi-codegen/issues/373))
 
 ### Documentation
 
@@ -84,7 +81,7 @@ Includes:
 ## Documentation Quality
 
 ✓ 3,000+ lines of comprehensive documentation\
-✓ OpenAPI 3.1.0 specification (industry standard)\
+✓ OpenAPI 3.0.0 specification (industry standard)\
 ✓ 100% endpoint coverage (8 endpoints fully documented)\
 ✓ 16 error codes defined and explained\
 ✓ Working code examples in 4 languages\
@@ -103,14 +100,14 @@ Includes:
 
 ### For API Integration
 
-1. Import **openapi.yaml** into Postman, Insomnia, or Swagger UI
+1. Import **`client/openapi.json`** into Postman, Insomnia, or Swagger UI
 2. Follow authentication setup in **API.md**
 3. Test endpoints using examples from **examples/**
-4. Generate client SDKs from **openapi.json** if needed
+4. Generate client SDKs from **`client/openapi.json`** if needed
 
 ### For API Documentation Hosting
 
-1. Use **openapi.yaml** with Swagger UI or ReDoc
+1. Use **`client/openapi.json`** with Swagger UI or ReDoc
 2. Include **API.md** for additional context
 3. Host **examples/** for developer reference
 4. Setup auto-generation from openapi specification
@@ -154,13 +151,13 @@ See **API.md** and **examples/** for complete examples.
 
 ```tree
 gpg-signing-service/
-├── openapi.yaml         # OpenAPI 3.1 specification (YAML)
-├── openapi.json         # OpenAPI 3.1 specification (JSON)
 ├── API.md               # Developer guide with examples
 ├── DOCUMENTATION.md     # Overview and navigation
 ├── DEVELOPER_GUIDE.md   # Context and key concepts
 ├── DOCS_SUMMARY.txt     # Quick reference summary
 ├── docs-index.md        # This file
+├── client/
+│   └── openapi.json     # Generated OpenAPI 3.0 specification
 └── examples/
     ├── README.md        # Examples guide
     ├── bash/
@@ -180,7 +177,7 @@ gpg-signing-service/
 
 All documentation follows industry best practices:
 
-- **OpenAPI 3.1.0** - Current standard for API specifications
+- **OpenAPI 3.0.0** - Consumed by the Go client generator
 - **Professional Writing** - Clear, concise technical content
 - **Complete Examples** - Production-ready code samples
 - **Security-Focused** - All security considerations documented
@@ -194,7 +191,7 @@ All documentation follows industry best practices:
 1. ✓ Review **DOCS_SUMMARY.txt** for overview
 2. ✓ Choose a file based on your role:
    - **Developer**: Start with **API.md**
-   - **Integrator**: Start with **openapi.yaml** + **examples/**
+   - **Integrator**: Start with **`client/openapi.json`** + **examples/**
    - **Administrator**: Start with **DEVELOPER_GUIDE.md**
 3. ✓ Setup authentication with your CI/CD system
 4. ✓ Test endpoints using provided examples
@@ -203,7 +200,7 @@ All documentation follows industry best practices:
 
 ## Support
 
-- **OpenAPI Specification**: See `openapi.yaml`
+- **OpenAPI Specification**: See `client/openapi.json`
 - **Implementation Details**: See `API.md`
 - **Code Examples**: See `examples/`
 - **Troubleshooting**: See `DOCUMENTATION.md`
@@ -212,7 +209,7 @@ All documentation follows industry best practices:
 ## Version Information
 
 - **API Version**: 1.0.0
-- **OpenAPI Version**: 3.1.0
+- **OpenAPI Version**: 3.0.0
 - **Generated**: 2024-01-15
 - **Status**: Production-ready
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -715,4 +715,5 @@ python3 python/manage_keys.py rotate \
 4. Monitor audit logs for operations
 5. Implement error handling as needed
 
-For more details, see the main `API.md` and `openapi.yaml` files.
+For more details, see the main `API.md` and the generated
+[`client/openapi.json`](../client/openapi.json) contract.


### PR DESCRIPTION
The root-level openapi.yaml and openapi.json presented as deliverables were never generated and are not served (both 404 on the deployment). The real artifact is client/openapi.json, produced by `task gen`.

- repoint every openapi.yaml / root openapi.json reference at client/openapi.json, or at the deployed `GET /doc` and `GET /ui`
- correct the OpenAPI 3.1 claims to 3.0.0, and record why it is pinned: oapi-codegen does not support 3.1.x yet (oapi-codegen#373), the same rationale carried in src/lib/openapi.ts
- replace the manual `swagger-cli` / `yq . openapi.yaml | jq .` regeneration recipe in DEVELOPER_GUIDE.md with `task gen`, and say plainly that the spec is generated from the routes in src/ rather than hand-edited
- drop the YAML story entirely; nothing produces YAML today

docs/api.md already stated 3.0 correctly, so it is unchanged.

Closes #38