### PR TITLE
docs: state the trusted-subject model, and stop the client discarding 401 bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,19 @@ design records.
 | Call `/sign`                                    | Accepted OIDC JWT or `gst_` service token |
 | Call `/admin/*`                                 | Deployment's static `ADMIN_TOKEN`         |
 
-The current OIDC implementation validates issuer, audience, time, algorithm,
-and signature, but does **not** authorize repository, organization, workflow,
-ref, environment, namespace, or project claims. An accepted signing credential
-can request signatures over arbitrary non-empty text with any accessible key.
-Read the [authentication](docs/authentication.md) and
+A verified OIDC token is not an authorized one. `ALLOWED_ISSUERS` is not a
+repository allowlist — every repository on GitHub Actions gets a token from the
+same issuer — so authorization is a separate table of trusted subjects managed
+through `/admin/subjects`. A token is refused with `Subject is not trusted for
+signing` unless its issuer and `sub` match a live row, and each row carries its
+own key allowlist, expiry, and revocation. **An empty table denies everyone**:
+a fresh deployment cannot sign over OIDC until a subject is trusted.
+
+Trust is granted per issuer, subject prefix, and key. Within that grant a
+trusted caller can request signatures over arbitrary non-empty text with any
+key its row allows; the service does not further authorize workflow, ref,
+environment, or project claims. Read the
+[authentication](docs/authentication.md) and
 [security](docs/security-model.md) guides before exposing a deployment.
 
 ## Quick start: install the CLI

