### PR TITLE
fix(client): let the retrier see the statuses it claims to retry

### DIFF
--- a/client/cmd/gpg-sign/main.go
+++ b/client/cmd/gpg-sign/main.go
@@ -253,7 +253,9 @@ Example:
 		result, err := c.Sign(ctx, string(data), keyID)
 		if err != nil {
 			if client.IsRateLimitError(err) {
-				// The wrapper already retried, so this is a final failure
+				// The retries are already spent by the time this returns, so the
+				// limit is a standing one and not a burst worth re-running the
+				// command over. The wrapped error carries how long to wait.
 				return fmt.Errorf("rate limit exceeded: %w", err)
 			}
 			return fmt.Errorf("signing failed: %w", err)

--- a/client/pkg/client/MIGRATION.md
+++ b/client/pkg/client/MIGRATION.md
@@ -142,7 +142,7 @@ if resp.JSON401 != nil {
 }
 
 if resp.JSON429 != nil {
-    return fmt.Errorf("rate limited, retry after %d seconds", *resp.JSON429.RetryAfter)
+    return fmt.Errorf("rate limited, retry after %d seconds", resp.JSON429.RetryAfter)
 }
 
 if resp.StatusCode() != 200 {

--- a/client/pkg/client/README.md
+++ b/client/pkg/client/README.md
@@ -322,8 +322,14 @@ describes something only the caller can change, so re-sending either spends the
 timeout budget to arrive at the same answer. A cancelled or expired context is
 not retried either: the next attempt fails the same way, immediately.
 
-Three things worth knowing:
+Four things worth knowing:
 
+- `WithTimeout` bounds one attempt, not the operation. `http.Client` applies its
+  timeout per request, so every attempt is handed a fresh one, and a server that
+  answers _promptly_ with a retryable status never trips it — `WithTimeout(30s)`
+  under the default policy is four attempts of up to 30s plus roughly 15s of
+  backoff. Pass a context with a deadline when you need one budget for the whole
+  call; the retrier checks it before every wait.
 - `Health` never retries a status. Its `503` is `degraded`, a documented answer
   carrying a body you are meant to read, and a probe wants the current state
   rather than an eventually healthy one. Transport faults still retry there.

--- a/client/pkg/client/README.md
+++ b/client/pkg/client/README.md
@@ -97,11 +97,7 @@ if resp.JSON401 != nil {
 }
 
 if resp.JSON429 != nil {
-    retryAfter := 0
-    if resp.JSON429.RetryAfter != nil {
-        retryAfter = *resp.JSON429.RetryAfter
-    }
-    return fmt.Errorf("rate limited, retry after %d", retryAfter)
+    return fmt.Errorf("rate limited, retry after %d", resp.JSON429.RetryAfter)
 }
 
 if resp.JSON400 != nil {
@@ -179,7 +175,8 @@ c, err := client.New(baseURL string, opts ...Option)
 - `AuthError` - Authentication failures (carries the service's `Code`,
   `Message`, and `RequestID`)
 - `RateLimitError` - Rate limit exceeded (carries the retry-after duration, read
-  from the body's `retryAfter` or the `Retry-After` header)
+  from the body's `retryAfter` or the `Retry-After` header, in either the
+  delay-seconds or the HTTP-date form)
 - `ValidationError` - Invalid request data
 - `ServiceError` - API errors with codes
 
@@ -281,14 +278,18 @@ fmt.Printf("Found %d audit entries\n", logs.Count)
 
 The client automatically retries:
 
-- Rate limit errors (respects `Retry-After` header)
-- Service errors (5xx status codes)
+- Rate limits (`429`)
+- Transient service errors (`500`, `502`, `503`, `504`)
+- Transport faults — a refused dial, a connection dropped mid-body
 
 It never retries:
 
 - Authentication errors (401)
 - Validation errors (400)
 - Not found errors (404)
+- `501` and `505`, which describe what the server will never do
+- A cancelled or expired context
+- A response that arrived and failed to decode — the bytes are already in hand
 
 Retry strategy:
 
@@ -314,20 +315,31 @@ c, _ := client.New(baseURL,
 
 ### What is retried
 
-A `429`, and a `500`, `502`, `503` or `504` — a transport fault or a state the
-server may be out of by the next attempt. Nothing else. A `501` or a `505`
-describes what the server will never do, and every 4xx below `429` describes
-something only the caller can change, so re-sending either spends the timeout
-budget to arrive at the same answer.
+A `429`, a `500`, `502`, `503` or `504`, and a transport fault — a state the
+server or the network may be out of by the next attempt. Nothing else. A `501`
+or a `505` describes what the server will never do, and every 4xx below `429`
+describes something only the caller can change, so re-sending either spends the
+timeout budget to arrive at the same answer. A cancelled or expired context is
+not retried either: the next attempt fails the same way, immediately.
 
-Two exceptions worth knowing:
+Three things worth knowing:
 
 - `Health` never retries a status. Its `503` is `degraded`, a documented answer
   carrying a body you are meant to read, and a probe wants the current state
-  rather than an eventually-healthy one.
+  rather than an eventually healthy one. Transport faults still retry there.
 - The wait between attempts is the exponential backoff, not the server's
-  `Retry-After`. The hint is not discarded — it reaches you on the
+  `Retry-After`. The hint is not reachable from the generic response type the
+  retry policy sees — but it is not discarded either: it reaches you on the
   `RateLimitError` returned once the attempts are spent.
+- `Sign` and `UploadKey` are retried like everything else. Neither carries an
+  idempotency key, so a retried attempt is a second request the service will
+  act on: `Sign` produces another signature and another `sign` audit row,
+  `UploadKey` rewrites `key:<keyId>` with the same bytes and appends another
+  `key_upload` row. Both converge on the same state — a signature is a pure
+  function of the request, and an overwrite with identical content is a no-op —
+  so what a retry duplicates is the audit trail, which is a record of attempts
+  and is meant to show them. If your deployment needs at-most-once semantics
+  instead, run those calls with `WithMaxRetries(0)` and decide for yourself.
 
 Retries are exhausted before an operation returns, so an error you receive is
 final under the configured policy.

--- a/client/pkg/client/README.md
+++ b/client/pkg/client/README.md
@@ -178,7 +178,8 @@ c, err := client.New(baseURL string, opts ...Option)
 
 - `AuthError` - Authentication failures (carries the service's `Code`,
   `Message`, and `RequestID`)
-- `RateLimitError` - Rate limit exceeded (includes retry-after duration)
+- `RateLimitError` - Rate limit exceeded (carries the retry-after duration, read
+  from the body's `retryAfter` or the `Retry-After` header)
 - `ValidationError` - Invalid request data
 - `ServiceError` - API errors with codes
 
@@ -310,6 +311,26 @@ c, _ := client.New(baseURL,
     client.WithoutRateLimitRetry(), // Fail fast on rate limits
 )
 ```
+
+### What is retried
+
+A `429`, and a `500`, `502`, `503` or `504` — a transport fault or a state the
+server may be out of by the next attempt. Nothing else. A `501` or a `505`
+describes what the server will never do, and every 4xx below `429` describes
+something only the caller can change, so re-sending either spends the timeout
+budget to arrive at the same answer.
+
+Two exceptions worth knowing:
+
+- `Health` never retries a status. Its `503` is `degraded`, a documented answer
+  carrying a body you are meant to read, and a probe wants the current state
+  rather than an eventually-healthy one.
+- The wait between attempts is the exponential backoff, not the server's
+  `Retry-After`. The hint is not discarded — it reaches you on the
+  `RateLimitError` returned once the attempts are spent.
+
+Retries are exhausted before an operation returns, so an error you receive is
+final under the configured policy.
 
 ## Rate Limit Information
 

--- a/client/pkg/client/README.md
+++ b/client/pkg/client/README.md
@@ -176,7 +176,8 @@ c, err := client.New(baseURL string, opts ...Option)
   `Message`, and `RequestID`)
 - `RateLimitError` - Rate limit exceeded (carries the retry-after duration, read
   from the body's `retryAfter` or the `Retry-After` header, in either the
-  delay-seconds or the HTTP-date form)
+  delay-seconds or the HTTP-date form, and the `RequestID` — which on a 429 is
+  the echoed `X-Request-ID` header, since no 429 body declares one)
 - `ValidationError` - Invalid request data
 - `ServiceError` - API errors with codes
 
@@ -293,7 +294,8 @@ It never retries:
 
 Retry strategy:
 
-- Exponential backoff with jitter
+- The server's `Retry-After` when a `429` carries one, clamped to the configured
+  maximum; exponential backoff with jitter otherwise
 - Default: 3 retries, 1s-30s backoff range
 - Respects context cancellation
 
@@ -333,10 +335,23 @@ Four things worth knowing:
 - `Health` never retries a status. Its `503` is `degraded`, a documented answer
   carrying a body you are meant to read, and a probe wants the current state
   rather than an eventually healthy one. Transport faults still retry there.
-- The wait between attempts is the exponential backoff, not the server's
-  `Retry-After`. The hint is not reachable from the generic response type the
-  retry policy sees — but it is not discarded either: it reaches you on the
+- The wait between attempts is the server's `Retry-After` when a `429` carries
+  one — read from the body's `retryAfter` or the header, in either RFC 9110
+  form — and the exponential backoff otherwise. A hint longer than
+  `WithRetryWait`'s maximum is clamped to it, so a misconfigured responder
+  cannot park the call; the untruncated value still reaches you on the
   `RateLimitError` returned once the attempts are spent.
+- A caller-side deadline that expires while the policy is still waiting costs
+  you the retry, not the answer. The response that caused the wait is returned
+  and mapped as usual, so `IsRateLimitError` still holds for a throttled call
+  whose `context` ran out. A context you _cancel_ is reported as cancelled, and
+  so is a deadline that expires before any attempt completes.
+- `DeleteKey`'s `deleted` field describes the attempt that answered, not the
+  call. A delete that commits and then loses its response is answered
+  `deleted:false` by the next attempt, so once a retry has happened this client
+  reports success rather than `KEY_NOT_FOUND` — the postcondition holds either
+  way, and the alternative is telling you nothing happened for work that did.
+  A `deleted:false` on the _first_ attempt is still a not-found.
 - `Sign` and `UploadKey` are retried like everything else. Neither carries an
   idempotency key, so a retried attempt is a second request the service will
   act on: `Sign` produces another signature and another `sign` audit row,
@@ -344,8 +359,12 @@ Four things worth knowing:
   `key_upload` row. Both converge on the same state — a signature is a pure
   function of the request, and an overwrite with identical content is a no-op —
   so what a retry duplicates is the audit trail, which is a record of attempts
-  and is meant to show them. If your deployment needs at-most-once semantics
-  instead, run those calls with `WithMaxRetries(0)` and decide for yourself.
+  and is meant to show them. A retried `500` on `/sign` does spend one
+  rate-limit token per attempt — the limiter is consulted before the work, so
+  unlike a retried `429`, which `consumeToken` answers without decrementing,
+  the extra attempts draw down the caller's budget. If your deployment needs
+  at-most-once semantics instead, run those calls with `WithMaxRetries(0)` and
+  decide for yourself.
 
 Retries are exhausted before an operation returns, so an error you receive is
 final under the configured policy.

--- a/client/pkg/client/additional_coverage_test.go
+++ b/client/pkg/client/additional_coverage_test.go
@@ -22,7 +22,7 @@ func TestSignMethodAllPaths(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, _ := New(server.URL)
+		client := newMappingClient(t, server.URL)
 		_, err := client.Sign(context.Background(), "data", "")
 		if err == nil {
 			t.Error("expected validation error")
@@ -40,7 +40,7 @@ func TestSignMethodAllPaths(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, _ := New(server.URL)
+		client := newMappingClient(t, server.URL)
 		_, err := client.Sign(context.Background(), "data", "")
 		if err == nil {
 			t.Error("expected validation error")
@@ -59,7 +59,7 @@ func TestSignMethodAllPaths(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, _ := New(server.URL)
+		client := newMappingClient(t, server.URL)
 		_, err := client.Sign(context.Background(), "data", "")
 		if err == nil {
 			t.Error("expected service error")
@@ -80,7 +80,7 @@ func TestSignMethodAllPaths(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, _ := New(server.URL)
+		client := newMappingClient(t, server.URL)
 		_, err := client.Sign(context.Background(), "data", "")
 		if err == nil {
 			t.Error("expected service error")
@@ -104,7 +104,7 @@ func TestUploadKeyAllPaths(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, _ := New(server.URL, WithAdminToken(testMsgTest))
+		client := newMappingClient(t, server.URL, WithAdminToken(testMsgTest))
 		_, err := client.UploadKey(context.Background(), "id", "key")
 		// Should get unexpected status error since 200 is not expected
 		if err == nil {
@@ -122,7 +122,7 @@ func TestUploadKeyAllPaths(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, _ := New(server.URL, WithAdminToken(testMsgTest))
+		client := newMappingClient(t, server.URL, WithAdminToken(testMsgTest))
 		_, err := client.UploadKey(context.Background(), "id", "key")
 		if err == nil {
 			t.Error("expected validation error")
@@ -135,7 +135,7 @@ func TestUploadKeyAllPaths(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, _ := New(server.URL, WithAdminToken(testMsgTest))
+		client := newMappingClient(t, server.URL, WithAdminToken(testMsgTest))
 		_, err := client.UploadKey(context.Background(), "id", "key")
 		if err == nil {
 			t.Error("expected service error")
@@ -156,7 +156,7 @@ func TestAuditLogsAllPaths(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, _ := New(server.URL, WithAdminToken(testMsgTest))
+		client := newMappingClient(t, server.URL, WithAdminToken(testMsgTest))
 		_, err := client.AuditLogs(context.Background(), AuditFilter{})
 		if err == nil {
 			t.Error("expected unexpected status error for 206")
@@ -173,7 +173,7 @@ func TestAuditLogsAllPaths(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, _ := New(server.URL, WithAdminToken(testMsgTest))
+		client := newMappingClient(t, server.URL, WithAdminToken(testMsgTest))
 		_, err := client.AuditLogs(context.Background(), AuditFilter{})
 		if err == nil {
 			t.Error("expected validation error")
@@ -186,7 +186,7 @@ func TestAuditLogsAllPaths(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, _ := New(server.URL, WithAdminToken(testMsgTest))
+		client := newMappingClient(t, server.URL, WithAdminToken(testMsgTest))
 		_, err := client.AuditLogs(context.Background(), AuditFilter{})
 		if err == nil {
 			t.Error("expected service error")

--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -148,7 +148,7 @@ func (c *Client) PublicKey(ctx context.Context, keyID string) (string, error) {
 		keyIDPtr = &keyID
 	}
 
-	resp, err := executeWithRetry(ctx, c.retrier, func() (*api.GetPublicKeyResponse, error) {
+	resp, err := executeWithRetry(ctx, c.retrier, func(ctx context.Context) (*api.GetPublicKeyResponse, error) {
 		return c.raw.GetPublicKeyWithResponse(ctx, &api.GetPublicKeyParams{
 			KeyId: keyIDPtr,
 		})
@@ -196,7 +196,10 @@ func (c *Client) Sign(ctx context.Context, commitData string, keyID string) (*Si
 
 	params := buildSignParams(keyID)
 
-	resp, err := executeWithRetry(ctx, c.retrier, func() (*api.PostSignResponse, error) {
+	resp, err := executeWithRetry(ctx, c.retrier, func(ctx context.Context) (*api.PostSignResponse, error) {
+		// The reader is built per attempt on purpose: one hoisted out of the
+		// closure is drained by the first request and every retry after it
+		// POSTs an empty body.
 		return c.raw.PostSignWithBodyWithResponse(ctx, params, "text/plain", strings.NewReader(commitData))
 	})
 	if err != nil {
@@ -234,7 +237,7 @@ func (c *Client) UploadKey(ctx context.Context, keyID string, armoredPrivateKey 
 		KeyId:             keyID,
 	}
 
-	resp, err := executeWithRetry(ctx, c.retrier, func() (*api.PostAdminKeysResponse, error) {
+	resp, err := executeWithRetry(ctx, c.retrier, func(ctx context.Context) (*api.PostAdminKeysResponse, error) {
 		return c.raw.PostAdminKeysWithResponse(ctx, body)
 	})
 	if err != nil {
@@ -271,7 +274,7 @@ func (c *Client) UploadKey(ctx context.Context, keyID string, armoredPrivateKey 
 
 // ListKeys lists all signing keys (admin operation).
 func (c *Client) ListKeys(ctx context.Context) ([]KeyMetadata, error) {
-	resp, err := executeWithRetry(ctx, c.retrier, func() (*api.GetAdminKeysResponse, error) {
+	resp, err := executeWithRetry(ctx, c.retrier, func(ctx context.Context) (*api.GetAdminKeysResponse, error) {
 		return c.raw.GetAdminKeysWithResponse(ctx)
 	})
 	if err != nil {
@@ -311,8 +314,13 @@ func (c *Client) ListKeys(ctx context.Context) ([]KeyMetadata, error) {
 // Returns KEY_NOT_FOUND error (with StatusCode 200) when the API indicates
 // the key was not deleted (deleted=false), typically meaning the key doesn't exist.
 // Callers should use IsKeyNotFound() to detect this case.
+//
+// That report is only trustworthy on the first attempt. `deleted` describes
+// the attempt that answered, not the call — see the attempts check below.
 func (c *Client) DeleteKey(ctx context.Context, keyID string) error {
-	resp, err := executeWithRetry(ctx, c.retrier, func() (*api.DeleteAdminKeysKeyIdResponse, error) {
+	attempts := 0
+	resp, err := executeWithRetry(ctx, c.retrier, func(ctx context.Context) (*api.DeleteAdminKeysKeyIdResponse, error) {
+		attempts++
 		return c.raw.DeleteAdminKeysKeyIdWithResponse(ctx, keyID)
 	})
 	if err != nil {
@@ -320,7 +328,21 @@ func (c *Client) DeleteKey(ctx context.Context, keyID string) error {
 	}
 
 	if resp.JSON200 != nil {
-		if resp.JSON200.Deleted {
+		// Sign and UploadKey converge under a retry because their state does;
+		// this one's state converges but its *answer* does not. The handler
+		// reports whether the key was there when this attempt ran, so a delete
+		// that committed and then lost its response — a 500 raised by the audit
+		// write that follows it, a connection dropped mid-body — is answered
+		// `deleted:false` by the next attempt, and mapped to KEY_NOT_FOUND for
+		// a key this call removed a moment earlier. The CLI prints
+		// {"deleted":false} and exits 0 for work it did do.
+		//
+		// Once an attempt has already run, "it was not there" and "I removed it
+		// a moment ago" are the same response and the postcondition holds
+		// either way, so the call succeeds. Nothing changes before a retry: the
+		// first attempt's `deleted:false` is still a not-found, which is the
+		// only reading a single round trip supports.
+		if resp.JSON200.Deleted || attempts > 1 {
 			return nil
 		}
 		return &ServiceError{
@@ -349,7 +371,7 @@ func (c *Client) DeleteKey(ctx context.Context, keyID string) error {
 func (c *Client) AuditLogs(ctx context.Context, filter AuditFilter) (*AuditResult, error) {
 	params := buildAuditParams(filter)
 
-	resp, err := executeWithRetry(ctx, c.retrier, func() (*api.GetAdminAuditResponse, error) {
+	resp, err := executeWithRetry(ctx, c.retrier, func(ctx context.Context) (*api.GetAdminAuditResponse, error) {
 		return c.raw.GetAdminAuditWithResponse(ctx, params)
 	})
 	if err != nil {
@@ -376,7 +398,7 @@ func (c *Client) AdminPublicKey(ctx context.Context, keyID string) (string, erro
 		}
 	}
 
-	resp, err := executeWithRetry(ctx, c.retrier, func() (*api.GetAdminKeysKeyIdPublicResponse, error) {
+	resp, err := executeWithRetry(ctx, c.retrier, func(ctx context.Context) (*api.GetAdminKeysKeyIdPublicResponse, error) {
 		return c.raw.GetAdminKeysKeyIdPublicWithResponse(ctx, keyID)
 	})
 	if err != nil {
@@ -565,7 +587,9 @@ func mapSignResponseError(resp *api.PostSignResponse) error {
 		// JSON, which is the only responder that reaches here without the
 		// service's envelope — printed as a bare "rate limited: " and dropped the
 		// Retry-After header sitting beside it.
-		return newRateLimitError(resp.JSON429.Error, resp.JSON429.RetryAfter, resp.HTTPResponse.Header)
+		// No envelope id to prefer: RateLimitErrorSchema declares no
+		// `requestId`, so the echoed header is the only source there is.
+		return newRateLimitError(resp.JSON429.Error, resp.JSON429.RetryAfter, "", resp.HTTPResponse.Header)
 	case resp.JSON500 != nil || resp.JSON503 != nil:
 		return mapServerError(resp)
 	default:

--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -559,10 +559,13 @@ func mapSignResponseError(resp *api.PostSignResponse) error {
 			StatusCode: 404,
 		}
 	case resp.JSON429 != nil:
-		return &RateLimitError{
-			Message:    resp.JSON429.Error,
-			RetryAfter: retryAfterSeconds(resp.JSON429.RetryAfter),
-		}
+		// Through the shared constructor rather than inline: this is the declared
+		// path, and it had neither fallback the undeclared one grew. A 429 that
+		// decodes into the typed body without filling it — an edge throttle's own
+		// JSON, which is the only responder that reaches here without the
+		// service's envelope — printed as a bare "rate limited: " and dropped the
+		// Retry-After header sitting beside it.
+		return newRateLimitError(resp.JSON429.Error, resp.JSON429.RetryAfter, resp.HTTPResponse.Header)
 	case resp.JSON500 != nil || resp.JSON503 != nil:
 		return mapServerError(resp)
 	default:

--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -96,7 +96,8 @@ func (c *Client) Health(ctx context.Context) (*HealthStatus, error) {
 	// an answer rather than a failure. `degraded` is a documented state carrying
 	// a body the caller is meant to read, and re-asking three times with backoff
 	// would delay that report to learn nothing — a probe wants the current
-	// status, not an eventually-healthy one. Transport faults still retry.
+	// status, not an eventually healthy one. Transport faults still retry: a
+	// dial that never connected is not an answer about anything.
 	var resp *api.GetHealthResponse
 	err := c.retrier.Do(ctx, func() error {
 		var execErr error

--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -92,6 +92,11 @@ func New(baseURL string, opts ...Option) (*Client, error) {
 // allowing callers to inspect partial health data while being informed of degradation.
 // Callers should check both return values when handling degraded states.
 func (c *Client) Health(ctx context.Context) (*HealthStatus, error) {
+	// Deliberately not executeWithRetry: this is the one operation whose 503 is
+	// an answer rather than a failure. `degraded` is a documented state carrying
+	// a body the caller is meant to read, and re-asking three times with backoff
+	// would delay that report to learn nothing — a probe wants the current
+	// status, not an eventually-healthy one. Transport faults still retry.
 	var resp *api.GetHealthResponse
 	err := c.retrier.Do(ctx, func() error {
 		var execErr error
@@ -113,17 +118,22 @@ func (c *Client) Health(ctx context.Context) (*HealthStatus, error) {
 	}
 
 	if resp.JSON503 != nil {
-		return &HealthStatus{
-				Status:     string(resp.JSON503.Status),
-				Version:    resp.JSON503.Version,
-				Timestamp:  resp.JSON503.Timestamp,
-				KeyStorage: resp.JSON503.Checks.KeyStorage,
-				Database:   resp.JSON503.Checks.Database,
-			}, &ServiceError{
-				Code:       ErrCodeDegraded,
-				Message:    "service degraded",
-				StatusCode: 503,
-			}
+		// Bound to a name rather than returned inline: goimports and gofumpt
+		// indent a two-value return of composite literals differently, and this
+		// block is the one place in the package where they disagree — enough to
+		// fail `task c:l` whichever of the two last touched the file.
+		degraded := &HealthStatus{
+			Status:     string(resp.JSON503.Status),
+			Version:    resp.JSON503.Version,
+			Timestamp:  resp.JSON503.Timestamp,
+			KeyStorage: resp.JSON503.Checks.KeyStorage,
+			Database:   resp.JSON503.Checks.Database,
+		}
+		return degraded, &ServiceError{
+			Code:       ErrCodeDegraded,
+			Message:    "service degraded",
+			StatusCode: 503,
+		}
 	}
 
 	return nil, newStatusError(resp.StatusCode(), resp.Body, resp.HTTPResponse.Header)
@@ -137,13 +147,10 @@ func (c *Client) PublicKey(ctx context.Context, keyID string) (string, error) {
 		keyIDPtr = &keyID
 	}
 
-	var resp *api.GetPublicKeyResponse
-	err := c.retrier.Do(ctx, func() error {
-		var execErr error
-		resp, execErr = c.raw.GetPublicKeyWithResponse(ctx, &api.GetPublicKeyParams{
+	resp, err := executeWithRetry(ctx, c.retrier, func() (*api.GetPublicKeyResponse, error) {
+		return c.raw.GetPublicKeyWithResponse(ctx, &api.GetPublicKeyParams{
 			KeyId: keyIDPtr,
 		})
-		return execErr
 	})
 	if err != nil {
 		return "", err
@@ -188,11 +195,8 @@ func (c *Client) Sign(ctx context.Context, commitData string, keyID string) (*Si
 
 	params := buildSignParams(keyID)
 
-	var resp *api.PostSignResponse
-	err := c.retrier.Do(ctx, func() error {
-		var execErr error
-		resp, execErr = c.raw.PostSignWithBodyWithResponse(ctx, params, "text/plain", strings.NewReader(commitData))
-		return execErr
+	resp, err := executeWithRetry(ctx, c.retrier, func() (*api.PostSignResponse, error) {
+		return c.raw.PostSignWithBodyWithResponse(ctx, params, "text/plain", strings.NewReader(commitData))
 	})
 	if err != nil {
 		return nil, err
@@ -229,11 +233,8 @@ func (c *Client) UploadKey(ctx context.Context, keyID string, armoredPrivateKey 
 		KeyId:             keyID,
 	}
 
-	var resp *api.PostAdminKeysResponse
-	err := c.retrier.Do(ctx, func() error {
-		var execErr error
-		resp, execErr = c.raw.PostAdminKeysWithResponse(ctx, body)
-		return execErr
+	resp, err := executeWithRetry(ctx, c.retrier, func() (*api.PostAdminKeysResponse, error) {
+		return c.raw.PostAdminKeysWithResponse(ctx, body)
 	})
 	if err != nil {
 		return nil, err
@@ -269,11 +270,8 @@ func (c *Client) UploadKey(ctx context.Context, keyID string, armoredPrivateKey 
 
 // ListKeys lists all signing keys (admin operation).
 func (c *Client) ListKeys(ctx context.Context) ([]KeyMetadata, error) {
-	var resp *api.GetAdminKeysResponse
-	err := c.retrier.Do(ctx, func() error {
-		var execErr error
-		resp, execErr = c.raw.GetAdminKeysWithResponse(ctx)
-		return execErr
+	resp, err := executeWithRetry(ctx, c.retrier, func() (*api.GetAdminKeysResponse, error) {
+		return c.raw.GetAdminKeysWithResponse(ctx)
 	})
 	if err != nil {
 		return nil, err
@@ -313,11 +311,8 @@ func (c *Client) ListKeys(ctx context.Context) ([]KeyMetadata, error) {
 // the key was not deleted (deleted=false), typically meaning the key doesn't exist.
 // Callers should use IsKeyNotFound() to detect this case.
 func (c *Client) DeleteKey(ctx context.Context, keyID string) error {
-	var resp *api.DeleteAdminKeysKeyIdResponse
-	err := c.retrier.Do(ctx, func() error {
-		var execErr error
-		resp, execErr = c.raw.DeleteAdminKeysKeyIdWithResponse(ctx, keyID)
-		return execErr
+	resp, err := executeWithRetry(ctx, c.retrier, func() (*api.DeleteAdminKeysKeyIdResponse, error) {
+		return c.raw.DeleteAdminKeysKeyIdWithResponse(ctx, keyID)
 	})
 	if err != nil {
 		return err
@@ -353,11 +348,8 @@ func (c *Client) DeleteKey(ctx context.Context, keyID string) error {
 func (c *Client) AuditLogs(ctx context.Context, filter AuditFilter) (*AuditResult, error) {
 	params := buildAuditParams(filter)
 
-	var resp *api.GetAdminAuditResponse
-	err := c.retrier.Do(ctx, func() error {
-		var execErr error
-		resp, execErr = c.raw.GetAdminAuditWithResponse(ctx, params)
-		return execErr
+	resp, err := executeWithRetry(ctx, c.retrier, func() (*api.GetAdminAuditResponse, error) {
+		return c.raw.GetAdminAuditWithResponse(ctx, params)
 	})
 	if err != nil {
 		return nil, err
@@ -383,11 +375,8 @@ func (c *Client) AdminPublicKey(ctx context.Context, keyID string) (string, erro
 		}
 	}
 
-	var resp *api.GetAdminKeysKeyIdPublicResponse
-	err := c.retrier.Do(ctx, func() error {
-		var execErr error
-		resp, execErr = c.raw.GetAdminKeysKeyIdPublicWithResponse(ctx, keyID)
-		return execErr
+	resp, err := executeWithRetry(ctx, c.retrier, func() (*api.GetAdminKeysKeyIdPublicResponse, error) {
+		return c.raw.GetAdminKeysKeyIdPublicWithResponse(ctx, keyID)
 	})
 	if err != nil {
 		return "", err

--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -561,7 +561,7 @@ func mapSignResponseError(resp *api.PostSignResponse) error {
 	case resp.JSON429 != nil:
 		return &RateLimitError{
 			Message:    resp.JSON429.Error,
-			RetryAfter: time.Duration(resp.JSON429.RetryAfter) * time.Second,
+			RetryAfter: retryAfterSeconds(resp.JSON429.RetryAfter),
 		}
 	case resp.JSON500 != nil || resp.JSON503 != nil:
 		return mapServerError(resp)

--- a/client/pkg/client/consts_test.go
+++ b/client/pkg/client/consts_test.go
@@ -1,5 +1,7 @@
 package client
 
+import "testing"
+
 // Shared fixtures for the client test suite. Extracted so repeated literals
 // have a single definition (and a single place to change them).
 const (
@@ -23,8 +25,10 @@ const (
 	// Stub server and request fixtures.
 	testBaseURL   = "http://localhost:8080"
 	testRequestID = "550e8400-e29b-41d4-a716-446655440000"
-	testVersion   = "1.0.0"
-	testTimestamp = "2023-11-20T10:30:45Z"
+	// The id the stub servers embed in error envelopes.
+	testErrRequestID = "1b4e28ba-2fa1-11d2-883f-0016d3cca427"
+	testVersion      = "1.0.0"
+	testTimestamp    = "2023-11-20T10:30:45Z"
 
 	// Key fixtures.
 	testKeyID        = "key-123"
@@ -55,3 +59,21 @@ const (
 	testNameValidation   = "validation error"
 	testNameOtherErrType = "other error type"
 )
+
+// newMappingClient builds a client for a test that asserts how a response is
+// *reported* rather than whether it is re-attempted.
+//
+// Retries are off. A 429 or a transient 5xx is now genuinely retried against a
+// real server, so a stub answering one of those on every request would put the
+// default 1s–30s backoff between the test and the answer it is checking —
+// several minutes across the suite, to reach exactly the same error. Retry
+// behaviour has its own tests, which count requests instead of inspecting one.
+func newMappingClient(tb testing.TB, baseURL string, opts ...Option) *Client {
+	tb.Helper()
+
+	c, err := New(baseURL, append([]Option{WithMaxRetries(0)}, opts...)...)
+	if err != nil {
+		tb.Fatalf("failed to create client: %v", err)
+	}
+	return c
+}

--- a/client/pkg/client/coverage_test.go
+++ b/client/pkg/client/coverage_test.go
@@ -22,7 +22,11 @@ func TestUnexpectedStatusResponses(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, _ := New(server.URL, WithAdminToken(testMsgTest))
+			// Retries off: this asserts how an unmapped status is *reported*, and
+			// 502 and 504 are legitimately retryable, so leaving the default
+			// policy on would spend the backoff eight times per status to reach
+			// the same answer.
+			client := newMappingClient(t, server.URL, WithAdminToken(testMsgTest), WithMaxRetries(0))
 			ctx := context.Background()
 
 			// Test Health
@@ -166,11 +170,8 @@ func TestSignMethodEdgeCases(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, err := New(server.URL)
-		if err != nil {
-			t.Fatalf("failed to create client: %v", err)
-		}
-		_, err = client.Sign(context.Background(), "data", "")
+		client := newMappingClient(t, server.URL)
+		_, err := client.Sign(context.Background(), "data", "")
 		if err == nil {
 			t.Error("expected rate limit error")
 		}

--- a/client/pkg/client/coverage_test.go
+++ b/client/pkg/client/coverage_test.go
@@ -22,11 +22,7 @@ func TestUnexpectedStatusResponses(t *testing.T) {
 			}))
 			defer server.Close()
 
-			// Retries off: this asserts how an unmapped status is *reported*, and
-			// 502 and 504 are legitimately retryable, so leaving the default
-			// policy on would spend the backoff eight times per status to reach
-			// the same answer.
-			client := newMappingClient(t, server.URL, WithAdminToken(testMsgTest), WithMaxRetries(0))
+			client := newMappingClient(t, server.URL, WithAdminToken(testMsgTest))
 			ctx := context.Background()
 
 			// Test Health

--- a/client/pkg/client/errors.go
+++ b/client/pkg/client/errors.go
@@ -80,15 +80,26 @@ func (e *AuthError) Error() string {
 
 // RateLimitError represents the rate limit having been exceeded.
 type RateLimitError struct {
-	Message    string
+	Message string
+	// RequestID is the server's request identifier when the response carried
+	// one. On a 429 that is usually the echoed X-Request-ID header and nothing
+	// else: RateLimitErrorSchema declares no `requestId`, and none of the three
+	// bodies this service answers a 429 with sends one — so a rate limit was
+	// the one refusal whose id an operator could not quote, which is exactly
+	// what docs/troubleshooting.md asks them to do.
+	RequestID  string
 	RetryAfter time.Duration
 }
 
 func (e *RateLimitError) Error() string {
+	msg := "rate limited: " + e.Message
 	if e.RetryAfter > 0 {
-		return fmt.Sprintf("rate limited: %s (retry after %v)", e.Message, e.RetryAfter)
+		msg += fmt.Sprintf(" (retry after %v)", e.RetryAfter)
 	}
-	return fmt.Sprintf("rate limited: %s", e.Message)
+	if e.RequestID != "" {
+		msg += fmt.Sprintf(" (request %s)", e.RequestID)
+	}
+	return msg
 }
 
 // ValidationError represents invalid request data.
@@ -139,8 +150,14 @@ func IsServiceError(err error) bool {
 	return errors.As(err, &se) && se.StatusCode >= 500
 }
 
-// headerRequestID is the response header the service echoes its request id on.
-const headerRequestID = "X-Request-ID"
+// Response headers this client reads.
+const (
+	// headerRequestID is the one the service echoes its request id on.
+	headerRequestID = "X-Request-ID"
+	// headerRetryAfter is the RFC 9110 hint, in either of the two forms
+	// parseRetryAfter accepts.
+	headerRetryAfter = "Retry-After"
+)
 
 // requestIDFrom returns the id the caller should quote when asking what
 // happened, preferring the envelope's field and falling back to the header.
@@ -169,7 +186,7 @@ func retryAfterFrom(envelopeSeconds int, header http.Header) time.Duration {
 	if hint := retryAfterSeconds(envelopeSeconds); hint > 0 {
 		return hint
 	}
-	return parseRetryAfter(header.Get("Retry-After"), time.Now())
+	return parseRetryAfter(header.Get(headerRetryAfter), time.Now())
 }
 
 // maxRetryAfterSeconds is the largest delay-seconds a time.Duration can hold.
@@ -286,7 +303,7 @@ type apiErrorBody struct {
 // whose body carries neither field: no `error`, so Error() printed a bare
 // "rate limited: ", and no `retryAfter`, so a Retry-After header sitting on the
 // same response was discarded.
-func newRateLimitError(envelopeMessage string, envelopeSeconds int, header http.Header) *RateLimitError {
+func newRateLimitError(envelopeMessage string, envelopeSeconds int, envelopeRequestID string, header http.Header) *RateLimitError {
 	message := envelopeMessage
 	if message == "" {
 		// Otherwise Error() prints a bare "rate limited: ".
@@ -294,6 +311,7 @@ func newRateLimitError(envelopeMessage string, envelopeSeconds int, header http.
 	}
 	return &RateLimitError{
 		Message:    message,
+		RequestID:  requestIDFrom(envelopeRequestID, header),
 		RetryAfter: retryAfterFrom(envelopeSeconds, header),
 	}
 }
@@ -325,7 +343,7 @@ func newStatusError(statusCode int, body []byte, header http.Header) error {
 	// it was written for. A rate limit the document does not declare is still a
 	// rate limit, and so is one this service did not write.
 	if statusCode == http.StatusTooManyRequests {
-		return newRateLimitError(parsed.Error, parsed.RetryAfter, header)
+		return newRateLimitError(parsed.Error, parsed.RetryAfter, parsed.RequestID, header)
 	}
 
 	if !ok {

--- a/client/pkg/client/errors.go
+++ b/client/pkg/client/errors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/kjanat/gpg-signing-service/client/pkg/api"
@@ -158,18 +159,49 @@ func requestIDFrom(envelope string, header http.Header) string {
 // retryAfterFrom returns how long a 429 asks the caller to wait, preferring the
 // envelope's `retryAfter` seconds and falling back to the `Retry-After` header.
 //
-// Only the delta-seconds form of the header is read. RFC 9110 also permits an
-// HTTP-date; this service's limiter emits seconds, and an unparseable value
-// yields zero, which callers treat as "no hint" rather than "no wait".
+// The header matters more than its rarity suggests. This service's limiter
+// always emits `retryAfter` in the body when it emits a body at all, so the
+// only 429 that reaches the fallback is one this service did not author — an
+// edge throttle in front of it, which answers with a page rather than an
+// envelope. That is exactly the response whose hint is otherwise lost.
 func retryAfterFrom(envelopeSeconds int, header http.Header) time.Duration {
 	if envelopeSeconds > 0 {
 		return time.Duration(envelopeSeconds) * time.Second
 	}
-	seconds, err := strconv.Atoi(header.Get("Retry-After"))
-	if err != nil || seconds <= 0 {
+	return parseRetryAfter(header.Get("Retry-After"), time.Now())
+}
+
+// parseRetryAfter reads both forms RFC 9110 §10.2.3 permits: delay-seconds, and
+// an absolute HTTP-date, which is reported as the delay remaining at now.
+//
+// The date form is not hypothetical — intermediaries and CDNs emit IMF-fixdate
+// freely, and reading only integers turned one into "no hint". A value already
+// in the past, or one that parses as neither form, yields zero, which callers
+// read as "no hint" rather than "no wait": the retrier falls back to its own
+// backoff and the error simply carries nothing to show.
+func parseRetryAfter(value string, now time.Time) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
 		return 0
 	}
-	return time.Duration(seconds) * time.Second
+
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+
+	// http.ParseTime accepts IMF-fixdate and the two obsolete formats RFC 9110
+	// still requires a recipient to understand.
+	deadline, err := http.ParseTime(value)
+	if err != nil {
+		return 0
+	}
+	if wait := deadline.Sub(now); wait > 0 {
+		return wait
+	}
+	return 0
 }
 
 // newAuthErrorFromResponse turns the service's 401 envelope into an AuthError.
@@ -240,6 +272,29 @@ type apiErrorBody struct {
 // keeps text responses and empty bodies behaving as before.
 func newStatusError(statusCode int, body []byte, header http.Header) error {
 	parsed, ok := parseAPIErrorBody(body)
+
+	// Deliberately above the envelope gate. A 429 needs no body to be
+	// understood: the status *is* the whole meaning, and IsRateLimitError —
+	// with it the retry policy and the CLI's "you are being throttled"
+	// message — keys off the type. An edge throttle sitting in front of this
+	// service answers 429 with an HTML page and a Retry-After header, which is
+	// not a usable envelope but is unambiguously a rate limit; gating this
+	// branch on one collapsed it to the bare sentinel and threw the hint away,
+	// leaving retryAfterFrom's header fallback unreachable in the single case
+	// it was written for. A rate limit the document does not declare is still a
+	// rate limit, and so is one this service did not write.
+	if statusCode == http.StatusTooManyRequests {
+		message := parsed.Error
+		if message == "" {
+			// Otherwise Error() prints a bare "rate limited: ".
+			message = http.StatusText(statusCode)
+		}
+		return &RateLimitError{
+			Message:    message,
+			RetryAfter: retryAfterFrom(parsed.RetryAfter, header),
+		}
+	}
+
 	if !ok {
 		return newUnexpectedStatusError(statusCode)
 	}
@@ -251,18 +306,6 @@ func newStatusError(statusCode int, body []byte, header http.Header) error {
 			Code:      parsed.Code,
 			Message:   parsed.Error,
 			RequestID: requestID,
-		}
-	}
-
-	// 429 is the one status where falling through to ServiceError would lose
-	// information the typed path keeps. IsRateLimitError, and with it the
-	// retrier's rate-limit policy and the CLI's "you are being throttled"
-	// message, key off the type — a rate limit the document happens not to
-	// declare for an operation is still a rate limit.
-	if statusCode == http.StatusTooManyRequests {
-		return &RateLimitError{
-			Message:    parsed.Error,
-			RetryAfter: retryAfterFrom(parsed.RetryAfter, header),
 		}
 	}
 

--- a/client/pkg/client/errors.go
+++ b/client/pkg/client/errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/kjanat/gpg-signing-service/client/pkg/api"
@@ -60,8 +61,14 @@ type AuthError struct {
 
 func (e *AuthError) Error() string {
 	msg := e.Message
-	if e.Code != "" {
+	// Both halves are required for the separator to mean anything. An AuthError
+	// built from a response always has both, but the type is exported and a
+	// caller's own value need not — and "AUTH_MISSING: " reads as a message the
+	// service failed to send rather than one it never had.
+	if e.Code != "" && msg != "" {
 		msg = e.Code + ": " + msg
+	} else if msg == "" {
+		msg = e.Code
 	}
 	if e.RequestID != "" {
 		return fmt.Sprintf("authentication failed: %s (request %s)", msg, e.RequestID)
@@ -148,6 +155,23 @@ func requestIDFrom(envelope string, header http.Header) string {
 	return header.Get(headerRequestID)
 }
 
+// retryAfterFrom returns how long a 429 asks the caller to wait, preferring the
+// envelope's `retryAfter` seconds and falling back to the `Retry-After` header.
+//
+// Only the delta-seconds form of the header is read. RFC 9110 also permits an
+// HTTP-date; this service's limiter emits seconds, and an unparseable value
+// yields zero, which callers treat as "no hint" rather than "no wait".
+func retryAfterFrom(envelopeSeconds int, header http.Header) time.Duration {
+	if envelopeSeconds > 0 {
+		return time.Duration(envelopeSeconds) * time.Second
+	}
+	seconds, err := strconv.Atoi(header.Get("Retry-After"))
+	if err != nil || seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}
+
 // newAuthErrorFromResponse turns the service's 401 envelope into an AuthError.
 //
 // The document declares a 401 on every operation that requires a credential, so
@@ -196,6 +220,9 @@ type apiErrorBody struct {
 	Error     string `json:"error"`
 	Code      string `json:"code"`
 	RequestID string `json:"requestId"`
+	// RetryAfter is the delay in seconds a 429 asks for. Declared by
+	// RateLimitErrorSchema; absent, and so zero, on every other status.
+	RetryAfter int `json:"retryAfter"`
 }
 
 // newStatusError builds the richest error the response supports.
@@ -224,6 +251,18 @@ func newStatusError(statusCode int, body []byte, header http.Header) error {
 			Code:      parsed.Code,
 			Message:   parsed.Error,
 			RequestID: requestID,
+		}
+	}
+
+	// 429 is the one status where falling through to ServiceError would lose
+	// information the typed path keeps. IsRateLimitError, and with it the
+	// retrier's rate-limit policy and the CLI's "you are being throttled"
+	// message, key off the type — a rate limit the document happens not to
+	// declare for an operation is still a rate limit.
+	if statusCode == http.StatusTooManyRequests {
+		return &RateLimitError{
+			Message:    parsed.Error,
+			RetryAfter: retryAfterFrom(parsed.RetryAfter, header),
 		}
 	}
 

--- a/client/pkg/client/errors.go
+++ b/client/pkg/client/errors.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -165,10 +166,30 @@ func requestIDFrom(envelope string, header http.Header) string {
 // edge throttle in front of it, which answers with a page rather than an
 // envelope. That is exactly the response whose hint is otherwise lost.
 func retryAfterFrom(envelopeSeconds int, header http.Header) time.Duration {
-	if envelopeSeconds > 0 {
-		return time.Duration(envelopeSeconds) * time.Second
+	if hint := retryAfterSeconds(envelopeSeconds); hint > 0 {
+		return hint
 	}
 	return parseRetryAfter(header.Get("Retry-After"), time.Now())
+}
+
+// maxRetryAfterSeconds is the largest delay-seconds a time.Duration can hold.
+// A Duration is an int64 of nanoseconds, so the conversion wraps somewhere past
+// 292 years and a header meaning "wait forever" would arrive as a negative wait.
+const maxRetryAfterSeconds = int64(math.MaxInt64) / int64(time.Second)
+
+// retryAfterSeconds converts a delay-seconds hint to a Duration, reporting zero
+// — "no hint" — for anything a Duration cannot hold.
+//
+// Both sources are outside this client's control: the header is written by
+// whatever answered, and `retryAfter` in the envelope is an unbounded JSON
+// integer whatever wrote the body chose. The multiply wraps silently, so
+// 9223372036854 arrives as -775ms: a wait that is not merely wrong but reads as
+// one already past.
+func retryAfterSeconds(seconds int) time.Duration {
+	if seconds <= 0 || int64(seconds) > maxRetryAfterSeconds {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 // parseRetryAfter reads both forms RFC 9110 §10.2.3 permits: delay-seconds, and
@@ -186,10 +207,7 @@ func parseRetryAfter(value string, now time.Time) time.Duration {
 	}
 
 	if seconds, err := strconv.Atoi(value); err == nil {
-		if seconds <= 0 {
-			return 0
-		}
-		return time.Duration(seconds) * time.Second
+		return retryAfterSeconds(seconds)
 	}
 
 	// http.ParseTime accepts IMF-fixdate and the two obsolete formats RFC 9110

--- a/client/pkg/client/errors.go
+++ b/client/pkg/client/errors.go
@@ -275,6 +275,29 @@ type apiErrorBody struct {
 	RetryAfter int `json:"retryAfter"`
 }
 
+// newRateLimitError builds the RateLimitError a 429 deserves, from whichever of
+// its sources carries anything.
+//
+// Both paths that answer a 429 go through here so they cannot disagree about
+// what one means. The declared path — /sign's typed JSON429 — built the value
+// inline from the envelope alone, which cost it both fallbacks the undeclared
+// path has. An intermediary that answers 429 with a JSON body reaches the typed
+// path whenever that body happens to decode, and it is exactly the responder
+// whose body carries neither field: no `error`, so Error() printed a bare
+// "rate limited: ", and no `retryAfter`, so a Retry-After header sitting on the
+// same response was discarded.
+func newRateLimitError(envelopeMessage string, envelopeSeconds int, header http.Header) *RateLimitError {
+	message := envelopeMessage
+	if message == "" {
+		// Otherwise Error() prints a bare "rate limited: ".
+		message = http.StatusText(http.StatusTooManyRequests)
+	}
+	return &RateLimitError{
+		Message:    message,
+		RetryAfter: retryAfterFrom(envelopeSeconds, header),
+	}
+}
+
 // newStatusError builds the richest error the response supports.
 //
 // The service answers every refusal with a precise message — `AUTH_MISSING`,
@@ -302,15 +325,7 @@ func newStatusError(statusCode int, body []byte, header http.Header) error {
 	// it was written for. A rate limit the document does not declare is still a
 	// rate limit, and so is one this service did not write.
 	if statusCode == http.StatusTooManyRequests {
-		message := parsed.Error
-		if message == "" {
-			// Otherwise Error() prints a bare "rate limited: ".
-			message = http.StatusText(statusCode)
-		}
-		return &RateLimitError{
-			Message:    message,
-			RetryAfter: retryAfterFrom(parsed.RetryAfter, header),
-		}
+		return newRateLimitError(parsed.Error, parsed.RetryAfter, header)
 	}
 
 	if !ok {

--- a/client/pkg/client/errors.go
+++ b/client/pkg/client/errors.go
@@ -346,7 +346,12 @@ func parseAPIErrorBody(body []byte) (apiErrorBody, bool) {
 		return apiErrorBody{}, false
 	}
 	if parsed.Error == "" || parsed.Code == "" {
-		return apiErrorBody{}, false
+		// The value still goes back. Only newStatusError's 429 branch, which sits
+		// above the gate because a 429 needs no envelope to be understood, reads
+		// it when ok is false — a half-envelope carrying `error` and `retryAfter`
+		// but no `code` parsed cleanly and has both of the things that branch
+		// wants. Every other path discards it and reports the status alone.
+		return parsed, false
 	}
 	return parsed, true
 }

--- a/client/pkg/client/errors_test.go
+++ b/client/pkg/client/errors_test.go
@@ -80,7 +80,7 @@ func TestAuthError(t *testing.T) {
 			name:      "auth error empty message",
 			code:      "NO_CREDENTIALS",
 			message:   "",
-			wantError: "authentication failed: NO_CREDENTIALS: ",
+			wantError: "authentication failed: NO_CREDENTIALS",
 		},
 		{
 			name:      "auth error without a code",

--- a/client/pkg/client/methods_test.go
+++ b/client/pkg/client/methods_test.go
@@ -47,7 +47,7 @@ func runPublicKeyTest(
 			}))
 			defer server.Close()
 
-			client, _ := New(server.URL)
+			client := newMappingClient(t, server.URL)
 			key, err := callMethod(client, context.Background(), tt.keyID)
 
 			if tt.wantErr && err == nil {
@@ -145,7 +145,7 @@ func TestHealth(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, _ := New(server.URL)
+			client := newMappingClient(t, server.URL)
 			status, err := client.Health(context.Background())
 
 			if tt.wantErr && err == nil {
@@ -269,7 +269,7 @@ func TestUploadKey(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, _ := New(server.URL)
+			client := newMappingClient(t, server.URL)
 			info, err := client.UploadKey(context.Background(), tt.keyID, tt.privateKey)
 
 			if tt.wantErr && err == nil {
@@ -312,7 +312,7 @@ func TestListKeys(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL)
+	client := newMappingClient(t, server.URL)
 	keys, err := client.ListKeys(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -374,7 +374,7 @@ func TestDeleteKey(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, _ := New(server.URL)
+			client := newMappingClient(t, server.URL)
 			err := client.DeleteKey(context.Background(), tt.keyID)
 
 			if tt.wantErr && err == nil {
@@ -420,7 +420,7 @@ func TestAuditLogs(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL)
+	client := newMappingClient(t, server.URL)
 
 	filter := AuditFilter{
 		Limit: 10,
@@ -499,7 +499,7 @@ func TestAuditFilterWithAllFields(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL)
+	client := newMappingClient(t, server.URL)
 
 	filter := AuditFilter{
 		Limit:     20,
@@ -536,7 +536,7 @@ func BenchmarkHealth(b *testing.B) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL)
+	client := newMappingClient(b, server.URL)
 
 	for b.Loop() {
 		_, _ = client.Health(context.Background())
@@ -552,7 +552,7 @@ func BenchmarkPublicKey(b *testing.B) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL)
+	client := newMappingClient(b, server.URL)
 
 	for b.Loop() {
 		_, _ = client.PublicKey(context.Background(), "")
@@ -599,7 +599,7 @@ func TestAdminMethodsSurfaceUnauthorized(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, _ := New(server.URL)
+			client := newMappingClient(t, server.URL)
 			err := call(context.Background(), client)
 
 			var authErr *AuthError
@@ -637,7 +637,7 @@ func TestUnauthorizedWithoutMessageFallsBackToSentinel(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL)
+	client := newMappingClient(t, server.URL)
 
 	_, err := client.ListKeys(context.Background())
 	if !errors.Is(err, ErrUnexpectedStatus) {

--- a/client/pkg/client/options.go
+++ b/client/pkg/client/options.go
@@ -65,9 +65,14 @@ func WithRetryWait(minWait, maxWait time.Duration) Option {
 	}
 }
 
-// WithoutRateLimitRetry disables automatic retry on rate limit errors.
-// By default, rate limit errors are automatically retried after the
-// retry-after duration specified by the server.
+// WithoutRateLimitRetry makes a 429 final on the first response.
+//
+// By default a 429 is attempted again under the same budget as any other
+// retryable status. The wait between attempts is the exponential backoff, not
+// the server's retry-after hint — the hint is not reachable from the generic
+// response type the retry policy sees — but it is not lost either: it reaches
+// the caller on the RateLimitError returned once the attempts are spent. Set
+// this when a throttled call should fail fast rather than spend that budget.
 func WithoutRateLimitRetry() Option {
 	return func(o *Options) {
 		o.retryOnRateLimit = false

--- a/client/pkg/client/options.go
+++ b/client/pkg/client/options.go
@@ -68,11 +68,14 @@ func WithRetryWait(minWait, maxWait time.Duration) Option {
 // WithoutRateLimitRetry makes a 429 final on the first response.
 //
 // By default a 429 is attempted again under the same budget as any other
-// retryable status. The wait between attempts is the exponential backoff, not
-// the server's retry-after hint — the hint is not reachable from the generic
-// response type the retry policy sees — but it is not lost either: it reaches
-// the caller on the RateLimitError returned once the attempts are spent. Set
-// this when a throttled call should fail fast rather than spend that budget.
+// retryable status, and the wait between attempts is the server's retry-after
+// hint when the response carries one — from the body's `retryAfter` or the
+// Retry-After header — falling back to the exponential backoff when it does
+// not. A hint longer than WithRetryWait's maximum is clamped to it, so a
+// misconfigured responder cannot park the call; the untruncated value still
+// reaches the caller on the RateLimitError returned once the attempts are
+// spent. Set this when a throttled call should fail fast rather than spend
+// that budget.
 func WithoutRateLimitRetry() Option {
 	return func(o *Options) {
 		o.retryOnRateLimit = false

--- a/client/pkg/client/retry.go
+++ b/client/pkg/client/retry.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"math/rand/v2"
+	"net/http"
 	"time"
 )
 
@@ -142,4 +143,94 @@ func stopTimer(t *time.Timer) {
 		default:
 		}
 	}
+}
+
+// statusCoder is satisfied by every generated `…Response` type.
+type statusCoder interface {
+	StatusCode() int
+}
+
+// retrySignalError marks an error as the retrier's business and nobody else's.
+//
+// It exists because "should this be attempted again?" and "what is this failure
+// called?" have different answers here. The first is asked of a bare status
+// code, before any operation-specific mapping has run; the second is answered
+// by that mapping, which knows the endpoint's declared bodies and builds the
+// RateLimitError, ServiceError or AuthError a caller branches on. Signalling
+// the first with a throwaway wrapper leaves the second untouched:
+// executeWithRetry discards the signal once the attempts are spent, and the
+// final response is mapped exactly as it would have been.
+//
+// shouldRetry uses errors.As throughout, so the wrapper is transparent to it —
+// including Do's RateLimitError branch, which reads RetryAfter through the same
+// unwrap.
+type retrySignalError struct {
+	inner error
+}
+
+func (s *retrySignalError) Error() string { return s.inner.Error() }
+func (s *retrySignalError) Unwrap() error { return s.inner }
+
+// retryStatusSignal classifies a completed round trip for the retrier.
+//
+// A 429 or a 5xx is a *successful* HTTP exchange: the generated client returns
+// a nil error and puts the status on the response. A closure reporting only
+// that error therefore told the retrier nothing was wrong, which left
+// shouldRetry's RateLimitError and 5xx-ServiceError branches unreachable
+// against a real server — WithoutRateLimitRetry() toggled nothing, and
+// retryWaitMin/Max governed transport faults alone. Returning the
+// classification here is what connects them to responses.
+//
+// The values are skeletal by design; they are read for their type and nothing
+// else. The wait between attempts is the retrier's exponential backoff rather
+// than the server's `Retry-After` hint: the hint is not reachable from the
+// generic response type, and a bounded, jittered backoff is a well-behaved
+// policy to fall back to. Callers still receive the hint — it survives on the
+// mapped RateLimitError the operation returns once the attempts are spent.
+//
+// Not every 5xx qualifies. shouldRetry's ServiceError branch tests `>= 500`
+// because a caller reaching it has already decided the error is worth another
+// go; deciding it here from a bare status has to be narrower, because 501 and
+// 505 describe what the server will never do rather than what it could not do
+// this time. Repeating those only spends the caller's timeout budget.
+func retryStatusSignal(statusCode int) error {
+	switch statusCode {
+	case http.StatusTooManyRequests:
+		return &retrySignalError{inner: &RateLimitError{Message: "rate limited"}}
+	case http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return &retrySignalError{inner: &ServiceError{StatusCode: statusCode}}
+	}
+	return nil
+}
+
+// executeWithRetry runs one API call under the retry policy and returns the
+// final response.
+//
+// A retryable status is attempted again; everything else — including the last
+// attempt of a retryable one — is handed back with a nil error, so the caller's
+// own mapping decides what the failure is called. Only a transport error or a
+// cancelled context escapes as an error from here.
+func executeWithRetry[T statusCoder](
+	ctx context.Context,
+	r *Retrier,
+	call func() (T, error),
+) (T, error) {
+	var resp T
+	err := r.Do(ctx, func() error {
+		var execErr error
+		resp, execErr = call()
+		if execErr != nil {
+			return execErr
+		}
+		return retryStatusSignal(resp.StatusCode())
+	})
+
+	var signal *retrySignalError
+	if err != nil && !errors.As(err, &signal) {
+		return resp, err
+	}
+	return resp, nil
 }

--- a/client/pkg/client/retry.go
+++ b/client/pkg/client/retry.go
@@ -107,9 +107,16 @@ func (r *Retrier) shouldRetry(err error) bool {
 	// WithTimeout lands here too, and deliberately. net/http renders an exceeded
 	// Client.Timeout as "context deadline exceeded (Client.Timeout exceeded while
 	// awaiting headers)" and it satisfies errors.Is against DeadlineExceeded, so
-	// the configured timeout stays a budget for the whole call rather than one
-	// each attempt is handed afresh — WithTimeout(30s) with three retries would
-	// otherwise be a two-minute call.
+	// an attempt that ran out of time is final rather than repeated: the next one
+	// is handed the same duration and the same slow server.
+	//
+	// That does not make WithTimeout a budget for the whole call, and it never
+	// did. http.Client applies its Timeout per Do, so each attempt gets a fresh
+	// one, and a server answering *promptly* with a retryable status never trips
+	// it at all — WithTimeout(30s) under the default policy is four attempts of
+	// up to 30s plus ~15s of backoff. A caller wanting one budget for the whole
+	// operation passes a context with a deadline, which Do checks before every
+	// wait.
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}

--- a/client/pkg/client/retry.go
+++ b/client/pkg/client/retry.go
@@ -101,6 +101,13 @@ func (r *Retrier) shouldRetry(err error) bool {
 	// fails the same way, immediately, and the caller's deadline is the answer
 	// either way. Checked before the transport branch below, because a context
 	// that expires mid-flight surfaces wrapped in a *url.Error like any other.
+	//
+	// WithTimeout lands here too, and deliberately. net/http renders an exceeded
+	// Client.Timeout as "context deadline exceeded (Client.Timeout exceeded while
+	// awaiting headers)" and it satisfies errors.Is against DeadlineExceeded, so
+	// the configured timeout stays a budget for the whole call rather than one
+	// each attempt is handed afresh — WithTimeout(30s) with three retries would
+	// otherwise be a two-minute call.
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
@@ -111,12 +118,11 @@ func (r *Retrier) shouldRetry(err error) bool {
 	// retryWaitMin/Max governed nothing at all.
 	//
 	// net/http reports every one of those as a *url.Error — a refused dial, a
-	// connection closed mid-body, a failed handshake, a per-request timeout —
-	// which is why this tests for the type rather than defaulting to true. A
-	// response that arrived and then failed to decode is not a transport fault:
-	// the body is already in hand and the next attempt parses exactly as badly,
-	// so a blanket default would spend the whole backoff budget re-reading a
-	// malformed 200.
+	// connection closed mid-body, a failed handshake — which is why this tests
+	// for the type rather than defaulting to true. A response that arrived and
+	// then failed to decode is not a transport fault: the body is already in hand
+	// and the next attempt parses exactly as badly, so a blanket default would
+	// spend the whole backoff budget re-reading a malformed 200.
 	var urlErr *url.Error
 	return errors.As(err, &urlErr)
 }

--- a/client/pkg/client/retry.go
+++ b/client/pkg/client/retry.go
@@ -3,8 +3,10 @@ package client
 import (
 	"context"
 	"errors"
+	"io"
 	"math"
 	"math/rand/v2"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -117,14 +119,31 @@ func (r *Retrier) shouldRetry(err error) bool {
 	// retrier, and the transport faults that did fell through to false, so
 	// retryWaitMin/Max governed nothing at all.
 	//
-	// net/http reports every one of those as a *url.Error — a refused dial, a
-	// connection closed mid-body, a failed handshake — which is why this tests
-	// for the type rather than defaulting to true. A response that arrived and
-	// then failed to decode is not a transport fault: the body is already in hand
-	// and the next attempt parses exactly as badly, so a blanket default would
-	// spend the whole backoff budget re-reading a malformed 200.
+	// A fault before the response headers arrive — a refused dial, a failed
+	// handshake, a reset before the status line — is reported by net/http as a
+	// *url.Error, which is why this tests for the type rather than defaulting to
+	// true. A response that arrived and then failed to decode is not a transport
+	// fault: the body is already in hand and the next attempt parses exactly as
+	// badly, so a blanket default would spend the whole backoff budget re-reading
+	// a malformed 200.
 	var urlErr *url.Error
-	return errors.As(err, &urlErr)
+	if errors.As(err, &urlErr) {
+		return true
+	}
+
+	// A fault *after* the headers arrive does not look like one. The generated
+	// client reads the body with io.ReadAll inside Parse…Response, well past the
+	// *url.Error the round trip returned, so a connection dropped mid-body comes
+	// back bare: io.ErrUnexpectedEOF when the peer hung up, a *net.OpError when
+	// it reset. README lists that case among the faults this retries, and it is
+	// the more likely of the two in practice — the request was accepted and the
+	// server may well have done the work — so it has to be recognised here.
+	//
+	// Neither shape can be a decode failure. json.Unmarshal reports a truncated
+	// document as *json.SyntaxError ("unexpected end of JSON input") and never
+	// wraps io.ErrUnexpectedEOF, so a malformed 200 still falls through to false.
+	var opErr *net.OpError
+	return errors.Is(err, io.ErrUnexpectedEOF) || errors.As(err, &opErr)
 }
 
 func (r *Retrier) backoff(attempt int) time.Duration {

--- a/client/pkg/client/retry.go
+++ b/client/pkg/client/retry.go
@@ -33,11 +33,12 @@ func newRetrier(opts *Options) *Retrier {
 // Do executes fn with retry logic.
 func (r *Retrier) Do(ctx context.Context, fn func() error) error {
 	var lastErr error
+	var wait time.Duration
 
 	for attempt := 0; attempt <= r.maxRetries; attempt++ {
-		// Exponential backoff before retry (skip on the first attempt)
+		// Skipped on the first attempt; otherwise this is what the previous
+		// failure asked for, decided by waitBefore below.
 		if attempt > 0 {
-			wait := r.backoff(attempt)
 			select {
 			case <-time.After(wait):
 			case <-ctx.Done():
@@ -55,23 +56,38 @@ func (r *Retrier) Do(ctx context.Context, fn func() error) error {
 			return lastErr
 		}
 
-		// Handle rate limit with explicit wait
-		var rateLimitErr *RateLimitError
-		if errors.As(lastErr, &rateLimitErr) && r.retryOnRateLimit {
-			if rateLimitErr.RetryAfter > 0 {
-				timer := time.NewTimer(rateLimitErr.RetryAfter)
-				select {
-				case <-timer.C:
-					// Timer fired normally, no cleanup needed
-				case <-ctx.Done():
-					stopTimer(timer)
-					return ctx.Err()
-				}
-			}
-		}
+		wait = r.waitBefore(attempt+1, lastErr)
 	}
 
 	return lastErr
+}
+
+// waitBefore is how long to hold off before the given attempt.
+//
+// The exponential backoff, unless the failure carried the server's own
+// retry-after hint. Preferring the hint is not politeness: this service floors
+// `retryAfter` at one second and its limiter refills a single token in well
+// under that, so a client that ignores it turns a limit which cleared in one
+// second into a fifteen-second stall — and spends three more requests on a
+// bucket that had already refilled.
+//
+// Clamped to retryWaitMax, because the hint is written by whatever answered and
+// an unbounded one lets a misconfigured or hostile responder park the call for
+// as long as it likes. retryWaitMax is the ceiling the caller configured for
+// exactly that, and the true hint still reaches them on the RateLimitError the
+// operation returns.
+//
+// Gated on retryOnRateLimit only because a 429 is the sole failure that carries
+// a hint at all; WithoutRateLimitRetry stops the retry before this is reached.
+func (r *Retrier) waitBefore(attempt int, err error) time.Duration {
+	var rateLimitErr *RateLimitError
+	if r.retryOnRateLimit && errors.As(err, &rateLimitErr) && rateLimitErr.RetryAfter > 0 {
+		if rateLimitErr.RetryAfter > r.retryWaitMax {
+			return r.retryWaitMax
+		}
+		return rateLimitErr.RetryAfter
+	}
+	return r.backoff(attempt)
 }
 
 func (r *Retrier) shouldRetry(err error) bool {
@@ -186,19 +202,6 @@ func (r *Retrier) backoff(attempt int) time.Duration {
 	return wait
 }
 
-func stopTimer(t *time.Timer) {
-	if t == nil {
-		return
-	}
-
-	if !t.Stop() {
-		select {
-		case <-t.C:
-		default:
-		}
-	}
-}
-
 // statusCoder is satisfied by every generated `…Response` type.
 type statusCoder interface {
 	StatusCode() int
@@ -215,15 +218,50 @@ type statusCoder interface {
 // executeWithRetry discards the signal once the attempts are spent, and the
 // final response is mapped exactly as it would have been.
 //
-// shouldRetry uses errors.As throughout, so the wrapper is transparent to it —
-// including Do's RateLimitError branch, which reads RetryAfter through the same
-// unwrap.
+// shouldRetry and waitBefore both use errors.As, so the wrapper is transparent
+// to them: the signal's RateLimitError is what carries the server's retry-after
+// hint into the wait between attempts.
 type retrySignalError struct {
 	inner error
 }
 
 func (s *retrySignalError) Error() string { return s.inner.Error() }
 func (s *retrySignalError) Unwrap() error { return s.inner }
+
+// retryHint is where a completed response leaves what it asks the retrier to do
+// about the next attempt.
+//
+// The policy runs on a generic response type that exposes StatusCode() and
+// nothing else, so neither the `Retry-After` header nor this service's own
+// `retryAfter` envelope field is reachable from where the wait is decided —
+// which is why that wait ignored the server's hint entirely and answered a
+// one-second limit with fifteen seconds of backoff. Both sources are in hand at
+// exactly one point per response, errorBodyTransport, which already holds the
+// status, the headers and the body; so the hint is recorded there and travels
+// back on the request context, the way httptrace's hooks do.
+//
+// One sink per call, created by executeWithRetry, written by the transport on
+// the goroutine running the attempt and read after it returns. http.Client
+// calls RoundTrip synchronously, so that ordering needs no synchronisation.
+type retryHint struct {
+	retryAfter time.Duration
+}
+
+// retryHintKey is the context key for a *retryHint. Unexported struct type, so
+// nothing outside this package can collide with it or reach the sink.
+type retryHintKey struct{}
+
+func withRetryHint(ctx context.Context, hint *retryHint) context.Context {
+	return context.WithValue(ctx, retryHintKey{}, hint)
+}
+
+// retryHintFrom returns the sink for the call in flight, or nil when the caller
+// is not running under executeWithRetry — Health, which drives the retrier
+// directly.
+func retryHintFrom(ctx context.Context) *retryHint {
+	hint, _ := ctx.Value(retryHintKey{}).(*retryHint)
+	return hint
+}
 
 // retryStatusSignal classifies a completed round trip for the retrier.
 //
@@ -236,22 +274,24 @@ func (s *retrySignalError) Unwrap() error { return s.inner }
 // retryWaitMin/Max governed nothing at all. Returning the classification here
 // is what connects the policy to responses.
 //
-// The values are skeletal by design; they are read for their type and nothing
-// else. The wait between attempts is the retrier's exponential backoff rather
-// than the server's `Retry-After` hint: the hint is not reachable from the
-// generic response type, and a bounded, jittered backoff is a well-behaved
-// policy to fall back to. Callers still receive the hint — it survives on the
-// mapped RateLimitError the operation returns once the attempts are spent.
+// The values are skeletal apart from retryAfter, which is the one thing the
+// retrier acts on beyond the type: waitBefore prefers it over the backoff, so a
+// 429 costs the wait the server asked for rather than an exponential guess over
+// it. Callers still receive the full hint on the mapped RateLimitError the
+// operation returns once the attempts are spent.
 //
 // Not every 5xx qualifies. shouldRetry's ServiceError branch tests `>= 500`
 // because a caller reaching it has already decided the error is worth another
 // go; deciding it here from a bare status has to be narrower, because 501 and
 // 505 describe what the server will never do rather than what it could not do
 // this time. Repeating those only spends the caller's timeout budget.
-func retryStatusSignal(statusCode int) error {
+func retryStatusSignal(statusCode int, retryAfter time.Duration) error {
 	switch statusCode {
 	case http.StatusTooManyRequests:
-		return &retrySignalError{inner: &RateLimitError{Message: "rate limited"}}
+		return &retrySignalError{inner: &RateLimitError{
+			Message:    "rate limited",
+			RetryAfter: retryAfter,
+		}}
 	case http.StatusInternalServerError,
 		http.StatusBadGateway,
 		http.StatusServiceUnavailable,
@@ -268,23 +308,53 @@ func retryStatusSignal(statusCode int) error {
 // attempt of a retryable one — is handed back with a nil error, so the caller's
 // own mapping decides what the failure is called. Only a transport error or a
 // cancelled context escapes as an error from here.
+//
+// The closure is handed the context to use rather than closing over the
+// caller's: this one carries the retry-after sink the transport writes into.
 func executeWithRetry[T statusCoder](
 	ctx context.Context,
 	r *Retrier,
-	call func() (T, error),
+	call func(context.Context) (T, error),
 ) (T, error) {
 	var resp T
+	attempted := false
+
+	hint := &retryHint{}
+	ctx = withRetryHint(ctx, hint)
+
 	err := r.Do(ctx, func() error {
-		var execErr error
-		resp, execErr = call()
+		hint.retryAfter = 0
+		got, execErr := call(ctx)
 		if execErr != nil {
+			// resp is deliberately left alone. A transport fault on a later
+			// attempt would otherwise overwrite the response an earlier one
+			// produced, and that response is the more informative of the two.
 			return execErr
 		}
-		return retryStatusSignal(resp.StatusCode())
+		resp, attempted = got, true
+		return retryStatusSignal(resp.StatusCode(), hint.retryAfter)
 	})
 
 	var signal *retrySignalError
 	if err != nil && !errors.As(err, &signal) {
+		// A deadline that expired while the policy was still working is not the
+		// most informative thing that happened: a response is in hand and
+		// unmapped, and Do returns ctx.Err() from the backoff sleep — reached
+		// only *after* an attempt was classified retryable. Retries are an
+		// optimisation over that response, not a precondition for it, so
+		// running out of budget mid-policy costs the retry rather than the
+		// answer. Otherwise the CLI, which hands the same --timeout to
+		// WithTimeout and to its context, reports "context deadline exceeded"
+		// for a call the service already answered "you are being throttled".
+		//
+		// context.Canceled deliberately falls through: a caller who cancelled
+		// asked for exactly that, while a caller whose deadline lapsed asked
+		// for an answer within N seconds and one exists. So does a context that
+		// expired before any attempt completed — attempted is false, resp is
+		// the zero value, and the error is all there is.
+		if attempted && errors.Is(err, context.DeadlineExceeded) {
+			return resp, nil
+		}
 		return resp, err
 	}
 	return resp, nil

--- a/client/pkg/client/retry.go
+++ b/client/pkg/client/retry.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"math/rand/v2"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -96,7 +97,28 @@ func (r *Retrier) shouldRetry(err error) bool {
 		return false
 	}
 
-	return false
+	// A cancelled or expired context is not worth another attempt: the next one
+	// fails the same way, immediately, and the caller's deadline is the answer
+	// either way. Checked before the transport branch below, because a context
+	// that expires mid-flight surfaces wrapped in a *url.Error like any other.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// A round trip that never completed is the textbook case for trying again,
+	// and used to be the case this function dropped: statuses never reached the
+	// retrier, and the transport faults that did fell through to false, so
+	// retryWaitMin/Max governed nothing at all.
+	//
+	// net/http reports every one of those as a *url.Error — a refused dial, a
+	// connection closed mid-body, a failed handshake, a per-request timeout —
+	// which is why this tests for the type rather than defaulting to true. A
+	// response that arrived and then failed to decode is not a transport fault:
+	// the body is already in hand and the next attempt parses exactly as badly,
+	// so a blanket default would spend the whole backoff budget re-reading a
+	// malformed 200.
+	var urlErr *url.Error
+	return errors.As(err, &urlErr)
 }
 
 func (r *Retrier) backoff(attempt int) time.Duration {
@@ -177,9 +199,10 @@ func (s *retrySignalError) Unwrap() error { return s.inner }
 // a nil error and puts the status on the response. A closure reporting only
 // that error therefore told the retrier nothing was wrong, which left
 // shouldRetry's RateLimitError and 5xx-ServiceError branches unreachable
-// against a real server — WithoutRateLimitRetry() toggled nothing, and
-// retryWaitMin/Max governed transport faults alone. Returning the
-// classification here is what connects them to responses.
+// against a real server, and WithoutRateLimitRetry() toggling nothing. The
+// transport faults that did reach shouldRetry fell through to false, so
+// retryWaitMin/Max governed nothing at all. Returning the classification here
+// is what connects the policy to responses.
 //
 // The values are skeletal by design; they are read for their type and nothing
 // else. The wait between attempts is the retrier's exponential backoff rather

--- a/client/pkg/client/retry_policy_test.go
+++ b/client/pkg/client/retry_policy_test.go
@@ -1,0 +1,480 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// signature is what a stub answers a successful /sign with.
+const testSignature = "-----BEGIN PGP SIGNATURE-----\n\nsig\n-----END PGP SIGNATURE-----"
+
+// TestWaitBeforePrefersTheServersHint covers the decision that used to live in
+// Do as unreachable code.
+//
+// The retrier held a Retry-After branch that nothing could reach: every
+// response path runs through executeWithRetry, whose signal carried a zero
+// RetryAfter because the hint was not reachable from the generic response type.
+// So a 429 asking for one second cost the full exponential backoff instead —
+// on the shipped defaults, roughly fifteen seconds for a limit that had already
+// cleared. Held to the arithmetic here; the end-to-end test below pays for a
+// real wait once.
+func TestWaitBeforePrefersTheServersHint(t *testing.T) {
+	r := &Retrier{
+		maxRetries:       3,
+		retryWaitMin:     5 * time.Second,
+		retryWaitMax:     30 * time.Second,
+		retryOnRateLimit: true,
+	}
+	// backoff(1) is 2*retryWaitMin plus jitter, so anything the hint decides is
+	// unambiguously below it.
+	const floor = 10 * time.Second
+
+	tests := []struct {
+		name             string
+		retryOnRateLimit bool
+		err              error
+		want             time.Duration
+		wantBackoff      bool
+	}{
+		{
+			name:             "a hint shorter than the backoff is what the server asked for",
+			retryOnRateLimit: true,
+			err:              &RateLimitError{Message: testMsgRateLimited, RetryAfter: time.Second},
+			want:             time.Second,
+		},
+		{
+			name:             "the signal the status path builds carries it too",
+			retryOnRateLimit: true,
+			err:              &retrySignalError{inner: &RateLimitError{RetryAfter: 2 * time.Second}},
+			want:             2 * time.Second,
+		},
+		{
+			name:             "a hint past the configured ceiling is clamped to it",
+			retryOnRateLimit: true,
+			err:              &RateLimitError{Message: testMsgRateLimited, RetryAfter: time.Hour},
+			want:             30 * time.Second,
+		},
+		{
+			name:             "a 429 with no hint falls back to the backoff",
+			retryOnRateLimit: true,
+			err:              &RateLimitError{Message: testMsgRateLimited},
+			wantBackoff:      true,
+		},
+		{
+			name:             "a 5xx has no hint to prefer",
+			retryOnRateLimit: true,
+			err:              &ServiceError{Code: testCodeError, StatusCode: 503},
+			wantBackoff:      true,
+		},
+		{
+			name:             "WithoutRateLimitRetry leaves the backoff in charge",
+			retryOnRateLimit: false,
+			err:              &RateLimitError{Message: testMsgRateLimited, RetryAfter: time.Second},
+			wantBackoff:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := *r
+			policy.retryOnRateLimit = tt.retryOnRateLimit
+
+			got := policy.waitBefore(1, tt.err)
+			if tt.wantBackoff {
+				if got < floor || got > policy.retryWaitMax {
+					t.Errorf("expected a backoff in [%v, %v], got %v", floor, policy.retryWaitMax, got)
+				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("waitBefore = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRecordRetryHint covers the transport half of the same fix: the hint has
+// two sources and the retry policy can see neither.
+//
+// `Retry-After` is a header and this service's own hint is a body field, while
+// executeWithRetry works with a response type exposing StatusCode() alone. The
+// transport is the one place both are in hand at once.
+func TestRecordRetryHint(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		header     http.Header
+		want       time.Duration
+	}{
+		{
+			name:       "the envelope this service actually sends",
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"error":"slow down","code":"RATE_LIMITED","retryAfter":7}`,
+			want:       7 * time.Second,
+		},
+		{
+			name:       "the header, for a throttle that sent no envelope",
+			statusCode: http.StatusTooManyRequests,
+			header:     http.Header{headerRetryAfter: []string{"12"}},
+			want:       12 * time.Second,
+		},
+		{
+			name:       "a half-envelope still carries its hint",
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"error":"slow down","retryAfter":3}`,
+			want:       3 * time.Second,
+		},
+		{
+			name:       "a 429 with neither leaves the backoff in charge",
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"error":"slow down","code":"RATE_LIMITED"}`,
+		},
+		{
+			// 503 is the only other status that may carry Retry-After, and it
+			// is deliberately not read: the retrier has no hint type for it and
+			// WithoutRateLimitRetry does not govern it.
+			name:       "a 503 is not a rate limit",
+			statusCode: http.StatusServiceUnavailable,
+			header:     http.Header{headerRetryAfter: []string{"12"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := tt.header
+			if header == nil {
+				header = http.Header{}
+			}
+
+			sink := &retryHint{}
+			ctx := withRetryHint(context.Background(), sink)
+			recordRetryHint(ctx, tt.statusCode, []byte(tt.body), header)
+
+			if sink.retryAfter != tt.want {
+				t.Errorf("recorded %v, want %v", sink.retryAfter, tt.want)
+			}
+		})
+	}
+}
+
+// TestRecordRetryHintWithoutASink pins that a call outside executeWithRetry —
+// every request Health makes — records nothing rather than panicking.
+func TestRecordRetryHintWithoutASink(_ *testing.T) {
+	recordRetryHint(context.Background(), http.StatusTooManyRequests, nil, http.Header{
+		headerRetryAfter: []string{"5"},
+	})
+}
+
+// TestRateLimitWaitFollowsTheHintEndToEnd walks the hint the whole way: the
+// service's envelope, through the transport, into the wait the retrier takes.
+//
+// The one test here that pays for a real wait, because Retry-After is measured
+// in whole seconds and there is no sub-second way to state it. The backoff it
+// replaces would be 10s or more, so a second is the cheapest honest assertion.
+func TestRateLimitWaitFollowsTheHintEndToEnd(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = fmt.Fprint(w, `{"error":"rate limit exceeded","code":"RATE_LIMITED","retryAfter":1}`)
+			return
+		}
+		_, _ = fmt.Fprint(w, testSignature)
+	}))
+	defer server.Close()
+
+	// backoff(1) here is at least 10s, so a run that ignores the hint cannot
+	// finish inside the assertion below by luck.
+	c, err := New(server.URL,
+		WithMaxRetries(2),
+		WithRetryWait(5*time.Second, 30*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	start := time.Now()
+	result, err := c.Sign(context.Background(), "commit data", "")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+	if result.Signature != testSignature {
+		t.Errorf("unexpected signature: %q", result.Signature)
+	}
+	if requests != 2 {
+		t.Errorf("expected 2 requests, got %d", requests)
+	}
+	if elapsed < time.Second {
+		t.Errorf("expected the call to honour the server's 1s hint, took %v", elapsed)
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("expected the 1s hint rather than the backoff, took %v", elapsed)
+	}
+}
+
+// TestDeadlineKeepsTheAnswerAlreadyInHand covers what a caller-side deadline
+// costs once statuses are retried.
+//
+// Do returns ctx.Err() from the backoff sleep, which is reached only *after* a
+// response arrived and was classified retryable — so the response that caused
+// the wait was in hand, unmapped, and thrown away for a timeout. The CLI hands
+// the same --timeout to WithTimeout and to its context, so any limit shorter
+// than one backoff turned "you are being throttled" into "context deadline
+// exceeded" and IsRateLimitError into false. Retries are an optimisation over
+// the response, not a precondition for it.
+func TestDeadlineKeepsTheAnswerAlreadyInHand(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		check  func(*testing.T, error)
+	}{
+		{
+			name:   "a 429 stays a rate limit",
+			status: http.StatusTooManyRequests,
+			body:   `{"error":"rate limit exceeded","code":"RATE_LIMITED","retryAfter":30}`,
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				var re *RateLimitError
+				if !errors.As(err, &re) {
+					t.Fatalf("expected a *RateLimitError, got %T: %v", err, err)
+				}
+				if re.RetryAfter != 30*time.Second {
+					t.Errorf("expected the server's 30s hint to survive, got %v", re.RetryAfter)
+				}
+			},
+		},
+		{
+			name:   "a 503 stays a service error",
+			status: http.StatusServiceUnavailable,
+			body:   `{"error":"unavailable","code":"INTERNAL_ERROR"}`,
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				if !IsServiceError(err) {
+					t.Fatalf("expected a service error, got %T: %v", err, err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_, _ = fmt.Fprint(w, tt.body)
+			}))
+			defer server.Close()
+
+			// The wait is an order of magnitude past the deadline either way,
+			// so the sleep is always what the deadline interrupts.
+			c, err := New(server.URL,
+				WithMaxRetries(3),
+				WithRetryWait(2*time.Second, 10*time.Second),
+			)
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
+
+			_, err = c.Sign(ctx, "commit data", "")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("the deadline outranked the answer the server gave: %v", err)
+			}
+			tt.check(t, err)
+		})
+	}
+}
+
+// TestDeadlineBeforeAnyAnswerStaysADeadline is the other side of it. With no
+// response in hand there is nothing to prefer over the timeout, and reporting
+// one anyway would be an invention.
+func TestDeadlineBeforeAnyAnswerStaysADeadline(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(func() {
+		close(release)
+		server.Close()
+	})
+
+	c, err := New(server.URL, WithMaxRetries(3), WithRetryWait(time.Millisecond, 5*time.Millisecond))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	if _, err := c.Sign(ctx, "commit data", ""); !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected the deadline to stand, got %T: %v", err, err)
+	}
+}
+
+// TestCancellationOutranksTheAnswer pins the asymmetry above deliberately.
+//
+// A caller whose deadline lapsed asked for an answer within N seconds and one
+// exists. A caller who cancelled asked to stop, and handing them a rate limit
+// error for a call they abandoned would report work rather than the abandoning.
+func TestCancellationOutranksTheAnswer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = fmt.Fprint(w, `{"error":"unavailable","code":"INTERNAL_ERROR"}`)
+	}))
+	defer server.Close()
+
+	c, err := New(server.URL, WithMaxRetries(3), WithRetryWait(2*time.Second, 10*time.Second))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+
+	if _, err := c.Sign(ctx, "commit data", ""); !errors.Is(err, context.Canceled) {
+		t.Errorf("expected the cancellation to stand, got %T: %v", err, err)
+	}
+}
+
+// TestRateLimitCarriesTheRequestID covers the id a 429 used to lose.
+//
+// newStatusError threads a request id onto every other status. The 429 branch
+// sits above the line that reads it — deliberately, because a 429 needs no
+// envelope to be understood — and RateLimitError had no field to put one on.
+// Admin's rate limiter sends no `requestId` in the body at all, so the echoed
+// header is the only source, which is precisely the case requestIDFrom's
+// fallback exists for and precisely what troubleshooting.md asks operators to
+// quote.
+func TestRateLimitCarriesTheRequestID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(headerRequestID, testErrRequestID)
+		w.WriteHeader(http.StatusTooManyRequests)
+		// The shape adminRateLimit sends: no requestId in the body.
+		_, _ = fmt.Fprint(w, `{"error":"rate limit exceeded","code":"RATE_LIMITED","retryAfter":3}`)
+	}))
+	defer server.Close()
+
+	c := newMappingClient(t, server.URL, WithAdminToken(testMsgTest))
+
+	// The undeclared path, through newStatusError's hand-parsed envelope.
+	_, err := c.ListKeys(context.Background())
+	var re *RateLimitError
+	if !errors.As(err, &re) {
+		t.Fatalf("ListKeys: expected a *RateLimitError, got %T: %v", err, err)
+	}
+	if re.RequestID != testErrRequestID {
+		t.Errorf("ListKeys: RequestID = %q, want %q", re.RequestID, testErrRequestID)
+	}
+	if !strings.Contains(re.Error(), testErrRequestID) {
+		t.Errorf("ListKeys: the id is not in the error text: %q", re.Error())
+	}
+
+	// The declared path, through /sign's typed JSON429. RateLimitErrorSchema
+	// declares no requestId, so this one can only come from the header.
+	_, err = c.Sign(context.Background(), "commit data", "")
+	re = nil
+	if !errors.As(err, &re) {
+		t.Fatalf("Sign: expected a *RateLimitError, got %T: %v", err, err)
+	}
+	if re.RequestID != testErrRequestID {
+		t.Errorf("Sign: RequestID = %q, want %q", re.RequestID, testErrRequestID)
+	}
+}
+
+// TestDeleteKeyRetriedPastACommitReportsSuccess covers the one retried mutation
+// whose *answer* does not converge even though its state does.
+//
+// The handler reports whether the key was there when that attempt ran, so a
+// delete that committed and then lost its response — the audit write after it
+// throws, the connection drops mid-body — is answered `deleted:false` by the
+// next attempt. Mapped naively that is KEY_NOT_FOUND for a key this call
+// removed, and the CLI treats not-found as an idempotent no-op: it prints
+// {"deleted":false} and exits 0 for work it did do.
+func TestDeleteKeyRetriedPastACommitReportsSuccess(t *testing.T) {
+	requests := 0
+	deleted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			// The delete committed; the audit write that follows it did not.
+			deleted = true
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = fmt.Fprint(w, `{"error":"Failed to delete key","code":"INTERNAL_ERROR"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"success":true,"deleted":%t}`, !deleted)
+	}))
+	defer server.Close()
+
+	c, err := New(server.URL,
+		WithAdminToken(testMsgTest),
+		WithMaxRetries(2),
+		WithRetryWait(time.Millisecond, 5*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	if err := c.DeleteKey(context.Background(), testKeyID); err != nil {
+		t.Fatalf("expected the delete to be reported as done, got %T: %v", err, err)
+	}
+	if requests != 2 {
+		t.Errorf("expected 2 requests, got %d", requests)
+	}
+}
+
+// TestDeleteKeyNotFoundOnTheFirstAttemptStaysNotFound pins the other half: with
+// no earlier attempt, `deleted:false` means what it says and the narrowing
+// above must not swallow it.
+func TestDeleteKeyNotFoundOnTheFirstAttemptStaysNotFound(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"success":true,"deleted":false}`)
+	}))
+	defer server.Close()
+
+	c, err := New(server.URL,
+		WithAdminToken(testMsgTest),
+		WithMaxRetries(2),
+		WithRetryWait(time.Millisecond, 5*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	err = c.DeleteKey(context.Background(), testKeyIDMissing)
+	if !IsKeyNotFound(err) {
+		t.Fatalf("expected KEY_NOT_FOUND, got %T: %v", err, err)
+	}
+	if requests != 1 {
+		t.Errorf("expected 1 request, got %d", requests)
+	}
+}

--- a/client/pkg/client/retry_status_test.go
+++ b/client/pkg/client/retry_status_test.go
@@ -152,6 +152,9 @@ func TestParseRetryAfter(t *testing.T) {
 			want:  30 * time.Second,
 		},
 		{name: "a date already past is no hint", value: "Wed, 26 Aug 2026 11:00:00 GMT"},
+		// Atoi accepts it, time.Duration does not: the multiply wraps to -775ms.
+		{name: "seconds past what a Duration holds is no hint", value: "9223372036854"},
+		{name: "seconds past int64 is no hint", value: "99999999999999999999"},
 	}
 
 	for _, tt := range tests {

--- a/client/pkg/client/retry_status_test.go
+++ b/client/pkg/client/retry_status_test.go
@@ -356,9 +356,11 @@ func TestRetryAfterHeaderDateReachesTheCaller(t *testing.T) {
 	if !errors.As(err, &re) {
 		t.Fatalf("expected a *RateLimitError, got %T: %v", err, err)
 	}
-	// The header carries whole seconds and the round trip eats some of them.
-	if re.RetryAfter <= 80*time.Second || re.RetryAfter > 90*time.Second {
-		t.Errorf("expected roughly 90s from the date-form header, got %v", re.RetryAfter)
+	// A lower bound in seconds would be a stalled-runner flake whose failure
+	// message teaches nothing. What the test is about is that a date-form
+	// header produces a hint at all, and one no larger than the delay sent.
+	if re.RetryAfter <= 0 || re.RetryAfter > 90*time.Second {
+		t.Errorf("expected a positive hint of at most 90s from the date-form header, got %v", re.RetryAfter)
 	}
 }
 
@@ -393,7 +395,13 @@ func TestNegativeMaxRetriesIsRejected(t *testing.T) {
 // Held to milliseconds, with an order of magnitude between the handler's delay
 // and the timeout, so the arithmetic is the only thing under test.
 func TestTimeoutBoundsOneAttemptNotTheCall(t *testing.T) {
-	const perCall = 200 * time.Millisecond
+	// The two numbers are set apart deliberately. The timeout has to be far
+	// enough above the handler's 20ms that a stalled runner cannot trip it —
+	// that would turn the *ServiceError assertion into a *url.Error and read as
+	// a logic bug rather than a slow machine — while the backoffs have to add
+	// up to more than the timeout for the point of the test to hold at all.
+	// 20ms per attempt under a 400ms timeout, against 3 x 200ms of backoff.
+	const perCall = 400 * time.Millisecond
 
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -408,7 +416,7 @@ func TestTimeoutBoundsOneAttemptNotTheCall(t *testing.T) {
 	c, err := New(server.URL,
 		WithTimeout(perCall),
 		WithMaxRetries(3),
-		WithRetryWait(60*time.Millisecond, 120*time.Millisecond),
+		WithRetryWait(150*time.Millisecond, 200*time.Millisecond),
 	)
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)

--- a/client/pkg/client/retry_status_test.go
+++ b/client/pkg/client/retry_status_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -123,6 +124,176 @@ func TestOpaqueRateLimitIsStillRateLimited(t *testing.T) {
 
 	if _, err := c.Sign(context.Background(), "commit data", ""); !IsRateLimitError(err) {
 		t.Errorf("Sign: expected a rate limit error, got %T: %v", err, err)
+	}
+}
+
+// TestSignRetrySendsTheBodyAgain pins the invariant executeWithRetry rests on:
+// the closure must build the request body afresh on every attempt.
+//
+// Sign's reader is constructed inside the closure, which is correct and was
+// load-bearing the moment a status became retryable — a reader hoisted out is
+// drained by attempt one and every attempt after it POSTs an empty body. The
+// existing tests count requests and read the final response, so they pass
+// either way; nothing looked at what arrived. This does.
+func TestSignRetrySendsTheBodyAgain(t *testing.T) {
+	const commitData = "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\nauthor A <a@example.com>"
+	const signature = "-----BEGIN PGP SIGNATURE-----\n\nsig\n-----END PGP SIGNATURE-----"
+
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading request body: %v", err)
+			return
+		}
+		bodies = append(bodies, string(body))
+		if len(bodies) == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = fmt.Fprint(w, `{"error":"unavailable","code":"SERVICE_UNAVAILABLE"}`)
+			return
+		}
+		_, _ = fmt.Fprint(w, signature)
+	}))
+	defer server.Close()
+
+	c, err := New(server.URL,
+		WithMaxRetries(2),
+		WithRetryWait(time.Millisecond, 5*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	if _, err := c.Sign(context.Background(), commitData, ""); err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(bodies))
+	}
+	for i, body := range bodies {
+		if body != commitData {
+			t.Errorf("request %d carried %q, want the commit data", i+1, body)
+		}
+	}
+}
+
+// TestSignRetriesBodyTruncatedMidRead covers the transport fault that does not
+// look like one.
+//
+// The generated client reads the body with io.ReadAll inside Parse…Response,
+// well past the *url.Error the round trip returned, so a connection dropped
+// after the headers arrived comes back as a bare io.ErrUnexpectedEOF. Testing
+// only for *url.Error missed it, while README listed "a connection dropped
+// mid-body" among the faults this retries — the same shape of gap this file
+// exists to close, one layer further in.
+func TestSignRetriesBodyTruncatedMidRead(t *testing.T) {
+	const signature = "-----BEGIN PGP SIGNATURE-----\n\nsig\n-----END PGP SIGNATURE-----"
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			// Promise more than is sent, then hang up: the client reads the
+			// status and headers, then runs out of body.
+			w.Header().Set("Content-Type", "text/plain")
+			w.Header().Set("Content-Length", "512")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("-----BEGIN PGP SIG"))
+			conn, _, err := http.NewResponseController(w).Hijack()
+			if err != nil {
+				t.Errorf("hijack failed: %v", err)
+				return
+			}
+			_ = conn.Close()
+			return
+		}
+		_, _ = fmt.Fprint(w, signature)
+	}))
+	defer server.Close()
+
+	c, err := New(server.URL,
+		WithMaxRetries(2),
+		WithRetryWait(time.Millisecond, 5*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	result, err := c.Sign(context.Background(), "commit data", "")
+	if err != nil {
+		t.Fatalf("truncated body was not retried: %v", err)
+	}
+	if result.Signature != signature {
+		t.Errorf("unexpected signature: %q", result.Signature)
+	}
+	if requests != 2 {
+		t.Errorf("expected 2 requests, got %d", requests)
+	}
+}
+
+// TestMalformedBodyIsNotRetried pins the other side of that line.
+//
+// A response that arrived whole and failed to decode is not a transport fault:
+// the bytes are in hand and the next attempt parses exactly as badly. json
+// reports a truncated document as *json.SyntaxError and never wraps
+// io.ErrUnexpectedEOF, so recognising the truncated *read* must not drag the
+// truncated *document* along with it.
+func TestMalformedBodyIsNotRetried(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"keys":[`)
+	}))
+	defer server.Close()
+
+	c, err := New(server.URL,
+		WithAdminToken(testMsgTest),
+		WithMaxRetries(3),
+		WithRetryWait(time.Millisecond, 5*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	if _, err := c.ListKeys(context.Background()); err == nil {
+		t.Fatal("expected a decode error")
+	}
+	if requests != 1 {
+		t.Errorf("expected the malformed body to be final, got %d requests", requests)
+	}
+}
+
+// TestHalfEnvelopeRateLimitKeepsItsBody covers a 429 whose body parsed cleanly
+// but is not an envelope: `error` and `retryAfter` with no `code`, which is
+// what an intermediary that knows the shape but not the vocabulary emits.
+//
+// The 429 branch sits above the parse gate, so it reads a value the gate
+// rejected. Zeroing that value on rejection threw away a message and a hint
+// that had both survived json.Unmarshal — the hoist survived the type of the
+// body but not its contents.
+func TestHalfEnvelopeRateLimitKeepsItsBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"error":"Too many requests, slow down","retryAfter":7}`)
+	}))
+	defer server.Close()
+
+	c := newMappingClient(t, server.URL, WithAdminToken(testMsgTest))
+
+	_, err := c.ListKeys(context.Background())
+	var re *RateLimitError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected a *RateLimitError, got %T: %v", err, err)
+	}
+	if re.Message != "Too many requests, slow down" {
+		t.Errorf("expected the body's message, got %q", re.Message)
+	}
+	if re.RetryAfter != 7*time.Second {
+		t.Errorf("expected the body's 7s hint, got %v", re.RetryAfter)
 	}
 }
 

--- a/client/pkg/client/retry_status_test.go
+++ b/client/pkg/client/retry_status_test.go
@@ -1,0 +1,204 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestSignRetriesTransportFaults covers the half of the retry policy that never
+// worked in either direction.
+//
+// shouldRetry fell through to false for everything it did not recognise, and a
+// transport fault is recognised by nothing above that fallthrough — it arrives
+// as a bare *url.Error. So a dropped connection, the textbook case for another
+// attempt, came back to the caller on attempt one while README and the Health
+// comment both said it retried. The server hangs up mid-handshake once and then
+// answers normally; a working policy sees the signature.
+func TestSignRetriesTransportFaults(t *testing.T) {
+	const signature = "-----BEGIN PGP SIGNATURE-----\n\nsig\n-----END PGP SIGNATURE-----"
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			// Hijack and close without writing a response: the client sees EOF,
+			// which is the shape a dropped connection actually has.
+			conn, _, err := http.NewResponseController(w).Hijack()
+			if err != nil {
+				t.Errorf("hijack failed: %v", err)
+				return
+			}
+			_ = conn.Close()
+			return
+		}
+		_, _ = fmt.Fprint(w, signature)
+	}))
+	defer server.Close()
+
+	c, err := New(server.URL,
+		WithMaxRetries(2),
+		WithRetryWait(time.Millisecond, 5*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	result, err := c.Sign(context.Background(), "commit data", "")
+	if err != nil {
+		t.Fatalf("transport fault was not retried: %v", err)
+	}
+	if result.Signature != signature {
+		t.Errorf("unexpected signature: %q", result.Signature)
+	}
+	if requests != 2 {
+		t.Errorf("expected 2 requests, got %d", requests)
+	}
+}
+
+// TestSignDoesNotRetryCancelledContext pins the one error the transport-fault
+// default must not swallow. Retrying a dead context burns the whole budget on
+// attempts that fail identically and instantly.
+func TestSignDoesNotRetryCancelledContext(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c, err := New(server.URL, WithMaxRetries(5), WithRetryWait(time.Millisecond, 5*time.Millisecond))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := c.Sign(ctx, "commit data", ""); err == nil {
+		t.Fatal("expected an error")
+	}
+	if requests != 0 {
+		t.Errorf("expected the cancelled context to stop before any request, got %d", requests)
+	}
+}
+
+// TestOpaqueRateLimitIsStillRateLimited covers the 429 this service did not
+// write: an edge throttle answering with a page and a Retry-After header.
+//
+// It is not a usable error envelope, so the parse gate used to turn it into the
+// bare "unexpected status code: 429" sentinel — IsRateLimitError false, the
+// CLI's throttling message unreachable, and the header hint discarded by the
+// one function added to read it. It is also the only 429 that ever reaches that
+// header fallback, since this service always sends `retryAfter` alongside a
+// body.
+func TestOpaqueRateLimitIsStillRateLimited(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, "<html><body>error 1015</body></html>")
+	}))
+	defer server.Close()
+
+	c := newMappingClient(t, server.URL, WithAdminToken(testMsgTest))
+
+	_, err := c.ListKeys(context.Background())
+	var re *RateLimitError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected a *RateLimitError, got %T: %v", err, err)
+	}
+	if re.RetryAfter != 60*time.Second {
+		t.Errorf("expected the header's 60s hint, got %v", re.RetryAfter)
+	}
+	// Without a body to quote, the status text stands in — an empty Message
+	// would print as a dangling "rate limited: ".
+	if re.Message != http.StatusText(http.StatusTooManyRequests) {
+		t.Errorf("expected the status text as the message, got %q", re.Message)
+	}
+
+	if _, err := c.Sign(context.Background(), "commit data", ""); !IsRateLimitError(err) {
+		t.Errorf("Sign: expected a rate limit error, got %T: %v", err, err)
+	}
+}
+
+// TestParseRetryAfter covers both forms RFC 9110 permits for the header.
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{name: "delay seconds", value: "30", want: 30 * time.Second},
+		{name: "surrounding space", value: "  30  ", want: 30 * time.Second},
+		{name: "zero seconds is no hint", value: "0"},
+		{name: "negative seconds is no hint", value: "-5"},
+		{name: "empty is no hint", value: ""},
+		{name: "prose is no hint", value: "soon"},
+		{
+			name:  "IMF-fixdate",
+			value: "Wed, 26 Aug 2026 12:01:00 GMT",
+			want:  time.Minute,
+		},
+		{
+			name:  "RFC 850, which a recipient must still understand",
+			value: "Wednesday, 26-Aug-26 12:00:30 GMT",
+			want:  30 * time.Second,
+		},
+		{name: "a date already past is no hint", value: "Wed, 26 Aug 2026 11:00:00 GMT"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseRetryAfter(tt.value, now); got != tt.want {
+				t.Errorf("parseRetryAfter(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRetryAfterHeaderDateReachesTheCaller walks a date-form header the whole
+// way through the client, since parseRetryAfter being right is only half of it.
+func TestRetryAfterHeaderDateReachesTheCaller(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Retry-After", time.Now().Add(90*time.Second).UTC().Format(http.TimeFormat))
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, "throttled")
+	}))
+	defer server.Close()
+
+	c := newMappingClient(t, server.URL, WithAdminToken(testMsgTest))
+
+	_, err := c.ListKeys(context.Background())
+	var re *RateLimitError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected a *RateLimitError, got %T: %v", err, err)
+	}
+	// The header carries whole seconds and the round trip eats some of them.
+	if re.RetryAfter <= 80*time.Second || re.RetryAfter > 90*time.Second {
+		t.Errorf("expected roughly 90s from the date-form header, got %v", re.RetryAfter)
+	}
+}
+
+// TestNegativeMaxRetriesIsRejected pins where a negative budget is caught.
+//
+// Do's loop runs while `attempt <= maxRetries`, so a negative value would skip
+// it entirely and return a nil error having called nothing, leaving every
+// operation to dereference a nil response. New refuses to build such a client,
+// which is why no operation has to defend against one.
+func TestNegativeMaxRetriesIsRejected(t *testing.T) {
+	c, err := New("http://example.invalid", WithMaxRetries(-1))
+	if err == nil {
+		t.Fatalf("expected New to reject a negative retry budget, got %#v", c)
+	}
+	if c != nil {
+		t.Errorf("expected a nil client alongside the error, got %#v", c)
+	}
+}

--- a/client/pkg/client/retry_status_test.go
+++ b/client/pkg/client/retry_status_test.go
@@ -376,3 +376,55 @@ func TestNegativeMaxRetriesIsRejected(t *testing.T) {
 		t.Errorf("expected a nil client alongside the error, got %#v", c)
 	}
 }
+
+// TestTimeoutBoundsOneAttemptNotTheCall pins what WithTimeout actually bounds.
+//
+// http.Client applies its Timeout per request, so each attempt is handed a
+// fresh one — and a server answering promptly with a retryable status never
+// trips it at all. Connecting the retry policy to statuses is what made that
+// visible: before it, a 503 ended the call on attempt one and the configured
+// timeout was the only clock. It is now four attempts plus the backoff between
+// them, which on the defaults is a WithTimeout(30s) call of up to 2m15s. A
+// caller who wants one budget for the operation passes a context deadline,
+// which Do checks before every wait — TestSignDoesNotRetryCancelledContext
+// covers that side.
+//
+// Held to milliseconds, with an order of magnitude between the handler's delay
+// and the timeout, so the arithmetic is the only thing under test.
+func TestTimeoutBoundsOneAttemptNotTheCall(t *testing.T) {
+	const perCall = 200 * time.Millisecond
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		time.Sleep(20 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = fmt.Fprint(w, `{"error":"unavailable","code":"INTERNAL_ERROR"}`)
+	}))
+	defer server.Close()
+
+	c, err := New(server.URL,
+		WithTimeout(perCall),
+		WithMaxRetries(3),
+		WithRetryWait(60*time.Millisecond, 120*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	start := time.Now()
+	_, err = c.Sign(context.Background(), "commit data", "")
+	elapsed := time.Since(start)
+
+	var se *ServiceError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected a *ServiceError, got %T: %v", err, err)
+	}
+	if requests != 4 {
+		t.Errorf("expected 4 attempts, got %d", requests)
+	}
+	if elapsed <= perCall {
+		t.Errorf("expected the call to outlast WithTimeout(%v), took %v", perCall, elapsed)
+	}
+}

--- a/client/pkg/client/retry_status_test.go
+++ b/client/pkg/client/retry_status_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -426,5 +427,71 @@ func TestTimeoutBoundsOneAttemptNotTheCall(t *testing.T) {
 	}
 	if elapsed <= perCall {
 		t.Errorf("expected the call to outlast WithTimeout(%v), took %v", perCall, elapsed)
+	}
+}
+
+// TestExpiredTimeoutEndsTheCall pins the other half of what WithTimeout does.
+//
+// The test above covers a timeout that never fires — a server answering
+// promptly with a retryable status. This one covers a timeout that does fire,
+// and the rule is the opposite: an attempt that ran out of time is final,
+// because the next one is handed the same duration and the same slow server.
+//
+// It rests entirely on an ordering inside shouldRetry. net/http renders an
+// exceeded Client.Timeout as a *url.Error wrapping "context deadline exceeded
+// (Client.Timeout exceeded while awaiting headers)", which also satisfies
+// errors.Is against context.DeadlineExceeded — so both the context branch and
+// the *url.Error branch below it match, and only the fact that the context one
+// is written first ends the call. Nothing asserted that: moving the context
+// branch below the transport branch left `task c:t` green while turning a
+// WithTimeout(30s) call against an unresponsive server into four of them plus
+// backoff. The comment above the branch and README's "It never retries: a
+// cancelled or expired context" both describe this; now something checks it.
+//
+// The handler parks until the client hangs up rather than sleeping a fixed
+// span, so a passing run costs one timeout instead of one sleep, and a
+// regression costs four timeouts rather than hanging. That also makes this the
+// one test here whose handler is still running when the call returns, which is
+// why the counter is atomic where the rest of the file uses a plain int: every
+// other handler has written its response by then, and the round trip is the
+// happens-before this one does not get.
+func TestExpiredTimeoutEndsTheCall(t *testing.T) {
+	const perCall = 100 * time.Millisecond
+
+	var requests atomic.Int32
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		// Never answers. Returns when the client gives up, or at teardown.
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(func() {
+		close(release)
+		server.Close()
+	})
+
+	c, err := New(server.URL,
+		WithTimeout(perCall),
+		WithMaxRetries(3),
+		WithRetryWait(60*time.Millisecond, 120*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	_, err = c.Sign(context.Background(), "commit data", "")
+	if err == nil {
+		t.Fatal("expected the expired timeout to surface as an error")
+	}
+	// The caller still learns it was a timeout rather than a status.
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected an error satisfying context.DeadlineExceeded, got %T: %v", err, err)
+	}
+
+	if got := requests.Load(); got != 1 {
+		t.Errorf("expected an expired timeout to be final after 1 attempt, got %d", got)
 	}
 }

--- a/client/pkg/client/sign_test.go
+++ b/client/pkg/client/sign_test.go
@@ -714,3 +714,78 @@ func TestAdminUndeclaredRateLimit(t *testing.T) {
 		t.Errorf("expected 1 request with retries off, got %d", requests)
 	}
 }
+
+// TestSignDeclaredRateLimitFallbacks covers the 429 the document declares,
+// answered by something other than this service.
+//
+// /sign is the one operation with a declared 429, so its body is unmarshalled
+// into the typed RateLimitError and never reaches newStatusError. Both cases
+// below are an edge throttle's own JSON in front of the service, and each broke
+// a different part of the typed path:
+//
+//   - A body with none of the envelope's fields decodes into the typed value
+//     and fills nothing — every field is optional to encoding/json — so the
+//     error printed as a bare "rate limited: " and the hint on the header
+//     alongside it was dropped. TestAdminUndeclaredRateLimit is this case with
+//     the endpoint swapped, and it has always passed.
+//   - `retryAfter` is an int in RateLimitError and absent from ErrorResponse,
+//     so a responder that stringifies its numbers produced a body that passed
+//     errorBodyTransport's guard and then died inside the generated parser's
+//     `return nil, err`, taking the status, the sentinel and every classifier
+//     with it — the regression that transport exists to prevent.
+//
+// Either way the caller has to end up holding a rate limit it can act on.
+func TestSignDeclaredRateLimitFallbacks(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		retryAfter  string
+		wantMessage string
+		wantWait    time.Duration
+	}{
+		{
+			name:        "no envelope fields falls back to status text and header",
+			body:        `{"message":"slow down"}`,
+			retryAfter:  "30",
+			wantMessage: http.StatusText(http.StatusTooManyRequests),
+			wantWait:    30 * time.Second,
+		},
+		{
+			// apiErrorBody declares `retryAfter` as an int too, so the hand parse
+			// declines the same body — but it declines it the way every
+			// unparseable body is declined, falling back to the status text and
+			// the header, rather than by destroying the response.
+			name:        "off-schema retryAfter survives as a rate limit",
+			body:        `{"error":"too many requests","code":"RATE_LIMITED","retryAfter":"60"}`,
+			retryAfter:  "12",
+			wantMessage: http.StatusText(http.StatusTooManyRequests),
+			wantWait:    12 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Retry-After", tt.retryAfter)
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = fmt.Fprint(w, tt.body)
+			}))
+			defer server.Close()
+
+			c := newMappingClient(t, server.URL)
+			_, err := c.Sign(context.Background(), "commit data", "")
+
+			var re *RateLimitError
+			if !errors.As(err, &re) {
+				t.Fatalf("expected a *RateLimitError, got %T: %v", err, err)
+			}
+			if re.Message != tt.wantMessage {
+				t.Errorf("Message = %q, want %q", re.Message, tt.wantMessage)
+			}
+			if re.RetryAfter != tt.wantWait {
+				t.Errorf("RetryAfter = %v, want %v", re.RetryAfter, tt.wantWait)
+			}
+		})
+	}
+}

--- a/client/pkg/client/sign_test.go
+++ b/client/pkg/client/sign_test.go
@@ -586,6 +586,44 @@ func TestSignRetriesRealStatusResponses(t *testing.T) {
 			wantRequests: 2,
 		},
 		{
+			// 502 and 504 are the two arms of retryStatusSignal's 5xx switch
+			// that no other case reaches. Without them the switch can lose
+			// either one and nothing in the suite notices.
+			name:         "a bad gateway is retried and then succeeds",
+			failures:     1,
+			status:       http.StatusBadGateway,
+			body:         `{"error":"bad gateway","code":"INTERNAL_ERROR"}`,
+			wantRequests: 2,
+		},
+		{
+			name:         "a gateway timeout is retried and then succeeds",
+			failures:     1,
+			status:       http.StatusGatewayTimeout,
+			body:         `{"error":"gateway timeout","code":"INTERNAL_ERROR"}`,
+			wantRequests: 2,
+		},
+		{
+			// The narrowing this change argues for: a 5xx describing what the
+			// server will never do is not a state it may be out of next time,
+			// so re-asking only spends the caller's budget. Asserted here
+			// because the README and the 5xx switch both promise it and
+			// neither was pinned.
+			name:         "a 501 is not retried",
+			failures:     99,
+			status:       http.StatusNotImplemented,
+			body:         `{"error":"not implemented","code":"INTERNAL_ERROR"}`,
+			wantRequests: 1,
+			wantErr:      true,
+		},
+		{
+			name:         "a 505 is not retried",
+			failures:     99,
+			status:       http.StatusHTTPVersionNotSupported,
+			body:         `{"error":"version not supported","code":"INTERNAL_ERROR"}`,
+			wantRequests: 1,
+			wantErr:      true,
+		},
+		{
 			name:         "retries are bounded by maxRetries",
 			failures:     99,
 			status:       http.StatusInternalServerError,

--- a/client/pkg/client/sign_test.go
+++ b/client/pkg/client/sign_test.go
@@ -553,9 +553,10 @@ func TestSignUndocumentedStatusWithBody(t *testing.T) {
 // which is why a gap sat here unseen: a 429 or a 500 is a *successful* round
 // trip, so the closure the client used to pass reported a nil error and the
 // retrier saw nothing to retry. shouldRetry's RateLimitError and 5xx branches
-// were unreachable against a real server, WithoutRateLimitRetry() toggled
-// nothing, and retryWaitMin/Max governed transport faults alone. Only a test
-// that counts requests arriving at a server can tell the difference.
+// were unreachable against a real server and WithoutRateLimitRetry() toggled
+// nothing. Only a test that counts requests arriving at a server can tell the
+// difference. TestSignRetriesTransportFaults covers the other half: the faults
+// that did reach shouldRetry were dropped by its fallthrough.
 func TestSignRetriesRealStatusResponses(t *testing.T) {
 	const signature = "-----BEGIN PGP SIGNATURE-----\n\nsig\n-----END PGP SIGNATURE-----"
 
@@ -665,7 +666,7 @@ func TestSignRateLimitKeepsRetryAfter(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := newMappingClient(t, server.URL, WithMaxRetries(0))
+	c := newMappingClient(t, server.URL)
 	_, err := c.Sign(context.Background(), "commit data", "")
 	if !IsRateLimitError(err) {
 		t.Fatalf("expected a rate limit error, got %T: %v", err, err)
@@ -695,7 +696,7 @@ func TestAdminUndeclaredRateLimit(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := newMappingClient(t, server.URL, WithMaxRetries(0))
+	c := newMappingClient(t, server.URL)
 	_, err := c.ListKeys(context.Background())
 	if !IsRateLimitError(err) {
 		t.Fatalf("expected a rate limit error, got %T: %v", err, err)

--- a/client/pkg/client/sign_test.go
+++ b/client/pkg/client/sign_test.go
@@ -21,7 +21,7 @@ func TestSignValidation(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL)
+	client := newMappingClient(t, server.URL)
 
 	tests := []struct {
 		name       string
@@ -67,7 +67,7 @@ func TestSignSuccessResponse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL)
+	client := newMappingClient(t, server.URL)
 	result, err := client.Sign(context.Background(), "commit data", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -93,7 +93,7 @@ func TestSignWithRateLimitHeaders(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL)
+	client := newMappingClient(t, server.URL)
 	result, err := client.Sign(context.Background(), "commit data", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -115,7 +115,7 @@ func TestSignWithKeyID(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL)
+	client := newMappingClient(t, server.URL)
 	result, err := client.Sign(context.Background(), "commit data", "test-key-123")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -428,11 +428,11 @@ func TestSignKeyNotAllowed(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = fmt.Fprint(w, `{"error":"Token is not allowed to sign with key BBBBBBBBBBBBBBBB",`+
-			`"code":"KEY_NOT_ALLOWED","requestId":"1b4e28ba-2fa1-11d2-883f-0016d3cca427"}`)
+			`"code":"KEY_NOT_ALLOWED","requestId":"`+testErrRequestID+`"}`)
 	}))
 	defer server.Close()
 
-	c, _ := New(server.URL)
+	c := newMappingClient(t, server.URL)
 	_, err := c.Sign(context.Background(), "commit data", "BBBBBBBBBBBBBBBB")
 	if err == nil {
 		t.Fatal("expected an error for a 403 response")
@@ -454,7 +454,7 @@ func TestSignKeyNotAllowed(t *testing.T) {
 	if !strings.Contains(se.Message, "not allowed to sign") {
 		t.Errorf("server message was discarded: %q", se.Message)
 	}
-	if se.RequestID != "1b4e28ba-2fa1-11d2-883f-0016d3cca427" {
+	if se.RequestID != testErrRequestID {
 		t.Errorf("request id was discarded: %q", se.RequestID)
 	}
 }
@@ -469,11 +469,11 @@ func TestSignUntrustedSubject(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = fmt.Fprint(w, `{"error":"Subject is not trusted for signing",`+
-			`"code":"AUTH_INVALID","requestId":"1b4e28ba-2fa1-11d2-883f-0016d3cca427"}`)
+			`"code":"AUTH_INVALID","requestId":"`+testErrRequestID+`"}`)
 	}))
 	defer server.Close()
 
-	c, _ := New(server.URL)
+	c := newMappingClient(t, server.URL)
 	_, err := c.Sign(context.Background(), "commit data", "")
 	if err == nil {
 		t.Fatal("expected an error for a 401 response")
@@ -495,7 +495,7 @@ func TestSignUntrustedSubject(t *testing.T) {
 	if ae.Code != testCodeAuthInvalid {
 		t.Errorf("error code was discarded: %q", ae.Code)
 	}
-	if ae.RequestID != "1b4e28ba-2fa1-11d2-883f-0016d3cca427" {
+	if ae.RequestID != testErrRequestID {
 		t.Errorf("request id was discarded: %q", ae.RequestID)
 	}
 	if !strings.Contains(err.Error(), "Subject is not trusted for signing") {
@@ -511,7 +511,7 @@ func TestSignAuthErrorWithoutBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c, _ := New(server.URL)
+	c := newMappingClient(t, server.URL)
 	_, err := c.Sign(context.Background(), "commit data", "")
 	if !errors.Is(err, ErrUnexpectedStatus) {
 		t.Fatalf("expected the unexpected-status sentinel, got %v", err)
@@ -531,7 +531,7 @@ func TestSignUndocumentedStatusWithBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c, _ := New(server.URL)
+	c := newMappingClient(t, server.URL)
 	_, err := c.Sign(context.Background(), "commit data", "")
 
 	var se *ServiceError
@@ -543,5 +543,173 @@ func TestSignUndocumentedStatusWithBody(t *testing.T) {
 	}
 	if se.Message != "brewing refused" {
 		t.Errorf("server message was discarded: %q", se.Message)
+	}
+}
+
+// TestSignRetriesRealStatusResponses drives the retry policy through an actual
+// HTTP server rather than a synthetic closure.
+//
+// The unit tests around Retrier hand it functions that return errors directly,
+// which is why a gap sat here unseen: a 429 or a 500 is a *successful* round
+// trip, so the closure the client used to pass reported a nil error and the
+// retrier saw nothing to retry. shouldRetry's RateLimitError and 5xx branches
+// were unreachable against a real server, WithoutRateLimitRetry() toggled
+// nothing, and retryWaitMin/Max governed transport faults alone. Only a test
+// that counts requests arriving at a server can tell the difference.
+func TestSignRetriesRealStatusResponses(t *testing.T) {
+	const signature = "-----BEGIN PGP SIGNATURE-----\n\nsig\n-----END PGP SIGNATURE-----"
+
+	tests := []struct {
+		name string
+		// failures is how many attempts answer with status before one succeeds;
+		// a count above maxRetries means every attempt fails.
+		failures     int
+		status       int
+		body         string
+		opts         []Option
+		wantRequests int
+		wantErr      bool
+	}{
+		{
+			name:         "rate limit is retried and then succeeds",
+			failures:     2,
+			status:       http.StatusTooManyRequests,
+			body:         `{"error":"rate limit exceeded","code":"RATE_LIMITED","retryAfter":1}`,
+			wantRequests: 3,
+		},
+		{
+			name:         "server error is retried and then succeeds",
+			failures:     1,
+			status:       http.StatusInternalServerError,
+			body:         `{"error":"boom","code":"INTERNAL_ERROR"}`,
+			wantRequests: 2,
+		},
+		{
+			name:         "retries are bounded by maxRetries",
+			failures:     99,
+			status:       http.StatusInternalServerError,
+			body:         `{"error":"boom","code":"INTERNAL_ERROR"}`,
+			wantRequests: 3,
+			wantErr:      true,
+		},
+		{
+			name:         "WithoutRateLimitRetry stops after the first 429",
+			failures:     99,
+			status:       http.StatusTooManyRequests,
+			body:         `{"error":"rate limit exceeded","code":"RATE_LIMITED","retryAfter":1}`,
+			opts:         []Option{WithoutRateLimitRetry()},
+			wantRequests: 1,
+			wantErr:      true,
+		},
+		{
+			name:         "a refusal the caller cannot fix is not retried",
+			failures:     99,
+			status:       http.StatusUnauthorized,
+			body:         `{"error":"Subject is not trusted for signing","code":"AUTH_INVALID"}`,
+			wantRequests: 1,
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests++
+				if requests > tt.failures {
+					w.WriteHeader(http.StatusOK)
+					_, _ = fmt.Fprint(w, signature)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_, _ = fmt.Fprint(w, tt.body)
+			}))
+			defer server.Close()
+
+			// Waits are held to milliseconds: the point is how many requests
+			// arrive, not how long the backoff sleeps between them.
+			opts := append([]Option{
+				WithMaxRetries(2),
+				WithRetryWait(time.Millisecond, 5*time.Millisecond),
+			}, tt.opts...)
+
+			c, err := New(server.URL, opts...)
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
+
+			_, err = c.Sign(context.Background(), "commit data", "")
+			if tt.wantErr && err == nil {
+				t.Fatal("expected an error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if requests != tt.wantRequests {
+				t.Errorf("expected %d requests, got %d", tt.wantRequests, requests)
+			}
+		})
+	}
+}
+
+// TestSignRateLimitKeepsRetryAfter checks that the hint survives the retries.
+// The retrier's own waits are exponential, but what the caller is finally handed
+// must still say how long the service asked it to wait.
+func TestSignRateLimitKeepsRetryAfter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "7")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"error":"rate limit exceeded","code":"RATE_LIMITED","retryAfter":42}`)
+	}))
+	defer server.Close()
+
+	c := newMappingClient(t, server.URL, WithMaxRetries(0))
+	_, err := c.Sign(context.Background(), "commit data", "")
+	if !IsRateLimitError(err) {
+		t.Fatalf("expected a rate limit error, got %T: %v", err, err)
+	}
+
+	var re *RateLimitError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected a *RateLimitError, got %T", err)
+	}
+	if re.RetryAfter != 42*time.Second {
+		t.Errorf("expected the envelope's 42s hint, got %v", re.RetryAfter)
+	}
+}
+
+// TestAdminUndeclaredRateLimit covers a 429 on an operation the document does
+// not declare one for. It reaches the caller through the envelope fallback, and
+// must still arrive as a rate limit: IsRateLimitError, the retry policy and the
+// CLI's throttling message all key off the type, not the status.
+func TestAdminUndeclaredRateLimit(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "3")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"error":"too many requests","code":"RATE_LIMITED"}`)
+	}))
+	defer server.Close()
+
+	c := newMappingClient(t, server.URL, WithMaxRetries(0))
+	_, err := c.ListKeys(context.Background())
+	if !IsRateLimitError(err) {
+		t.Fatalf("expected a rate limit error, got %T: %v", err, err)
+	}
+
+	var re *RateLimitError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected a *RateLimitError, got %T", err)
+	}
+	// No `retryAfter` in the body, so the header is the only source left.
+	if re.RetryAfter != 3*time.Second {
+		t.Errorf("expected the header's 3s hint, got %v", re.RetryAfter)
+	}
+	if requests != 1 {
+		t.Errorf("expected 1 request with retries off, got %d", requests)
 	}
 }

--- a/client/pkg/client/transport.go
+++ b/client/pkg/client/transport.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -84,6 +85,11 @@ func (t *errorBodyTransport) RoundTrip(req *http.Request) (*http.Response, error
 	if resp.StatusCode < http.StatusBadRequest {
 		return resp, nil
 	}
+	// Recorded before the body is read, so a response this transport declines
+	// to buffer still contributes its header, and refreshed below once the
+	// envelope — where this service actually puts the hint — is in hand.
+	recordRetryHint(req.Context(), resp.StatusCode, nil, resp.Header)
+
 	if !strings.Contains(resp.Header.Get("Content-Type"), "json") {
 		return resp, nil
 	}
@@ -107,6 +113,8 @@ func (t *errorBodyTransport) RoundTrip(req *http.Request) (*http.Response, error
 	// Put it back regardless: the generated code reads it again, and so does
 	// newStatusError via resp.Body on the fallback path.
 	resp.Body = io.NopCloser(bytes.NewReader(body))
+
+	recordRetryHint(req.Context(), resp.StatusCode, body, resp.Header)
 
 	if !decodesAsErrorEnvelope(resp.StatusCode, body) {
 		resp.Header.Set("Content-Type", contentTypeUndecodable)
@@ -152,4 +160,33 @@ func decodesAsErrorEnvelope(statusCode int, body []byte) bool {
 
 	var dest api.ErrorResponse
 	return json.Unmarshal(body, &dest) == nil
+}
+
+// recordRetryHint leaves the server's retry-after where the retry policy can
+// read it.
+//
+// See retryHint: this transport is the only point in a call where the status,
+// the headers and the body are in hand at once, and the retry policy sees none
+// of the three — it works with a generic response type exposing StatusCode()
+// alone. A no-op when no sink is on the context, which is every request Health
+// makes and every request a caller drives through the raw client.
+//
+// Only a 429 is recorded. It is the one status this client has a hint type for,
+// the one WithoutRateLimitRetry governs, and the only one this service attaches
+// a delay to.
+func recordRetryHint(ctx context.Context, statusCode int, body []byte, header http.Header) {
+	sink := retryHintFrom(ctx)
+	if sink == nil || statusCode != http.StatusTooManyRequests {
+		return
+	}
+
+	envelopeSeconds := 0
+	if len(body) > 0 {
+		// The `ok` is deliberately dropped: a half-envelope carrying
+		// `retryAfter` but no `code` still carries the hint, and reading it
+		// anyway is the same call newStatusError's 429 branch makes.
+		parsed, _ := parseAPIErrorBody(body)
+		envelopeSeconds = parsed.RetryAfter
+	}
+	sink.retryAfter = retryAfterFrom(envelopeSeconds, header)
 }

--- a/client/pkg/client/transport.go
+++ b/client/pkg/client/transport.go
@@ -108,7 +108,7 @@ func (t *errorBodyTransport) RoundTrip(req *http.Request) (*http.Response, error
 	// newStatusError via resp.Body on the fallback path.
 	resp.Body = io.NopCloser(bytes.NewReader(body))
 
-	if !decodesAsErrorEnvelope(body) {
+	if !decodesAsErrorEnvelope(resp.StatusCode, body) {
 		resp.Header.Set("Content-Type", contentTypeUndecodable)
 	}
 	return resp, nil
@@ -117,12 +117,39 @@ func (t *errorBodyTransport) RoundTrip(req *http.Request) (*http.Response, error
 // decodesAsErrorEnvelope reports whether body is what the generated parsers
 // will successfully unmarshal for a declared error status.
 //
-// Deliberately the same target type the generated code uses, so this cannot
+// Deliberately the same target types the generated code uses, so this cannot
 // drift into accepting a body the parser then rejects. `{}` and `null` decode
 // and are left alone — they are handled downstream, where an envelope carrying
 // no message is turned into the sentinel rather than an error with an empty
 // message.
-func decodesAsErrorEnvelope(body []byte) bool {
+//
+// There is more than one target type, which is why the status matters here.
+// ErrorResponse covers most of them, but a 429 is unmarshalled into
+// RateLimitError and /health's 503 into HealthResponse, and each carries a
+// field ErrorResponse does not: `retryAfter` is an int, `timestamp` a
+// time.Time. Checking ErrorResponse alone therefore passed bodies the real
+// parser rejects — `{"error":"…","code":"…","retryAfter":"60"}`, a service that
+// stringifies its numbers, decoded here and died there — which is the exact
+// `return nil, err` this transport exists to keep away from the caller.
+//
+// The transport cannot know which operation a response belongs to, so a status
+// answered by two schemas has to satisfy both. That costs nothing: every field
+// is optional to encoding/json, so a genuine ErrorResponse decodes into a
+// HealthResponse as a zero value and vice versa. Only a type conflict fails.
+func decodesAsErrorEnvelope(statusCode int, body []byte) bool {
+	switch statusCode {
+	case http.StatusTooManyRequests:
+		var rateLimit api.RateLimitError
+		if json.Unmarshal(body, &rateLimit) != nil {
+			return false
+		}
+	case http.StatusServiceUnavailable:
+		var health api.HealthResponse
+		if json.Unmarshal(body, &health) != nil {
+			return false
+		}
+	}
+
 	var dest api.ErrorResponse
 	return json.Unmarshal(body, &dest) == nil
 }

--- a/client/pkg/client/unauthorized_test.go
+++ b/client/pkg/client/unauthorized_test.go
@@ -168,7 +168,7 @@ func TestSuccessBodiesAreNotBuffered(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, _ := New(server.URL)
+	client := newMappingClient(t, server.URL)
 
 	key, err := client.PublicKey(context.Background(), "")
 	if err != nil {

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -58,11 +58,10 @@ prefix wins, so a specific repository can be granted different keys than the
 owner-wide row covering the rest.
 
 > [!TIP]
-> For an owner-wide trust prefer `repo:owner` over `repo:owner/`. The boundary
-> then falls on either `/` or `@`, so the row keeps matching if the repository
-> later enables immutable subject claims and its `sub` changes shape. It still
-> refuses `repo:ownerevil`. The failure is closed either way — signing breaks,
-> nothing opens — but it breaks at an awkward moment.
+> For an owner-wide trust prefer `repo:owner` over `repo:owner/`. It still
+> refuses `repo:ownerevil`, and it survives a change of `sub` shape the trailing
+> slash does not — see
+> [immutable subject claims](#immutable-subject-claims-change-sub-under-a-live-row).
 
 A prefix must also contain a delimiter with something after it. `repo:` and
 `repo` are refused, because a prefix ending at a delimiter is owner-wide and a

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -55,12 +55,15 @@ all, `Issuer not allowed: <iss>` an unlisted issuer, `Subject is not trusted for
 signing` an unregistered caller, and any other `AUTH_INVALID` a verification
 failure. `gpg-sign` prints that body, so read it before working down the list.
 
-`AUTH_MISSING` has two messages, and the second is the one that misleads.
-`Missing authorization header` means what it says. `Missing token` means the
-header arrived as `Bearer` with nothing after it — the step interpolated an
-empty value, which is what a mistyped `steps.<id>.outputs.token` or a token step
-that never ran produces. Nothing about the trusted-subject table is implicated;
-echo the length of the token the step captured.
+`AUTH_MISSING` has two messages, and the second is the one that misleads. The
+prefix test is for the word `Bearer` _followed by a space_, so a header that is
+the bare word alone never reaches the token check and reports
+`Missing authorization header`, exactly as sending no header at all does.
+`Missing token` means the space was there and nothing came after it — the step
+interpolated an empty value, which is what a mistyped
+`steps.<id>.outputs.token` or a token step that never ran produces. Nothing
+about the trusted-subject table is implicated; echo the length of the token the
+step captured.
 
 Use `core.getIDToken("gpg-signing-service")`. Raw endpoint responses store the
 JWT in `.value`, not `.token`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -133,7 +133,13 @@ and OIDC-authorization tables.
 ### `429`
 
 The caller's 100-token bucket is empty. Wait for refill. The bucket refills at
-100 tokens per minute.
+100 tokens per minute, proportionally — a single token against a ceiling of 100
+is back in well under the one second `retryAfter` is floored at.
+
+The Go client waits exactly that long before re-asking, and returns the hint on
+`RateLimitError.RetryAfter` once its attempts are spent. Quote the id from
+`X-Request-ID`: no 429 body carries a `requestId` field, so the header is the
+only place it appears.
 
 ### `503`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,10 +50,17 @@ verified token still needs a trusted subject. Check all of:
 - the token has not expired; and
 - discovery and JWKS endpoints are reachable.
 
-The response body separates these: `AUTH_MISSING` is an absent header,
-`Issuer not allowed: <iss>` an unlisted issuer, `Subject is not trusted for
+The response body separates these: `AUTH_MISSING` is no usable credential at
+all, `Issuer not allowed: <iss>` an unlisted issuer, `Subject is not trusted for
 signing` an unregistered caller, and any other `AUTH_INVALID` a verification
 failure. `gpg-sign` prints that body, so read it before working down the list.
