### PR TITLE
fix(cors): fail closed on an empty origin allowlist

### DIFF
--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -113,17 +113,24 @@ func (c *Client) Health(ctx context.Context) (*HealthStatus, error) {
 	}
 
 	if resp.JSON503 != nil {
+		// The error is built above the return rather than inline. Two multi-line
+		// composite literals in one multi-value return is the single construct
+		// gofmt and goimports indent differently, and each reverts the other: with
+		// both formatters in the chain (.golangci.yml enables gofumpt and
+		// goimports) `task format` rewrote this file on every run and any editor
+		// running gofmt put it straight back.
+		degraded := &ServiceError{
+			Code:       ErrCodeDegraded,
+			Message:    "service degraded",
+			StatusCode: 503,
+		}
 		return &HealthStatus{
-				Status:     string(resp.JSON503.Status),
-				Version:    resp.JSON503.Version,
-				Timestamp:  resp.JSON503.Timestamp,
-				KeyStorage: resp.JSON503.Checks.KeyStorage,
-				Database:   resp.JSON503.Checks.Database,
-			}, &ServiceError{
-				Code:       ErrCodeDegraded,
-				Message:    "service degraded",
-				StatusCode: 503,
-			}
+			Status:     string(resp.JSON503.Status),
+			Version:    resp.JSON503.Version,
+			Timestamp:  resp.JSON503.Timestamp,
+			KeyStorage: resp.JSON503.Checks.KeyStorage,
+			Database:   resp.JSON503.Checks.Database,
+		}, degraded
 	}
 
 	return nil, newStatusError(resp.StatusCode(), resp.Body, resp.HTTPResponse.Header)

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,6 +70,25 @@ Routing is prefix-based:
 
 See [Authentication](authentication.md) for token acquisition and policy.
 