--- a/client/cmd/gpg-sign/main.go
+++ b/client/cmd/gpg-sign/main.go
@@ -226,9 +226,6 @@ Example:
 
 		result, err := c.Sign(ctx, string(data), keyID)
 		if err != nil {
-			if client.IsAuthError(err) {
-				return fmt.Errorf("authentication failed: %w", err)
-			}
 			if client.IsRateLimitError(err) {
 				// The wrapper already retried, so this is a final failure
 				return fmt.Errorf("rate limit exceeded: %w", err)
@@ -303,9 +300,6 @@ var adminUploadCmd = &cobra.Command{
 
 		result, err := c.UploadKey(ctx, keyID, string(keyData))
 		if err != nil {
-			if client.IsAuthError(err) {
-				return fmt.Errorf("authentication failed: %w", err)
-			}
 			return fmt.Errorf("key upload failed: %w", err)
 		}
 
@@ -342,9 +336,6 @@ var adminListCmd = &cobra.Command{
 
 		keys, err := c.ListKeys(ctx)
 		if err != nil {
-			if client.IsAuthError(err) {
-				return fmt.Errorf("authentication failed: %w", err)
-			}
 			return fmt.Errorf("failed to list keys: %w", err)
 		}
 
@@ -391,9 +382,6 @@ var adminDeleteCmd = &cobra.Command{
 
 		err = c.DeleteKey(ctx, keyID)
 		if err != nil {
-			if client.IsAuthError(err) {
-				return fmt.Errorf("authentication failed: %w", err)
-			}
 			if client.IsKeyNotFound(err) {
 				fmt.Printf("Key '%s' was not found\n", keyID)
 				if jsonOutput {
@@ -440,9 +428,6 @@ var adminPublicKeyCmd = &cobra.Command{
 		// Use the admin-specific endpoint to ensure admin auth is exercised
 		pubKey, err := c.AdminPublicKey(ctx, keyID)
 		if err != nil {
-			if client.IsAuthError(err) {
-				return fmt.Errorf("authentication failed: %w", err)
-			}
 			if client.IsKeyNotFound(err) {
 				return fmt.Errorf("key not found")
 			}
@@ -507,9 +492,6 @@ var adminAuditCmd = &cobra.Command{
 
 		result, err := c.AuditLogs(ctx, filter)
 		if err != nil {
-			if client.IsAuthError(err) {
-				return fmt.Errorf("authentication failed: %w", err)
-			}
 			return fmt.Errorf("failed to get audit logs: %w", err)
 		}
 

--- a/client/pkg/client/README.md
+++ b/client/pkg/client/README.md
@@ -176,10 +176,19 @@ c, err := client.New(baseURL string, opts ...Option)
 
 #### Error Types
 
-- `AuthError` - Authentication failures
+- `AuthError` - Authentication failures (carries the service's `Code`,
+  `Message`, and `RequestID`)
 - `RateLimitError` - Rate limit exceeded (includes retry-after duration)
 - `ValidationError` - Invalid request data
 - `ServiceError` - API errors with codes
+
+Every non-2xx response is reported with the service's own `error` and `code`
+when the body carries them, including statuses the OpenAPI document does not
+declare. A `401` on `Sign` therefore reads
+`authentication failed: AUTH_INVALID: Subject is not trusted for signing`
+rather than a bare status number — that particular message means the credential
+verified but no trusted subject covers it. Only a response with no usable error
+body falls back to `ErrUnexpectedStatus`.
 
 #### Helper Functions
 

--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -123,7 +123,7 @@ func (c *Client) Health(ctx context.Context) (*HealthStatus, error) {
 			}
 	}
 
-	return nil, newUnexpectedStatusError(resp.StatusCode())
+	return nil, newStatusError(resp.StatusCode(), resp.Body)
 }
 
 // PublicKey retrieves the public signing key.
@@ -173,7 +173,7 @@ func (c *Client) PublicKey(ctx context.Context, keyID string) (string, error) {
 		}
 	}
 
-	return "", newUnexpectedStatusError(resp.StatusCode())
+	return "", newStatusError(resp.StatusCode(), resp.Body)
 }
 
 // Sign signs commit data and returns the signature.
@@ -203,7 +203,7 @@ func (c *Client) Sign(ctx context.Context, commitData string, keyID string) (*Si
 		return nil, mappedErr
 	}
 
-	return nil, newUnexpectedStatusError(resp.StatusCode())
+	return nil, newStatusError(resp.StatusCode(), resp.Body)
 }
 
 // UploadKey uploads a new signing key (admin operation).
@@ -257,7 +257,7 @@ func (c *Client) UploadKey(ctx context.Context, keyID string, armoredPrivateKey 
 		}
 	}
 
-	return nil, newUnexpectedStatusError(resp.StatusCode())
+	return nil, newStatusError(resp.StatusCode(), resp.Body)
 }
 
 // ListKeys lists all signing keys (admin operation).
@@ -293,7 +293,7 @@ func (c *Client) ListKeys(ctx context.Context) ([]KeyMetadata, error) {
 		}
 	}
 
-	return nil, newUnexpectedStatusError(resp.StatusCode())
+	return nil, newStatusError(resp.StatusCode(), resp.Body)
 }
 
 // DeleteKey deletes a signing key (admin operation).
@@ -331,7 +331,7 @@ func (c *Client) DeleteKey(ctx context.Context, keyID string) error {
 		}
 	}
 
-	return newUnexpectedStatusError(resp.StatusCode())
+	return newStatusError(resp.StatusCode(), resp.Body)
 }
 
 // AuditLogs queries audit logs (admin operation).
@@ -356,7 +356,7 @@ func (c *Client) AuditLogs(ctx context.Context, filter AuditFilter) (*AuditResul
 		return nil, mappedErr
 	}
 
-	return nil, newUnexpectedStatusError(resp.StatusCode())
+	return nil, newStatusError(resp.StatusCode(), resp.Body)
 }
 
 // AdminPublicKey retrieves the public key via the admin endpoint.
@@ -398,7 +398,7 @@ func (c *Client) AdminPublicKey(ctx context.Context, keyID string) (string, erro
 		}
 	}
 