+
+`AUTH_MISSING` has two messages, and the second is the one that misleads.
+`Missing authorization header` means what it says. `Missing token` means the
+header arrived as `Bearer` with nothing after it — the step interpolated an
+empty value, which is what a mistyped `steps.<id>.outputs.token` or a token step
+that never ran produces. Nothing about the trusted-subject table is implicated;
+echo the length of the token the step captured.
 
 Use `core.getIDToken("gpg-signing-service")`. Raw endpoint responses store the
 JWT in `.value`, not `.token`.


### PR DESCRIPTION
Retrier.Do was handed a closure returning only the transport error, and a 429 or a 5xx is a successful round trip — execErr is nil and the status lives on the response. Status mapping ran after the retrier returned, so shouldRetry's RateLimitError and 5xx-ServiceError branches were unreachable against a real server: WithoutRateLimitRetry() toggled nothing, retryWaitMin/Max governed transport faults alone, and main.go's "the wrapper already retried" was false. TestRetrier* passed throughout because it feeds the retrier synthetic closures and never an HTTP response.

executeWithRetry classifies each completed attempt and reports a retryable one to the retrier through a throwaway wrapper, which it discards once the attempts are spent — so the retry policy decides whether to try again and the operation's own mapping still decides what the failure is called. Only the transient 5xx qualify: 501 and 505 describe what the server will never do. Health keeps the old path, its 503 being a documented answer rather than a failure.

TestSignRetriesRealStatusResponses counts requests arriving at an httptest server, which is the only vantage point the gap was visible from. The suite went 0.3s -> 109s on the first green run, which is the same bug stated as a measurement: those stubs had never been re-asked. Status-mapping tests now build clients through newMappingClient with retries off, since they assert how a response is reported.

Also:

- An undeclared 429 stays a RateLimitError instead of collapsing to ServiceError; the retry-after hint is read from the envelope, or from the Retry-After header when the body has none.
- AuthError.Error no longer renders a dangling ": " for a value with a code and no message.
- The 503 branch of Health is bound to a name. goimports and gofumpt indent a two-value return of composite literals differently and that block was the only place they disagreed, failing `task c:l` on master.
- docs/authentication.md: delete the tip body the immutable-claims section superseded, leaving a pointer.
- docs/troubleshooting.md: AUTH_MISSING has two messages, and `Missing token` — a bare Bearer from an empty interpolation — does not implicate the subject table.
- Share the error-envelope request id across sign_test.go.