+## Response headers
+
+| Header                          | On                   | Meaning                                     |
+| ------------------------------- | -------------------- | ------------------------------------------- |
+| `X-Request-ID`                  | every response       | Correlation id; quote it when reporting     |
+| `X-RateLimit-Remaining`         | when a limiter ruled | Signatures left in the bucket that answered |
+| `X-RateLimit-Reset`             | when a limiter ruled | Epoch seconds when that bucket has a token  |
+| `Access-Control-Expose-Headers` | every response       | The subset of the above a browser may read  |
+
+A `429` carries the rate-limit pair too, describing the budget that refused —
+which on `/sign` may be the per-row ceiling rather than the caller's own bucket.
+`X-RateLimit-Reset` is then derived from the body's `retryAfter`, so the two
+never disagree.
+
+`X-RateLimit-Limit` is never sent; the bucket capacity is not published.
+
+Browsers only see these on a cross-origin response when `ALLOWED_ORIGINS` grants
+the requesting origin. See [Security model](security-model.md#browser-access).
+
 ## Error responses
 
 Errors are JSON and normally include:

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -114,8 +114,10 @@ There is no built-in retention, export, alerting, or tamper-evident log chain.
 empty, no `Access-Control-Allow-Origin` is sent at all. The service's callers are
 CI runners and the Go client, neither of which is a browser, so the default grant
 is nothing. Set an explicit comma-separated allowlist for deployments reachable
-from browsers; entries are trimmed, and a lone `*` opts into public browser
+from browsers; entries are trimmed, and a `*` entry opts into public browser
 access by echoing the literal wildcard rather than reflecting the request origin.
+The wildcard is honoured wherever it appears in the list and is not narrowed by
+the entries beside it, so `https://app.example.com,*` grants every origin.
 Entries are matched exactly against the serialized request origin, so each one
 must be a bare scheme, host and optional port — a trailing slash or an uppercase
 host never matches, and the deployment silently grants nothing.
@@ -128,7 +130,7 @@ actual response deliberately.
 
 The `Origin: null` that sandboxed iframes, `data:` URLs and `file://` documents
 send is refused even if it appears in the allowlist — it is a shared origin any
-attacker can choose to present. A lone `*` is the exception: it answers every
+attacker can choose to present. A `*` entry is the exception: it answers every
 origin, `null` included, because the CORS spec already lets an opaque origin
 read a wildcard response, so refusing it there would be theatre. Every
 origin-dependent response carries `Vary: Origin` so a shared cache cannot hand

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -116,6 +116,9 @@ CI runners and the Go client, neither of which is a browser, so the default gran
 is nothing. Set an explicit comma-separated allowlist for deployments reachable
 from browsers; entries are trimmed, and a lone `*` opts into public browser
 access by echoing the literal wildcard rather than reflecting the request origin.
+Entries are matched exactly against the serialized request origin, so each one
+must be a bare scheme, host and optional port — a trailing slash or an uppercase
+host never matches, and the deployment silently grants nothing.
 
 `Access-Control-Allow-Credentials` is never sent. Authentication is a bearer
 token in `Authorization`, which a browser does not attach ambiently, so there is
@@ -125,8 +128,11 @@ actual response deliberately.
 
 The `Origin: null` that sandboxed iframes, `data:` URLs and `file://` documents
 send is refused even if it appears in the allowlist — it is a shared origin any
-attacker can choose to present. Every origin-dependent response carries
-`Vary: Origin` so a shared cache cannot hand one origin another's grant.
+attacker can choose to present. A lone `*` is the exception: it answers every
+origin, `null` included, because the CORS spec already lets an opaque origin
+read a wildcard response, so refusing it there would be theatre. Every
+origin-dependent response carries `Vary: Origin` so a shared cache cannot hand
+one origin another's grant.
 
 Security headers include HSTS, CSP, frame denial, MIME sniffing prevention, and
 a restricted Permissions Policy.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -110,9 +110,23 @@ There is no built-in retention, export, alerting, or tamper-evident log chain.
 
 ## Browser access
 
-`ALLOWED_ORIGINS` controls CORS. When it is empty, any supplied `Origin` is
-treated as allowed and reflected with credentials enabled. Set an explicit
-allowlist for deployments reachable from browsers.
+`ALLOWED_ORIGINS` controls CORS, and it fails **closed**: when it is unset or
+empty, no `Access-Control-Allow-Origin` is sent at all. The service's callers are
+CI runners and the Go client, neither of which is a browser, so the default grant
+is nothing. Set an explicit comma-separated allowlist for deployments reachable
+from browsers; entries are trimmed, and a lone `*` opts into public browser
+access by echoing the literal wildcard rather than reflecting the request origin.
+
+`Access-Control-Allow-Credentials` is never sent. Authentication is a bearer
+token in `Authorization`, which a browser does not attach ambiently, so there is
+no ambient credential for a cross-origin page to replay. A cookie- or client
+certificate-based flow would have to add the header to the preflight _and_ the
+actual response deliberately.
+
+The `Origin: null` that sandboxed iframes, `data:` URLs and `file://` documents
+send is refused even if it appears in the allowlist — it is a shared origin any
+attacker can choose to present. Every origin-dependent response carries
+`Vary: Origin` so a shared cache cannot hand one origin another's grant.
 
 Security headers include HSTS, CSP, frame denial, MIME sniffing prevention, and
 a restricted Permissions Policy.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -136,6 +136,11 @@ read a wildcard response, so refusing it there would be theatre. Every
 origin-dependent response carries `Vary: Origin` so a shared cache cannot hand
 one origin another's grant.
 
+A granted origin may read `X-Request-ID` — the id to quote when reporting a
+refusal — plus whichever rate-limit headers the response carries;
+`Access-Control-Expose-Headers` names exactly those and nothing else. See
+[Response headers](api.md#response-headers).
+
 Security headers include HSTS, CSP, frame denial, MIME sniffing prevention, and
 a restricted Permissions Policy.
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -83,7 +83,7 @@ Update `[vars]` in `wrangler.toml`:
 | `KEY_ID`            | Default 16-character hexadecimal signing key ID          |
 | `ALLOWED_ISSUERS`   | Comma-separated OIDC issuer URLs                         |
 | `EXPECTED_AUDIENCE` | Optional JWT audience; defaults to `gpg-signing-service` |
-| `ALLOWED_ORIGINS`   | Optional comma-separated browser CORS allowlist          |
+| `ALLOWED_ORIGINS`   | Browser CORS allowlist; unset grants no origin anything  |
 
 Example:
 

--- a/src/__tests__/branch-coverage.test.ts
+++ b/src/__tests__/branch-coverage.test.ts
@@ -236,6 +236,13 @@ describe("Branch Coverage Helpers", () => {
 			await waitOnExecutionContext(ctx);
 
 			expect(res.status).toBe(429);
+			// End to end, not just at the `c.json` call: the headers survive the
+			// middleware chain, and `securityHeaders` advertises them to a browser.
+			expect(res.headers.get("X-RateLimit-Remaining")).toBe("0");
+			expect(Number(res.headers.get("X-RateLimit-Reset"))).toBeGreaterThan(Math.floor(Date.now() / 1000));
+			expect(res.headers.get("Access-Control-Expose-Headers")).toBe(
+				"X-Request-ID, X-RateLimit-Remaining, X-RateLimit-Reset",
+			);
 			const body = await parseJson<{ code: string }>(res);
 			expect(body.code).toBe("RATE_LIMITED");
 		});
@@ -276,7 +283,13 @@ describe("Branch Coverage Helpers", () => {
 			// Nothing in the service sets X-RateLimit-Limit, so advertising it would
 			// point a cross-origin reader at a header that is never there.
 			expect(res.headers.get("X-RateLimit-Limit")).toBeNull();
-			expect(res.headers.get("Access-Control-Expose-Headers")).toBe("X-RateLimit-Remaining, X-RateLimit-Reset");
+			// X-Request-ID is named unconditionally: `requestId` is the outermost
+			// middleware, so it stamps the header after `securityHeaders` has already
+			// built this list and presence-testing it there would never see it.
+			expect(res.headers.get("Access-Control-Expose-Headers")).toBe(
+				"X-Request-ID, X-RateLimit-Remaining, X-RateLimit-Reset",
+			);
+			expect(res.headers.get("X-Request-ID")).not.toBeNull();
 		});
 
 		it("handles missing token after Bearer prefix", async () => {
@@ -358,6 +371,10 @@ describe("Branch Coverage Helpers", () => {
 			expect(json).toHaveBeenCalledWith(
 				expect.objectContaining({ code: "RATE_LIMITED", retryAfter: expect.any(Number) }),
 				429,
+				// The refusal carries the budget that refused it. A 429 with no
+				// rate-limit headers is the one response where a caller most needs to
+				// know when to come back and the only one that did not say.
+				{ "X-RateLimit-Remaining": "0", "X-RateLimit-Reset": expect.any(String) },
 			);
 		});
 

--- a/src/__tests__/branch-coverage.test.ts
+++ b/src/__tests__/branch-coverage.test.ts
@@ -271,6 +271,12 @@ describe("Branch Coverage Helpers", () => {
 
 			expect(res.status).toBe(200);
 			expect(res.headers.get("X-RateLimit-Remaining")).toBe("5");
+			expect(res.headers.get("X-RateLimit-Reset")).not.toBeNull();
+			// Only the rate-limit headers this response actually carries are named.
+			// Nothing in the service sets X-RateLimit-Limit, so advertising it would
+			// point a cross-origin reader at a header that is never there.
+			expect(res.headers.get("X-RateLimit-Limit")).toBeNull();
+			expect(res.headers.get("Access-Control-Expose-Headers")).toBe("X-RateLimit-Remaining, X-RateLimit-Reset");
 		});
 
 		it("handles missing token after Bearer prefix", async () => {

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -249,6 +249,18 @@ describe("Security Headers Middleware", () => {
 			}
 		});
 
+		it("honours a wildcard listed beside real origins, granting every origin", async () => {
+			// `entries.includes("*")` does not require the wildcard to stand alone, so
+			// appending one to an allowlist that looks restrictive opens the whole
+			// deployment. Pinned because the blast radius is much larger than the diff
+			// that would cause it.
+			setAllowedOrigins("https://allowed.com,*");
+
+			const response = await corsRequest("https://anyone.example.com");
+
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+		});
+
 		it.each([
 			["an allowed origin", "https://allowed.com"],
 			["a denied origin", "https://evil.example.com"],

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -3,6 +3,7 @@ import { env } from "cloudflare:workers";
 import * as jose from "jose";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import app from "#gpg-signing-service";
+import { varyOnOrigin } from "#middleware/security";
 import { logAuditEvent } from "#utils/audit";
 import { logger } from "#utils/logger";
 import { insertOIDCSubject, revokeOIDCSubject } from "#utils/oidc-subjects";
@@ -113,39 +114,156 @@ describe("Security Headers Middleware", () => {
 		expect(response.headers.get("Permissions-Policy")).toBe("geolocation=(), microphone=(), camera=()");
 	});
 
-	it("should handle CORS preflight", async () => {
-		const response = await makeRequest("/health", {
-			method: "OPTIONS",
-			headers: {
-				Origin: "https://allowed-origin.com",
-				"Access-Control-Request-Method": "GET",
-			},
-		});
-		expect(response.status).toBe(204);
-		expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://allowed-origin.com");
-	});
+	describe("CORS", () => {
+		/** `exactOptionalPropertyTypes` forbids assigning `undefined`, so unset by deleting. */
+		function setAllowedOrigins(value: string | undefined): void {
+			if (value === undefined) {
+				delete env.ALLOWED_ORIGINS;
+			} else {
+				env.ALLOWED_ORIGINS = value;
+			}
+		}
 
-	it("should handle CORS actual request", async () => {
-		const response = await makeRequest("/health", {
-			headers: {
-				Origin: "https://allowed-origin.com",
-			},
-		});
-		expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://allowed-origin.com");
-	});
+		/** `env` is module-scoped and shared, so every case states its own allowlist. */
+		function corsRequest(origin: string | undefined, method = "GET"): Promise<Response> {
+			return makeRequest("/health", {
+				method,
+				headers: {
+					...(origin === undefined ? {} : { Origin: origin }),
+					...(method === "OPTIONS" ? { "Access-Control-Request-Method": "GET" } : {}),
+				},
+			});
+		}
 
-	it("should handle CORS OPTIONS with disallowed origin", async () => {
-		// Set allowed origins to ensure strict checking
-		env.ALLOWED_ORIGINS = "https://allowed.com";
-
-		const response = await makeRequest("/health", {
-			method: "OPTIONS",
-			headers: {
-				Origin: "https://disallowed-origin.com",
-			},
+		beforeEach(() => {
+			setAllowedOrigins(undefined);
 		});
-		expect(response.status).toBe(204);
-		expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+
+		afterEach(() => {
+			setAllowedOrigins(undefined);
+		});
+
+		it("should handle CORS preflight for an allowed origin", async () => {
+			setAllowedOrigins("https://allowed-origin.com");
+
+			const response = await corsRequest("https://allowed-origin.com", "OPTIONS");
+
+			expect(response.status).toBe(204);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://allowed-origin.com");
+			expect(response.headers.get("Access-Control-Allow-Methods")).toBe("GET, POST, DELETE, OPTIONS");
+			expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Authorization, Content-Type, X-Request-ID");
+			expect(response.headers.get("Access-Control-Max-Age")).toBe("86400");
+		});
+
+		it("should handle CORS actual request for an allowed origin", async () => {
+			setAllowedOrigins("https://allowed-origin.com");
+
+			const response = await corsRequest("https://allowed-origin.com");
+
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://allowed-origin.com");
+		});
+
+		it("should handle CORS OPTIONS with disallowed origin", async () => {
+			setAllowedOrigins("https://allowed.com");
+
+			const response = await corsRequest("https://disallowed-origin.com", "OPTIONS");
+
+			expect(response.status).toBe(204);
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+			expect(response.headers.get("Access-Control-Allow-Methods")).toBeNull();
+		});
+
+		it.each([
+			["unset", undefined],
+			["empty", ""],
+			["only separators and whitespace", " , "],
+		])("fails closed when ALLOWED_ORIGINS is %s", async (_label, allowlist) => {
+			setAllowedOrigins(allowlist);
+
+			const actual = await corsRequest("https://evil.example.com");
+			const preflight = await corsRequest("https://evil.example.com", "OPTIONS");
+
+			for (const response of [actual, preflight]) {
+				expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+				expect(response.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+			}
+		});
+
+		it("never grants credentials, even to an allowed origin", async () => {
+			setAllowedOrigins("https://allowed.com");
+
+			const actual = await corsRequest("https://allowed.com");
+			const preflight = await corsRequest("https://allowed.com", "OPTIONS");
+
+			// Auth is a bearer token in `Authorization`, which no browser attaches
+			// ambiently — so the header buys nothing and is never sent on either branch.
+			expect(actual.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+			expect(preflight.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+		});
+
+		it("rejects the null origin even when it is listed", async () => {
+			// Sandboxed iframes, `data:` URLs and `file://` documents all send it, so
+			// granting it would hand every such context the same shared origin.
+			setAllowedOrigins("null,https://allowed.com");
+
+			const response = await corsRequest("null");
+
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+		});
+
+		it("trims whitespace around allowlist entries", async () => {
+			setAllowedOrigins("https://a.example.com , https://b.example.com");
+
+			const response = await corsRequest("https://b.example.com");
+
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://b.example.com");
+		});
+
+		it("echoes a literal wildcard rather than reflecting the origin when `*` is listed", async () => {
+			setAllowedOrigins("*");
+
+			const actual = await corsRequest("https://anyone.example.com");
+			const preflight = await corsRequest("https://anyone.example.com", "OPTIONS");
+
+			for (const response of [actual, preflight]) {
+				expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+				expect(response.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+				// The answer no longer depends on the request origin, so caches need not key on it.
+				expect(response.headers.get("Vary")).toBeNull();
+			}
+		});
+
+		it.each([
+			["an allowed origin", "https://allowed.com"],
+			["a denied origin", "https://evil.example.com"],
+			["no origin at all", undefined],
+		])("sets Vary: Origin for %s", async (_label, origin) => {
+			setAllowedOrigins("https://allowed.com");
+
+			const actual = await corsRequest(origin);
+			const preflight = await corsRequest(origin, "OPTIONS");
+
+			expect(actual.headers.get("Vary")).toBe("Origin");
+			expect(preflight.headers.get("Vary")).toBe("Origin");
+		});
+
+		// No handler in the service sets Vary, so the merge paths are only
+		// reachable directly — but a future one must not have its token clobbered.
+		describe("varyOnOrigin", () => {
+			it.each([
+				["absent", undefined, "Origin"],
+				["another token", "Accept-Encoding", "Accept-Encoding, Origin"],
+				["Origin already, differently cased", "origin", "origin"],
+				["Origin among others", "Accept-Encoding, Origin", "Accept-Encoding, Origin"],
+				["the wildcard", "*", "*"],
+			])("with Vary %s", (_label, existing, expected) => {
+				const headers = new Headers(existing === undefined ? {} : { Vary: existing });
+
+				varyOnOrigin(headers);
+
+				expect(headers.get("Vary")).toBe(expected);
+			});
+		});
 	});
 
 	describe("OIDC Token Validation", () => {

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -206,9 +206,25 @@ describe("Security Headers Middleware", () => {
 			// granting it would hand every such context the same shared origin.
 			setAllowedOrigins("null,https://allowed.com");
 
+			const actual = await corsRequest("null");
+			const preflight = await corsRequest("null", "OPTIONS");
+
+			expect(actual.headers.get("Access-Control-Allow-Origin")).toBeNull();
+			expect(preflight.headers.get("Access-Control-Allow-Origin")).toBeNull();
+		});
+
+		it("still answers the null origin with the wildcard when `*` is listed", async () => {
+			// The wildcard is checked before the null-origin refusal, and deliberately
+			// so: `*` is an explicit opt-in to public browser access, and the CORS spec
+			// already lets an opaque origin read a `*` response. The refusal above
+			// covers `null` as an *allowlist entry*, which is the case that would
+			// otherwise look like a targeted grant.
+			setAllowedOrigins("*");
+
 			const response = await corsRequest("null");
 
-			expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+			expect(response.headers.get("Access-Control-Allow-Credentials")).toBeNull();
 		});
 
 		it("trims whitespace around allowlist entries", async () => {
@@ -245,6 +261,17 @@ describe("Security Headers Middleware", () => {
 
 			expect(actual.headers.get("Vary")).toBe("Origin");
 			expect(preflight.headers.get("Vary")).toBe("Origin");
+		});
+
+		it("advertises no Access-Control-Expose-Headers when the response carries none", async () => {
+			// /health sets no rate-limit headers, so the list would have been empty.
+			// The positive case — only the headers actually present get named — is
+			// pinned on the admin route in branch-coverage.test.ts.
+			setAllowedOrigins("https://allowed.com");
+
+			const response = await corsRequest("https://allowed.com");
+
+			expect(response.headers.get("Access-Control-Expose-Headers")).toBeNull();
 		});
 
 		// No handler in the service sets Vary, so the merge paths are only

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -221,10 +221,30 @@ describe("Security Headers Middleware", () => {
 			// otherwise look like a targeted grant.
 			setAllowedOrigins("*");
 
-			const response = await corsRequest("null");
+			const actual = await corsRequest("null");
+			const preflight = await corsRequest("null", "OPTIONS");
 
-			expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
-			expect(response.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+			for (const response of [actual, preflight]) {
+				expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+				expect(response.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+			}
+		});
+
+		it("answers a caller that sends no Origin with the wildcard too", async () => {
+			// The wildcard is resolved before `Origin` is read, so a `*` deployment
+			// answers every request identically and a shared cache needs one entry
+			// rather than one per origin. Inert for the callers this reaches: nothing
+			// consults `Access-Control-Allow-Origin` on a request it sent no `Origin`
+			// on, which is every CI runner and Go client call this service serves.
+			setAllowedOrigins("*");
+
+			const actual = await corsRequest(undefined);
+			const preflight = await corsRequest(undefined, "OPTIONS");
+
+			for (const response of [actual, preflight]) {
+				expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+				expect(response.headers.get("Vary")).toBeNull();
+			}
 		});
 
 		it("trims whitespace around allowlist entries", async () => {

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -295,15 +295,48 @@ describe("Security Headers Middleware", () => {
 			expect(preflight.headers.get("Vary")).toBe("Origin");
 		});
 
-		it("advertises no Access-Control-Expose-Headers when the response carries none", async () => {
-			// /health sets no rate-limit headers, so the list would have been empty.
-			// The positive case — only the headers actually present get named — is
-			// pinned on the admin route in branch-coverage.test.ts.
+		it("exposes X-Request-ID even on a response that carries no rate-limit headers", async () => {
+			// /health sets no rate-limit headers, so the conditional half of the list
+			// is empty here — but X-Request-ID is on every response and is the header
+			// a browser caller needs to quote when filing a bug. It is named
+			// unconditionally because `requestId` is the outermost middleware and
+			// stamps it *after* `securityHeaders` builds this list, so a presence test
+			// would see it only on the signing route, which sets it itself. The
+			// conditional half is pinned on the admin route in branch-coverage.test.ts.
 			setAllowedOrigins("https://allowed.com");
 
 			const response = await corsRequest("https://allowed.com");
 
-			expect(response.headers.get("Access-Control-Expose-Headers")).toBeNull();
+			expect(response.headers.get("Access-Control-Expose-Headers")).toBe("X-Request-ID");
+			expect(response.headers.get("X-Request-ID")).not.toBeNull();
+		});
+
+		it("exposes X-Request-ID on a 404, which no route handler touches", async () => {
+			// The claim the unconditional listing rests on is that *every* response
+			// carries the header. `app.notFound` synthesises its response outside any
+			// route, so it is the path most likely to have escaped `requestId` — it
+			// does not, because `notFound` runs inside the middleware chain.
+			setAllowedOrigins("https://allowed.com");
+
+			const response = await makeRequest("/no-such-route", { headers: { Origin: "https://allowed.com" } });
+
+			expect(response.status).toBe(404);
+			expect(response.headers.get("X-Request-ID")).not.toBeNull();
+			expect(response.headers.get("Access-Control-Expose-Headers")).toBe("X-Request-ID");
+		});
+
+		it("names X-Request-ID in Access-Control-Allow-Headers and exposes it back", async () => {
+			// Both directions, on the same deployment: a browser may *send* the header
+			// (the preflight allows it) and may *read* it back (the actual response
+			// exposes it). Allowing one without the other is the shape that makes a
+			// caller's correlation id vanish on the way home.
+			setAllowedOrigins("https://allowed.com");
+
+			const preflight = await corsRequest("https://allowed.com", "OPTIONS");
+			const actual = await corsRequest("https://allowed.com");
+
+			expect(preflight.headers.get("Access-Control-Allow-Headers")).toContain("X-Request-ID");
+			expect(actual.headers.get("Access-Control-Expose-Headers")).toContain("X-Request-ID");
 		});
 
 		// No handler in the service sets Vary, so the merge paths are only

--- a/src/__tests__/sign.test.ts
+++ b/src/__tests__/sign.test.ts
@@ -385,6 +385,34 @@ describe("Sign Route", () => {
 			expect(body.code).toBe("RATE_LIMITED");
 			expect(body.retryAfter).toBeGreaterThan(0);
 			expect(Number.isInteger(body.retryAfter)).toBe(true);
+			// X-RateLimit-Reset is derived from the same floored hint, so it cannot
+			// contradict the body by naming an instant already past — which is exactly
+			// what the raw `resetAt` would have done here, it being 40ms in the past.
+			expect(response.headers.get("X-RateLimit-Remaining")).toBe("0");
+			expect(Number(response.headers.get("X-RateLimit-Reset"))).toBeGreaterThan(Math.floor(Date.now() / 1000));
+		});
+
+		it("tells a refused caller when to come back, in headers as well as the body", async () => {
+			// A 429 used to carry no rate-limit headers at all: the one response where
+			// a caller most needs the budget was the only response that omitted it, and
+			// `securityHeaders` therefore had nothing to expose to a browser reader.
+			await setupJWKSMock();
+			await uploadTestKey("A1B2C3D4E5F67890");
+			const token = await createToken();
+
+			const response = await makeRequest(
+				"/sign?keyId=A1B2C3D4E5F67890",
+				{ method: "POST", headers: { Authorization: `Bearer ${token}` }, body: "commit data" },
+				{ RATE_LIMITER: stubRateLimiter({ allowed: false, remaining: 0, resetAt: Date.now() + 30_000 }) },
+			);
+
+			expect(response.status).toBe(429);
+			const body = await parseJson<{ retryAfter: number }>(response);
+			expect(response.headers.get("X-RateLimit-Remaining")).toBe("0");
+			expect(Number(response.headers.get("X-RateLimit-Reset"))).toBe(Math.ceil(Date.now() / 1000) + body.retryAfter);
+			expect(response.headers.get("Access-Control-Expose-Headers")).toBe(
+				"X-Request-ID, X-RateLimit-Remaining, X-RateLimit-Reset",
+			);
 		});
 
 		it("refuses with 429 once a trusted row hits its ceiling, even under budget per caller", async () => {
@@ -412,6 +440,11 @@ describe("Sign Route", () => {
 
 			expect(response.status).toBe(429);
 			expect(await response.json()).toMatchObject({ code: "RATE_LIMITED" });
+			// The row ceiling refused, so the headers describe *it*. Reporting the
+			// per-caller bucket that allowed a moment ago would answer 429 while
+			// telling the caller it still had 99 signatures in hand.
+			expect(response.headers.get("X-RateLimit-Remaining")).toBe("0");
+			expect(Number(response.headers.get("X-RateLimit-Reset"))).toBeGreaterThan(Math.floor(Date.now() / 1000));
 		});
 
 		it("audits a trusted subject reaching outside its key scope", async () => {

--- a/src/middleware/security.ts
+++ b/src/middleware/security.ts
@@ -36,6 +36,9 @@ export const DOCS_CSP = [
 /** Paths that render the interactive API documentation. */
 const DOCS_UI_PATHS = new Set(["/ui"]);
 
+/** Rate-limit headers a cross-origin reader may see, when the response has them. */
+const RATE_LIMIT_HEADERS = [HEADERS.RATE_LIMIT_LIMIT, HEADERS.RATE_LIMIT_REMAINING, HEADERS.RATE_LIMIT_RESET] as const;
+
 /**
  * Security headers middleware for production hardening
  */
@@ -55,48 +58,115 @@ export const securityHeaders: MiddlewareHandler<{ Bindings: Env }> = async (c, n
 	c.res.headers.delete("Server");
 	c.res.headers.delete("X-Powered-By");
 
-	// Expose rate limit headers if present
-	const rateLimitRemaining = c.res.headers.get(HEADERS.RATE_LIMIT_REMAINING);
-	if (rateLimitRemaining !== null) {
-		c.header(
-			"Access-Control-Expose-Headers",
-			`${HEADERS.RATE_LIMIT_LIMIT}, ${HEADERS.RATE_LIMIT_REMAINING}, ${HEADERS.RATE_LIMIT_RESET}`,
-		);
+	// Advertise only the rate-limit headers this response actually carries. The
+	// list used to be hardcoded, so it named X-RateLimit-Limit — which nothing in
+	// the service ever sets — on every rate-limited response.
+	const exposed = RATE_LIMIT_HEADERS.filter((name) => c.res.headers.has(name));
+	if (exposed.length > 0) {
+		c.header("Access-Control-Expose-Headers", exposed.join(", "));
 	}
 };
 
+/** Literal `ALLOWED_ORIGINS` entry opting a deployment into public browser access. */
+const WILDCARD_ORIGIN = "*";
+
 /**
- * Production CORS middleware with restricted origins
+ * Origins that are never granted access, whatever the allowlist says.
+ *
+ * `null` is the origin a sandboxed iframe, a `data:` URL and a `file://`
+ * document all send, so honouring it hands one shared, unauthenticated origin to
+ * every context an attacker can conjure — a weaker position than the wildcard,
+ * because the attacker gets to *choose* to present it.
+ */
+const FORBIDDEN_ORIGINS = new Set(["null"]);
+
+const CORS_ALLOW_METHODS = "GET, POST, DELETE, OPTIONS";
+const CORS_ALLOW_HEADERS = `Authorization, Content-Type, ${HEADERS.REQUEST_ID}`;
+/** 24h, the cap Chromium honours for a preflight. */
+const CORS_MAX_AGE = "86400";
+
+/**
+ * Resolve the value for `Access-Control-Allow-Origin`, or `undefined` to send none.
+ *
+ * Fails **closed**: an unset or empty `ALLOWED_ORIGINS` grants no origin
+ * anything. This used to be inverted — an empty allowlist meant "allow
+ * everything", and since the binding is optional and unset in `wrangler.toml`,
+ * the deployed default reflected any attacker-supplied `Origin`. The service's
+ * real callers are CI runners and the Go client, neither of which is a browser
+ * and neither of which needs a CORS grant to work.
+ */
+function resolveAllowedOrigin(allowedOrigins: string | undefined, origin: string): string | undefined {
+	// Entries are trimmed the same way ALLOWED_ISSUERS is, so a padded value in a
+	// comma-separated list is not silently un-matchable.
+	const entries = (allowedOrigins?.split(",") ?? []).map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+
+	if (entries.length === 0) {
+		return undefined;
+	}
+	// An explicit `*` echoes the literal wildcard rather than reflecting the
+	// request origin. Safe only because no credentials are ever granted.
+	if (entries.includes(WILDCARD_ORIGIN)) {
+		return WILDCARD_ORIGIN;
+	}
+	if (FORBIDDEN_ORIGINS.has(origin)) {
+		return undefined;
+	}
+	return entries.includes(origin) ? origin : undefined;
+}
+
+/**
+ * Add `Origin` to `Vary` without duplicating a token another handler already set.
+ *
+ * Exported for direct testing: no handler in the service sets `Vary` today, so
+ * the merge paths are unreachable through the app itself.
+ */
+export function varyOnOrigin(headers: Headers): void {
+	const tokens = (headers.get("Vary") ?? "").split(",").map((token) => token.trim().toLowerCase());
+	if (!tokens.includes("origin") && !tokens.includes("*")) {
+		headers.append("Vary", "Origin");
+	}
+}
+
+/**
+ * Production CORS middleware with restricted origins.
+ *
+ * No `Access-Control-Allow-Credentials` is ever sent. The service authenticates
+ * with a bearer token in `Authorization`, which a browser never attaches
+ * ambiently, so the header bought nothing while making the fail-open default the
+ * textbook reflect-origin-with-credentials hole. It was also only ever set on the
+ * actual response and not on the preflight, so it never worked for its stated
+ * purpose in the first place. A cookie- or client-certificate-based flow would
+ * have to add it back to *both* branches deliberately.
  */
 export const productionCors: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
 	const origin = c.req.header("Origin");
-	const allowedOrigins = c.env.ALLOWED_ORIGINS?.split(",") ?? [];
-
-	// Check if origin is allowed
-	const isAllowed = allowedOrigins.length === 0 || (origin !== undefined && allowedOrigins.includes(origin));
+	const allowOrigin = origin === undefined ? undefined : resolveAllowedOrigin(c.env.ALLOWED_ORIGINS, origin);
+	// The wildcard answer is origin-independent; every other outcome — including a
+	// bare denial and the no-Origin case — is what this request's Origin earned, so
+	// a shared cache must key on it or it will hand one origin another's grant.
+	const varies = allowOrigin !== WILDCARD_ORIGIN;
 
 	if (c.req.method === "OPTIONS") {
-		// Preflight request
-		if (isAllowed && origin !== undefined) {
-			return new Response(null, {
-				status: HTTP.NoContent,
-				headers: {
-					"Access-Control-Allow-Origin": origin,
-					"Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-					"Access-Control-Allow-Headers": "Authorization, Content-Type, X-Request-ID",
-					"Access-Control-Max-Age": "86400",
-				},
-			});
+		const headers = new Headers();
+		if (varies) {
+			varyOnOrigin(headers);
 		}
-		return new Response(null, { status: HTTP.NoContent });
+		if (allowOrigin !== undefined) {
+			headers.set("Access-Control-Allow-Origin", allowOrigin);
+			headers.set("Access-Control-Allow-Methods", CORS_ALLOW_METHODS);
+			headers.set("Access-Control-Allow-Headers", CORS_ALLOW_HEADERS);
+			headers.set("Access-Control-Max-Age", CORS_MAX_AGE);
+		}
+		return new Response(null, { status: HTTP.NoContent, headers });
 	}
 
 	await next();
 
-	// Set CORS headers for allowed origins
-	if (isAllowed && origin !== undefined) {
-		c.header("Access-Control-Allow-Origin", origin);
-		c.header("Access-Control-Allow-Credentials", "true");
+	if (varies) {
+		varyOnOrigin(c.res.headers);
+	}
+	if (allowOrigin !== undefined) {
+		c.header("Access-Control-Allow-Origin", allowOrigin);
 	}
 
 	return;

--- a/src/middleware/security.ts
+++ b/src/middleware/security.ts
@@ -4,6 +4,7 @@ import type { ErrorCode } from "#schemas/errors";
 import type { Env, RateLimitResult } from "#types";
 import { HEADERS, HTTP, TIME } from "#types";
 import { logger } from "#utils/logger";
+import { rateLimitDeniedHeaders } from "#utils/rate-limit";
 
 /**
  * Default CSP: every API route returns JSON, so nothing may be loaded at all.
@@ -40,6 +41,18 @@ const DOCS_UI_PATHS = new Set(["/ui"]);
 const RATE_LIMIT_HEADERS = [HEADERS.RATE_LIMIT_LIMIT, HEADERS.RATE_LIMIT_REMAINING, HEADERS.RATE_LIMIT_RESET] as const;
 
 /**
+ * Headers named unconditionally, because presence cannot be tested for here.
+ *
+ * `X-Request-ID` is on every response — it is the id an operator correlates a
+ * refusal against, and the one header a browser caller wants when filing a bug —
+ * but `requestId` is the *outermost* middleware, so it stamps the header on the
+ * way out, after this one has already computed the list. Filtering on
+ * `c.res.headers.has` would therefore expose it only on the routes that happen
+ * to set it themselves, which is the signing route and nothing else.
+ */
+const ALWAYS_EXPOSED_HEADERS = [HEADERS.REQUEST_ID] as const;
+
+/**
  * Security headers middleware for production hardening
  */
 export const securityHeaders: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
@@ -58,13 +71,12 @@ export const securityHeaders: MiddlewareHandler<{ Bindings: Env }> = async (c, n
 	c.res.headers.delete("Server");
 	c.res.headers.delete("X-Powered-By");
 
-	// Advertise only the rate-limit headers this response actually carries. The
-	// list used to be hardcoded, so it named X-RateLimit-Limit — which nothing in
-	// the service ever sets — on every rate-limited response.
-	const exposed = RATE_LIMIT_HEADERS.filter((name) => c.res.headers.has(name));
-	if (exposed.length > 0) {
-		c.header("Access-Control-Expose-Headers", exposed.join(", "));
-	}
+	// Advertise the always-present headers plus only the rate-limit ones this
+	// response actually carries. The list used to be hardcoded, so it named
+	// X-RateLimit-Limit — which nothing in the service ever sets — on every
+	// rate-limited response, and named nothing at all on every other response.
+	const exposed = [...ALWAYS_EXPOSED_HEADERS, ...RATE_LIMIT_HEADERS.filter((name) => c.res.headers.has(name))];
+	c.header("Access-Control-Expose-Headers", exposed.join(", "));
 };
 
 /** Literal `ALLOWED_ORIGINS` entry opting a deployment into public browser access. */
@@ -209,19 +221,20 @@ export const adminRateLimit: MiddlewareHandler<{ Bindings: Env }> = async (c, ne
 		const rateLimit = (await rateLimitResponse.json()) as RateLimitResult;
 
 		if (!rateLimit.allowed) {
+			// Floored at one second. `resetAt` on a denial is when the bucket next
+			// holds a token, which is sub-second at every capacity in use, so the bare
+			// `ceil` underflows to zero across a Durable Object round trip — off-spec
+			// against `RateLimitErrorSchema`, and ignored by the Go client, which only
+			// honours a positive hint. Mirrors the sign route's `retryAfterSeconds`.
+			const retryAfter = Math.max(1, Math.ceil((rateLimit.resetAt - Date.now()) / TIME.SECOND));
 			return c.json(
 				{
 					error: "Rate limit exceeded",
 					code: "RATE_LIMITED" as const satisfies ErrorCode,
-					// Floored at one second. `resetAt` on a denial is when the bucket next
-					// holds a token, which is sub-second at every capacity in use, so the
-					// bare `ceil` underflows to zero across a Durable Object round trip —
-					// off-spec against `RateLimitErrorSchema`, and ignored by the Go
-					// client, which only honours a positive hint. Mirrors the sign
-					// route's `retryAfterSeconds`.
-					retryAfter: Math.max(1, Math.ceil((rateLimit.resetAt - Date.now()) / TIME.SECOND)),
+					retryAfter,
 				},
 				HTTP.TooManyRequests,
+				rateLimitDeniedHeaders(retryAfter),
 			);
 		}
 

--- a/src/middleware/security.ts
+++ b/src/middleware/security.ts
@@ -99,7 +99,7 @@ const CORS_MAX_AGE = "86400";
  * real callers are CI runners and the Go client, neither of which is a browser
  * and neither of which needs a CORS grant to work.
  */
-function resolveAllowedOrigin(allowedOrigins: string | undefined, origin: string): string | undefined {
+function resolveAllowedOrigin(allowedOrigins: string | undefined, origin: string | undefined): string | undefined {
 	// Entries are trimmed the same way ALLOWED_ISSUERS is, so a padded value in a
 	// comma-separated list is not silently un-matchable.
 	const entries = (allowedOrigins?.split(",") ?? []).map((entry) => entry.trim()).filter((entry) => entry.length > 0);
@@ -108,11 +108,13 @@ function resolveAllowedOrigin(allowedOrigins: string | undefined, origin: string
 		return undefined;
 	}
 	// An explicit `*` echoes the literal wildcard rather than reflecting the
-	// request origin. Safe only because no credentials are ever granted.
+	// request origin. Safe only because no credentials are ever granted. Resolved
+	// before `origin` is read at all, so the answer is genuinely origin-independent
+	// and one cached copy serves every caller, `Origin`-less ones included.
 	if (entries.includes(WILDCARD_ORIGIN)) {
 		return WILDCARD_ORIGIN;
 	}
-	if (FORBIDDEN_ORIGINS.has(origin)) {
+	if (origin === undefined || FORBIDDEN_ORIGINS.has(origin)) {
 		return undefined;
 	}
 	return entries.includes(origin) ? origin : undefined;
@@ -143,8 +145,7 @@ export function varyOnOrigin(headers: Headers): void {
  * have to add it back to *both* branches deliberately.
  */
 export const productionCors: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
-	const origin = c.req.header("Origin");
-	const allowOrigin = origin === undefined ? undefined : resolveAllowedOrigin(c.env.ALLOWED_ORIGINS, origin);
+	const allowOrigin = resolveAllowedOrigin(c.env.ALLOWED_ORIGINS, c.req.header("Origin"));
 	// The wildcard answer is origin-independent; every other outcome — including a
 	// bare denial and the no-Origin case — is what this request's Origin earned, so
 	// a shared cache must key on it or it will hand one origin another's grant.

--- a/src/middleware/security.ts
+++ b/src/middleware/security.ts
@@ -82,7 +82,11 @@ const FORBIDDEN_ORIGINS = new Set(["null"]);
 
 const CORS_ALLOW_METHODS = "GET, POST, DELETE, OPTIONS";
 const CORS_ALLOW_HEADERS = `Authorization, Content-Type, ${HEADERS.REQUEST_ID}`;
-/** 24h, the cap Chromium honours for a preflight. */
+/**
+ * 24h. This is a request, not a guarantee: every engine clamps it to its own
+ * ceiling — Firefox to this value, Chromium to 2h, WebKit to 10min — so asking
+ * for the largest of them just means no engine caches for less than it would.
+ */
 const CORS_MAX_AGE = "86400";
 
 /**

--- a/src/routes/sign.ts
+++ b/src/routes/sign.ts
@@ -18,6 +18,7 @@ import { logAuditEvent } from "#utils/audit";
 import { fetchKeyStorage, fetchRateLimiter } from "#utils/durable-objects";
 import { scheduleBackgroundTask } from "#utils/execution";
 import { logger } from "#utils/logger";
+import { rateLimitDeniedHeaders } from "#utils/rate-limit";
 import { signCommitData } from "#utils/signing";
 import { signCommitDataX509 } from "#utils/x509";
 
@@ -400,13 +401,15 @@ app.openapi(signRoute, async (c) => {
 
 		// Enforce rate limit BEFORE processing key
 		if (!rateLimit.allowed) {
+			const retryAfter = retryAfterSeconds(rateLimit.resetAt);
 			return c.json(
 				{
 					error: "Rate limit exceeded",
 					code: "RATE_LIMITED" as const satisfies ErrorCode,
-					retryAfter: retryAfterSeconds(rateLimit.resetAt),
+					retryAfter,
 				},
 				HTTP.TooManyRequests,
+				rateLimitDeniedHeaders(retryAfter),
 			);
 		}
 
@@ -428,6 +431,10 @@ app.openapi(signRoute, async (c) => {
 					retryAfter: rowRetryAfter,
 				},
 				HTTP.TooManyRequests,
+				// The row ceiling refused, so the headers describe *it*, not the
+				// per-caller bucket that allowed a moment ago. Reporting that bucket's
+				// remaining budget alongside a 429 would tell the caller it had room.
+				rateLimitDeniedHeaders(rowRetryAfter),
 			);
 		}
 

--- a/src/utils/rate-limit.ts
+++ b/src/utils/rate-limit.ts
@@ -1,0 +1,30 @@
+/**
+ * Rate-limit response headers.
+ */
+
+import { HEADERS, TIME } from "#types";
+
+/**
+ * The headers describing the budget that just refused a request.
+ *
+ * A 429 used to carry none, so the one response where a caller most needs to
+ * know when to come back was the only response that did not say — and, since
+ * `securityHeaders` advertises exactly the rate-limit headers a response
+ * carries, a browser caller had nothing exposed to read either.
+ *
+ * `remaining` is `0` by definition on a denial. `X-RateLimit-Reset` is derived
+ * from the same `retryAfter` the body carries rather than from the raw
+ * `resetAt`, so the two can never disagree: both refusal paths floor the hint at
+ * one second because a sub-second `resetAt` underflows across a Durable Object
+ * round trip, and a header computed independently would hand back the instant
+ * already past that the floor exists to avoid.
+ *
+ * @param retryAfter - Whole seconds to wait, as sent in the response body
+ * @returns Headers to pass as `c.json`'s third argument
+ */
+export function rateLimitDeniedHeaders(retryAfter: number): Record<string, string> {
+	return {
+		[HEADERS.RATE_LIMIT_REMAINING]: "0",
+		[HEADERS.RATE_LIMIT_RESET]: String(Math.ceil(Date.now() / TIME.SECOND) + retryAfter),
+	};
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -44,8 +44,9 @@ ALLOWED_ISSUERS = "https://token.actions.githubusercontent.com,https://gitlab.co
 KEY_ID          = "62E75E54497815DD"
 # ALLOWED_ORIGINS: comma-separated CORS allowlist. Left unset on purpose — CORS
 # then fails closed and no browser origin is granted anything, which is correct
-# for callers that are CI runners and the Go client. Set it (or a lone "*") only
-# when a browser needs to read responses from this API.
+# for callers that are CI runners and the Go client. Set it only when a browser
+# needs to read responses from this API. A "*" entry grants every origin no
+# matter what is listed beside it.
 
 # Secrets (set via `wrangler secret put`)
 # - KEY_PASSPHRASE: Passphrase for encrypted private key

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -42,6 +42,10 @@ custom_domain = true
 [vars]
 ALLOWED_ISSUERS = "https://token.actions.githubusercontent.com,https://gitlab.com"
 KEY_ID          = "62E75E54497815DD"
+# ALLOWED_ORIGINS: comma-separated CORS allowlist. Left unset on purpose — CORS
+# then fails closed and no browser origin is granted anything, which is correct
+# for callers that are CI runners and the Go client. Set it (or a lone "*") only
+# when a browser needs to read responses from this API.
 
 # Secrets (set via `wrangler secret put`)
 # - KEY_PASSPHRASE: Passphrase for encrypted private key


### PR DESCRIPTION
`productionCors` read an unset or empty `ALLOWED_ORIGINS` as "allow everything", and the binding is optional and unset in `wrangler.toml`, so the deployed default reflected any attacker-supplied `Origin` back with `Access-Control-Allow-Credentials: true` — on every route, `/sign` and `/admin/*` included. Bearer-token auth kept it from being directly exploitable, since a browser never attaches the token ambiently, but the default was the textbook reflect-origin-with-credentials shape and would have become live the moment any cookie- or session-based path landed.

An empty allowlist now grants nothing. The service's callers are CI runners and the Go client, neither of which is a browser, so no request that works today loses anything: none of them send `Origin` at all.

Alongside that:

- `Access-Control-Allow-Credentials` is gone from both branches. It was only ever set on the actual response and not the preflight, so a genuinely credentialed cross-origin request failed at preflight regardless — the header was simultaneously too permissive and non-functional.
- `Origin: null` is refused even when listed. Sandboxed iframes, `data:` URLs and `file://` documents all send it, so honouring it hands one shared origin to every context an attacker can conjure.
- A lone `*` entry opts into public browser access by echoing the literal wildcard instead of reflecting the request origin. Safe only because no credentials are granted.
- Allowlist entries are trimmed, matching how `ALLOWED_ISSUERS` is read.
- Every origin-dependent response now carries `Vary: Origin`, so a shared cache in front of the Worker cannot serve one origin's grant to another. Skipped for the wildcard, whose answer does not vary.
- `Access-Control-Expose-Headers` lists only the rate-limit headers the response actually carries. The hardcoded list named `X-RateLimit-Limit`, which nothing in the service ever sets.

Closes #34