-	return "", newUnexpectedStatusError(resp.StatusCode())
+	return "", newStatusError(resp.StatusCode(), resp.Body)
 }
 
 func mapAuditResponseError(resp *api.GetAdminAuditResponse) error {

--- a/client/pkg/client/consts_test.go
+++ b/client/pkg/client/consts_test.go
@@ -40,6 +40,7 @@ const (
 	testMsgTest        = "test"
 	testMsgRateLimited = "rate limit exceeded"
 	testMsgServerError = "server error"
+	testMsgExpired     = "token expired"
 
 	// Table-driven test case names and operations.
 	testOpSign           = "Sign"

--- a/client/pkg/client/errors.go
+++ b/client/pkg/client/errors.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 )
 
@@ -39,10 +41,20 @@ func (e *ServiceError) Error() string {
 type AuthError struct {
 	Code    string
 	Message string
+	// RequestID is the server's request identifier when the response carried
+	// one. Empty for locally constructed errors.
+	RequestID string
 }
 
 func (e *AuthError) Error() string {
-	return fmt.Sprintf("authentication failed: %s", e.Message)
+	msg := e.Message
+	if e.Code != "" {
+		msg = e.Code + ": " + msg
+	}
+	if e.RequestID != "" {
+		return fmt.Sprintf("authentication failed: %s (request %s)", msg, e.RequestID)
+	}
+	return fmt.Sprintf("authentication failed: %s", msg)
 }
 
 // RateLimitError represents the rate limit having been exceeded.
@@ -108,4 +120,60 @@ func IsServiceError(err error) bool {
 
 func newUnexpectedStatusError(code int) error {
 	return fmt.Errorf("%w: %d", ErrUnexpectedStatus, code)
+}
+
+// apiErrorBody is the service's error envelope. The generated client only
+// exposes typed fields for statuses the OpenAPI document declares per
+// operation, so a response the document omits — a 401 on /sign above all —
+// arrives with its body intact but no field to read it from.
+type apiErrorBody struct {
+	Error     string `json:"error"`
+	Code      string `json:"code"`
+	RequestID string `json:"requestId"`
+}
+
+// newStatusError builds the richest error the response supports.
+//
+// The service answers every refusal with a precise message — `AUTH_MISSING`,
+// `Issuer not allowed: <iss>`, `Subject is not trusted for signing` — and
+// collapsing that to "unexpected status code: 401" throws away the one thing
+// that tells an operator which of those it hit. A CI-only OIDC token cannot be
+// replayed from a laptop to recover it, so the body is read here or not at all.
+//
+// Falls back to the bare sentinel when the body is not a usable error envelope,
+// which keeps text responses and empty bodies behaving as before.
+func newStatusError(statusCode int, body []byte) error {
+	parsed, ok := parseAPIErrorBody(body)
+	if !ok {
+		return newUnexpectedStatusError(statusCode)
+	}
+
+	if statusCode == http.StatusUnauthorized {
+		return &AuthError{
+			Code:      parsed.Code,
+			Message:   parsed.Error,
+			RequestID: parsed.RequestID,
+		}
+	}
+
+	return &ServiceError{
+		Code:       parsed.Code,
+		Message:    parsed.Error,
+		StatusCode: statusCode,
+		RequestID:  parsed.RequestID,
+	}
+}
+
+// parseAPIErrorBody reports whether body is an error envelope carrying a
+// message. A body without `error` says nothing the status code did not, so it
+// is treated as unparseable rather than surfaced as an empty message.
+func parseAPIErrorBody(body []byte) (apiErrorBody, bool) {
+	var parsed apiErrorBody
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return apiErrorBody{}, false
+	}
+	if parsed.Error == "" {
+		return apiErrorBody{}, false
+	}
+	return parsed, true
 }

--- a/client/pkg/client/errors_test.go
+++ b/client/pkg/client/errors_test.go
@@ -67,27 +67,42 @@ func TestAuthError(t *testing.T) {
 		name      string
 		code      string
 		message   string
+		requestID string
 		wantError string
 	}{
 		{
 			name:      "auth error with message",
 			code:      "INVALID_TOKEN",
-			message:   "token expired",
-			wantError: "authentication failed: token expired",
+			message:   testMsgExpired,
+			wantError: "authentication failed: INVALID_TOKEN: " + testMsgExpired,
 		},
 		{
 			name:      "auth error empty message",
 			code:      "NO_CREDENTIALS",
 			message:   "",
-			wantError: "authentication failed: ",
+			wantError: "authentication failed: NO_CREDENTIALS: ",
+		},
+		{
+			name:      "auth error without a code",
+			message:   testMsgExpired,
+			wantError: "authentication failed: " + testMsgExpired,
+		},
+		{
+			name:      "auth error with request id",
+			code:      "AUTH_INVALID",
+			message:   "Subject is not trusted for signing",
+			requestID: testRequestID,
+			wantError: "authentication failed: AUTH_INVALID: Subject is not trusted for signing " +
+				"(request " + testRequestID + ")",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := &AuthError{
-				Code:    tt.code,
-				Message: tt.message,
+				Code:      tt.code,
+				Message:   tt.message,
+				RequestID: tt.requestID,
 			}
 
 			errStr := err.Error()
@@ -236,7 +251,7 @@ func TestIsAuthError(t *testing.T) {
 			name: "auth error",
 			err: &AuthError{
 				Code:    "INVALID_TOKEN",
-				Message: "token expired",
+				Message: testMsgExpired,
 			},
 			match: true,
 		},

--- a/client/pkg/client/sign_test.go
+++ b/client/pkg/client/sign_test.go
@@ -458,3 +458,91 @@ func TestSignKeyNotAllowed(t *testing.T) {
 		t.Errorf("request id was discarded: %q", se.RequestID)
 	}
 }
+
+// TestSignUntrustedSubject checks that a 401 reaches the caller with the
+// service's own message. The OpenAPI document declares no 401 for /sign, so the
+// generated client has no typed field for it and the response would otherwise
+// collapse to "unexpected status code: 401" — the exact failure an operator
+// cannot debug, because a CI-only OIDC token cannot be replayed from a laptop
+// to read the body by hand.
+func TestSignUntrustedSubject(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprint(w, `{"error":"Subject is not trusted for signing",`+
+			`"code":"AUTH_INVALID","requestId":"1b4e28ba-2fa1-11d2-883f-0016d3cca427"}`)
+	}))
+	defer server.Close()
+
+	c, _ := New(server.URL)
+	_, err := c.Sign(context.Background(), "commit data", "")
+	if err == nil {
+		t.Fatal("expected an error for a 401 response")
+	}
+	if !IsAuthError(err) {
+		t.Errorf("expected IsAuthError, got %v", err)
+	}
+	if errors.Is(err, ErrUnexpectedStatus) {
+		t.Error("a 401 carrying an error body must not report as an unexpected status")
+	}
+
+	var ae *AuthError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected an *AuthError, got %T", err)
+	}
+	if ae.Message != "Subject is not trusted for signing" {
+		t.Errorf("server message was discarded: %q", ae.Message)
+	}
+	if ae.Code != "AUTH_INVALID" {
+		t.Errorf("error code was discarded: %q", ae.Code)
+	}
+	if ae.RequestID != "1b4e28ba-2fa1-11d2-883f-0016d3cca427" {
+		t.Errorf("request id was discarded: %q", ae.RequestID)
+	}
+	if !strings.Contains(err.Error(), "Subject is not trusted for signing") {
+		t.Errorf("message missing from rendered error: %q", err.Error())
+	}
+}
+
+// TestSignAuthErrorWithoutBody keeps the fallback honest: a 401 with nothing to
+// read still has to produce an error, and the sentinel is all that is left.
+func TestSignAuthErrorWithoutBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	c, _ := New(server.URL)
+	_, err := c.Sign(context.Background(), "commit data", "")
+	if !errors.Is(err, ErrUnexpectedStatus) {
+		t.Fatalf("expected the unexpected-status sentinel, got %v", err)
+	}
+	if IsAuthError(err) {
+		t.Error("an empty body carries no auth detail to report")
+	}
+}
+
+// TestSignUndocumentedStatusWithBody covers the non-401 half of the same gap: a
+// status the document does not declare still carries a usable envelope.
+func TestSignUndocumentedStatusWithBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = fmt.Fprint(w, `{"error":"brewing refused","code":"INTERNAL_ERROR"}`)
+	}))
+	defer server.Close()
+
+	c, _ := New(server.URL)
+	_, err := c.Sign(context.Background(), "commit data", "")
+
+	var se *ServiceError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected a *ServiceError, got %T (%v)", err, err)
+	}
+	if se.StatusCode != http.StatusTeapot {
+		t.Errorf("expected status 418, got %d", se.StatusCode)
+	}
+	if se.Message != "brewing refused" {
+		t.Errorf("server message was discarded: %q", se.Message)
+	}
+}

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -75,6 +75,26 @@ entry in `ALLOWED_ISSUERS` might.
 Omit `keyIds` to allow every key. Omit `expiresInDays` for a trust that does
 not expire.
 
+### Immutable subject claims change `sub` under a live row
+
+A GitHub repository that enables immutable subject claims stops issuing
+`repo:owner/name:…` and starts issuing `repo:owner@<owner_id>/name@<repo_id>:…`.
+Nothing about the deployment changes, and nothing warns: an exact-repository row
+written for the old shape simply stops matching, and signing fails with a bare
+`401` and `Subject is not trusted for signing` at whatever later date the
+setting is flipped.
+
+The failure is closed — no trust widens — but it arrives detached from its
+cause. Two ways to survive it:
+
+- prefer an owner-wide `repo:owner` prefix, whose boundary falls on either `/`
+  or `@`, so it matches both shapes; or
+- when the setting is toggled deliberately, add the new-shape row before
+  flipping it, and revoke the old one after.
+
+`GET /admin/subjects` lists the prefixes as written, so comparing a failing
+run's `sub` against that list identifies this immediately.
+
 ### Revoke is not subtraction
 
 Resolution takes the longest **live** prefix. Revoking a narrow row therefore

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -13,6 +13,13 @@ The examples below stop after requesting `commit.sig`.
 
 ## GitHub Actions with OIDC
 
+> [!IMPORTANT]
+> This example returns `401` until the deployment trusts the calling
+> repository. OIDC authorization is a table of trusted subjects: register the
+> repository's issuer and subject prefix through `/admin/subjects` first — see
+> [trusted OIDC subjects](authentication.md#trusted-oidc-subjects). An empty
+> table denies everyone.
+
 ```yaml
 name: Request commit signature
 
@@ -57,7 +64,9 @@ jobs:
 ```
 
 The workflow needs `id-token: write` only for OIDC. Add `contents: write` only
-if a later step intentionally updates repository refs.
+if a later step intentionally updates repository refs. A `401` here is almost
+always the missing subject row rather than a token fault; the error `gpg-sign`
+prints carries the service's own message.
 
 ## GitHub Actions with a service token
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -35,8 +35,13 @@ installer action.
 
 ### `401` with GitHub Actions
 
-Check all of:
+The likely cause on a first call is authorization, not authentication: a
+verified token still needs a trusted subject. Check all of:
 
+- the calling repository's `sub` matches a live row in `GET /admin/subjects` —
+  a body of `Subject is not trusted for signing` means the credential verified
+  and nothing trusts it, and an empty table denies everyone (see
+  [trusted OIDC subjects](authentication.md#trusted-oidc-subjects));
 - the job grants `id-token: write`;
 - the token was requested with audience `gpg-signing-service`, or the configured
   `EXPECTED_AUDIENCE`;
@@ -45,13 +50,21 @@ Check all of:
 - the token has not expired; and
 - discovery and JWKS endpoints are reachable.
 
+The response body separates these: `AUTH_MISSING` is an absent header,
+`Issuer not allowed: <iss>` an unlisted issuer, `Subject is not trusted for
+signing` an unregistered caller, and any other `AUTH_INVALID` a verification
+failure. `gpg-sign` prints that body, so read it before working down the list.
+
 Use `core.getIDToken("gpg-signing-service")`. Raw endpoint responses store the
 JWT in `.value`, not `.token`.
 
 ### `401` with GitLab
 
-Declare `id_tokens` and set `aud` to the configured expected audience. Legacy
-`CI_JOB_JWT` examples do not establish that audience.
+Check the project's `sub` matches a live row in `GET /admin/subjects` first;
+`Subject is not trusted for signing` is a verified token that nothing trusts.
+
+Then declare `id_tokens` and set `aud` to the configured expected audience.
+Legacy `CI_JOB_JWT` examples do not establish that audience.
 
 ### Invalid `gst_` token
 


### PR DESCRIPTION
Closes #54.

Four places told a new caller something the service does not do, and the fifth threw away the message that would have corrected them.

### `README.md`

The access summary claimed the OIDC implementation "does **not** authorize repository, organization, workflow, ref, environment, namespace, or project claims" and that "an accepted signing credential can request signatures over arbitrary non-empty text with any accessible key". That is the opposite of the trusted-subject table: it understates the posture and, worse, sends anyone debugging a `401` toward issuer and audience faults. Replaced with the trusted-subject model, keeping the genuine caveat — within its row's key allowlist a trusted subject may sign arbitrary bytes, and nothing narrows that by workflow or ref.

### `docs/troubleshooting.md`

Both `401` checklists were entirely authentication-layer. The one condition guaranteed true for a repository calling a deployment for the first time — no matching row in the subject table — was absent from both. Each now leads with it, quoting `Subject is not trusted for signing` verbatim so it is greppable, plus a paragraph naming which body distinguishes an absent header from an unlisted issuer from an untrusted subject.

### `docs/integrations.md`

An `[!IMPORTANT]` prerequisite above the copy-pasteable OIDC example, linking `authentication.md#trusted-oidc-subjects`, and a sentence after it saying a `401` there is almost always the missing row.

### `docs/authentication.md`

Immutable subject claims promoted from an aside in the prefix tip to its own section. Toggling that setting rewrites `sub` and silently invalidates an exact-repository row; the resulting `401` lands at an arbitrary later date, detached from the change that caused it.

### `client/`

The OpenAPI document declares no `401` for any operation, so the generated client has no `JSON401` field and every `401` fell through to `unexpected status code: 401` — discarding a body the service had already filled in, in the one situation where it cannot be recovered by hand (a GitHub OIDC token only exists inside a workflow run).

The fallback at all eight call sites now parses the error envelope: a `401` becomes an `AuthError` carrying code, message and request id; any other unmapped status becomes a `ServiceError`. Admin endpoints benefit equally, their `401`s being just as undeclared. A response with no usable envelope still returns `ErrUnexpectedStatus`, so text and empty bodies are unchanged.

`AuthError.Error` now renders the code and request id when present, and the CLI's redundant `authentication failed:` re-wrap is removed — `AuthError` already opens with that phrase, so it doubled in front of the message the user needs. The output becomes:

```
Error: signing failed: authentication failed: AUTH_INVALID: Subject is not trusted for signing
```

### Not done

Adding `401` to the OpenAPI document (and regenerating `client/pkg/api`) would fix this at the root rather than at the fallback. Left out to keep the diff reviewable — say the word and it can follow.

### Verification

`task lint`, `task typecheck`, `task t`, `task c:l`, `task c:tc` all pass. Three new tests in `client/pkg/client/sign_test.go` cover a `401` with a body, a `401` without one, and an undeclared status carrying an envelope.

Generated with [Claude Code](https://claude.ai/code)