### PR TITLE
docs(subjects): answer the glob question in the schema, not just prose

### DIFF
--- a/client/openapi.json
+++ b/client/openapi.json
@@ -593,7 +593,7 @@
         "minLength": 1,
         "maxLength": 255,
         "pattern": "^[^\\s*?[\\]]*[:@/][^\\s*?[\\]]*[^\\s:@/*?[\\]][^\\s*?[\\]]*$",
-        "description": "A literal prefix of the token's `sub`, not a glob — `*`, `?` and `[` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.",
+        "description": "A literal prefix of the token's `sub`, not a glob — `*`, `?`, `[` and `]` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.",
         "example": "repo:owner/repository"
       },
       "SubjectCreate": {

--- a/client/openapi.json
+++ b/client/openapi.json
@@ -592,7 +592,9 @@
         "type": "string",
         "minLength": 1,
         "maxLength": 255,
-        "pattern": "^\\S*[:@/]\\S*[^\\s:@/]\\S*$"
+        "pattern": "^[^\\s*?[\\]]*[:@/][^\\s*?[\\]]*[^\\s:@/*?[\\]][^\\s*?[\\]]*$",
+        "description": "A literal prefix of the token's `sub`, not a glob — `*`, `?` and `[` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.",
+        "example": "repo:owner/repository"
       },
       "SubjectCreate": {
         "type": "object",

--- a/client/openapi.json
+++ b/client/openapi.json
@@ -541,7 +541,7 @@
             "type": "string"
           },
           "subjectPrefix": {
-            "$ref": "#/components/schemas/SubjectPrefix"
+            "$ref": "#/components/schemas/StoredSubjectPrefix"
           },
           "keyIds": {
             "type": "array",
@@ -588,12 +588,11 @@
         "maxLength": 64,
         "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._/-]*$"
       },
-      "SubjectPrefix": {
+      "StoredSubjectPrefix": {
         "type": "string",
         "minLength": 1,
         "maxLength": 255,
-        "pattern": "^[^\\s*?[\\]]*[:@/][^\\s*?[\\]]*[^\\s:@/*?[\\]][^\\s*?[\\]]*$",
-        "description": "A literal prefix of the token's `sub`, not a glob — `*`, `?`, `[` and `]` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.",
+        "description": "A stored `sub` prefix. Matching is `startsWith` plus a delimiter (`:`, `@`, `/`) or end-of-subject boundary; the longest live prefix wins. No `pattern` is published here on purpose: new prefixes must satisfy `SubjectPrefix`, but rows created before that rule existed are returned as they were stored, so a client that must list and revoke them can still read this response.",
         "example": "repo:owner/repository"
       },
       "SubjectCreate": {
@@ -631,6 +630,14 @@
           "subjectPrefix"
         ]
       },
+      "SubjectPrefix": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[^\\s*?\\[\\]]*[:@\\/][^\\s*?\\[\\]]*[^\\s:@\\/*?\\[\\]][^\\s*?\\[\\]]*$",
+        "description": "A literal prefix of the token's `sub`, not a glob — `*`, `?`, `[` and `]` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.",
+        "example": "repo:owner/repository"
+      },
       "SubjectListResponse": {
         "type": "object",
         "properties": {
@@ -658,7 +665,7 @@
             "type": "string"
           },
           "subjectPrefix": {
-            "$ref": "#/components/schemas/SubjectPrefix"
+            "$ref": "#/components/schemas/StoredSubjectPrefix"
           },
           "keyIds": {
             "type": "array",
@@ -744,7 +751,7 @@
             "$ref": "#/components/schemas/SubjectName"
           },
           "subjectPrefix": {
-            "$ref": "#/components/schemas/SubjectPrefix"
+            "$ref": "#/components/schemas/StoredSubjectPrefix"
           },
           "keyIds": {
             "type": "array",

--- a/client/pkg/api/api.gen.go
+++ b/client/pkg/api/api.gen.go
@@ -162,7 +162,7 @@ type CoveringSubject struct {
 	KeyIds *[]string   `json:"keyIds"`
 	Name   SubjectName `json:"name"`
 
-	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?` and `[` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
+	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?`, `[` and `]` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
 	SubjectPrefix SubjectPrefix `json:"subjectPrefix"`
 }
 
@@ -247,7 +247,7 @@ type SubjectCreate struct {
 	KeyIds        *[]string   `json:"keyIds,omitempty"`
 	Name          SubjectName `json:"name"`
 
-	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?` and `[` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
+	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?`, `[` and `]` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
 	SubjectPrefix SubjectPrefix `json:"subjectPrefix"`
 }
 
@@ -263,7 +263,7 @@ type SubjectCreatedResponse struct {
 	Name       SubjectName `json:"name"`
 	RevokedAt  *string     `json:"revokedAt"`
 
-	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?` and `[` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
+	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?`, `[` and `]` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
 	SubjectPrefix SubjectPrefix `json:"subjectPrefix"`
 }
 
@@ -275,7 +275,7 @@ type SubjectListResponse struct {
 // SubjectName defines model for SubjectName.
 type SubjectName = string
 
-// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?` and `[` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
+// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?`, `[` and `]` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
 type SubjectPrefix = string
 
 // SubjectRevokeResponse defines model for SubjectRevokeResponse.
@@ -303,7 +303,7 @@ type SubjectSummary struct {
 	Name       SubjectName `json:"name"`
 	RevokedAt  *string     `json:"revokedAt"`
 
-	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?` and `[` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
+	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?`, `[` and `]` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
 	SubjectPrefix SubjectPrefix `json:"subjectPrefix"`
 }
 
@@ -2883,7 +2883,7 @@ func ParsePostSignResponse(rsp *http.Response) (*PostSignResponse, error) {
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
 	"7Hz7cts4sverdHGnajP5JFlO7Fw0tbWj2BqPPju2juWczJ7Ya0NkS8KYBLgAKFubctV5iPOE50lO4cKb",
-	"RMqK1/YkG+ePWCRBoNGXX3cDDX72fB7FnCFT0ut89qQ/xYiYn90koKrrK8qZvkSWRF7nkyfphHkN7xLn",
+	"RMqK1/YkG+cPRyRBoNGXX3cDDX72fB7FnCFT0ut89qQ/xYiYn90koKrrK8qZvkSWRF7nkyfphHkN7xLn",
 	"50kcchK4C8EVUeg1PMUvkZ37AouXAmf8Ul/KZPQ7+ip/nt5wLc4anprH6HU8qQRlE++mYSk54BN5jDLm",
 	"TKKmJxY8RqEoGmJ9njClf0SU0UhT2s46okzhBIXuKeQT05wqjORyLySb7Q8Cx17H+9NGzp4Nx5uNImNu",
 	"Gh4KwcUOD/C293pZw5uGRwPdfMxFRJTX8ZKEakYuTZ1KmaBwEztANlFTr7NZ0fAS5/1gjXYRKhIQRXTT",
@@ -2893,64 +2893,64 @@ var swaggerSpec = []string{
 	"DW+/97fzw6OT81+OPhwWr7sHB0cfe+mdwfHRTs/0cN47Pj46drcP+sOT0o0Pg4Oj7m7p1m7voHfSy24N",
 	"+3uH2cVx96R3ftB/3z+puGUGd4SeH/f+40NveGLo3y00L5LePzzpHR92D9zDKig0DFoFg18IQwa81rDg",
 	"L0GGBVWwQzQsbVVC/xVJqKYrJjVF/7ICrTWMjYh9YxlWLnE+VFyQSeXzBRoLjRt5v1XESkVUIm/jsZ3S",
-	"0La9C8Y1vBkK6ZxRTJRCwbyO9/fT0+D/nZ62Cn9+uFUAjuQySKbdN1L21ktmmE05tcipuT/XvMKJIAEG",
-	"lcq6j/NdDFEjcL10A90Cg2ohrnAci5N0LRtZh1UT2sf5AZWqrzCq8P7hhAuqplEl3tqAJeiqyqdjyiYo",
-	"YkGZqkf0iifLemhcUrG74tCNApEr5lfP7Uucl/3KKi0ucus2X2g6riGpnpzVLF9gakSuU4jaajeKiKUv",
-	"C0byqdv8hTTH7ebbs89b7ZsfvJXxUt7r5qtSr/qyptfNV9W9rgx0Eoni7kqQsyrrqYbdH2xYvsxsEXGB",
-	"wUDQGVG4j/PF6bfb7TJfN9vtR2LdAguWSU2HrZrzIBmF1F9QNLwmUazDI6+p/73r7fUPYbA3gMGHdwf9",
-	"Hdjv/Q3eHRzt7JvHp6zValVJ9JgoPKARVb3UUz6ax1Vi3h0rG/3jtR8mks7wfZrf2KhvVbqzyg+X+q/i",
-	"6ZBO2LF1+mVuKoEIL96Ox5uv/Lf+5ha+eLX9YvTixfjN6PWb0aj9hmyT9uu3L9v+5tbrUxYTgUyB5e4t",
-	"U7ZjriFCHYN1Tz4c91bLzoWoOzbVXBIdXsdUoOyzXWJBMSLXlpkvX223C7zdrEol88wsD4cErYWaMure",
-	"K+hElPVtx5tfWxrgMoDF5Mu1rtS7osyCFZ7DV3RWE/qtdtVO7PZpTRZVSMCrM7Rc+g+SvIVEqg8yncKt",
-	"RN5ByHa5Zd0BHigzrNGLjIfl0CcXXJH8ErMaqV6sUK3VAZKjZP0gyfU6TKKIiPmtcVLW/woKD504Cyjx",
-	"amsRPYsgQZr/7Db/S4NE/rN1vtE8e/7DClzMpRmg9AWN7eKX14WQKhQkhNi0AD4GNUUwK3l/lnAhk9FF",
-	"AxhXQGAS8hH873//D1w8v2jAxV8vgLAALj5dABEIAseJxKAFXXATh4gof4oSrqbIgCqQiggl4YqqKagp",
-	"lWDpNN3oURleK/CnRBBfoQAqgUCAoXbJKODZRUcP+7P+b+PiR+DCvIQsSKl24zZAcrgQGPMOv2IoNuTM",
-	"v4CAo7QTCSKqFp83cUbDC028Y4SaEqX7lkBUiQwqzVhXNAx8IoJOqacLUCKRSgLOUMxBP5FUcTG3JBIF",
-	"pl0LPk5RIEjdjIQg+JW03GqYzkPOJigVhHSGKUFXlMmWMY3UUxbGzQfSrjfXpRfb26uU6e+np/L5Xz+d",
-	"np6dPf/U+XnjrHxHX3R+3nDXpWerlO3YGGy93dXg7F3cl6JhaFbeMHg3X1bvA80/w9yrKZcZK339hhWj",
-	"AxfgDBsQcalAxujTMfVhTIVULTjRwp7yMG8rfR4jXCLGEiSdMMomDUhYgAIucQ4TQZiSVtoRmcNIK4t+",
-	"qKaElQYV/OrPEp5ZBOyAhmaIkLBUfS5x/qMlwNACyJSYawW80n0LlDxM9Ewhpv6lBM7COYydWcREqMwu",
-	"DMGMg+HXidZQDD5SNaVM0wB+SGgkjWkrwydtzwx1qwZMkflOI90UnG7zK9BK3DDmW9LYVFXXAtXFhdOb",
-	"ZRe5TPYqUVvCnUCK7LbSbwBPFAoja8PWjsYngVoFwOdMEcokEMbVFIU1R3fXGn9ITfdkxGcIVLXgWA9K",
-	"GQRU/s4pU5bd0jKRK+Ai0PoJZKJ7VoDEn4Lp3XCc6IGb2oCtLAjThPoYIBBQSKKm1h5DnW4uOQgkFi+t",
-	"WmqCWnCkhW+AdsTV1Ny0JGAUqzlckaK+w5gyEt6riO6welNaOC5bcqXMV7jR1CU/xY5PseO/Gjue6Njn",
-	"YRLJrz49NHO3sq9K725h14oc7l6s6bH2ygpccJvay/5mEBIt2GtlY+WfQE75FQO8Jr4K58CZv+Z2ptNx",
-	"O0xBpXOO1XJ9dXpjelw/uTE9rpvauL5rKXvotMYMcsc4846uqnautb7nEfzLV+pESgb0JS5khYHcFeur",
-	"5Pbbdvvtd7ZZkVUl3Is93L5vkY64gv11mxe+/jmmPlE4sJt3d9i58KeEsru//jBiiLNNjrtSVrN/VO64",
-	"scjCZSFouaOfCKrmQ220lvMjJAJFN9Gjp1e/pEve///jidlyLa0fBRFl1gOazHOD6BsbzwFZEOtkSCuL",
-	"QQWjV6bDnDFTpWLNFk4D/wsGPerv7qRjCh7BHlW/JiOwZVoSuNB3DsgIdvrrjC5RzKiPBrNqqJhIdW43",
-	"HsqUDO2rjphIBwQBzCiBwdHwJGWG85W3UqJlQtmYG0Okyizx7A32YGiXGCAdrDvoFzb1O95mq91qGzbG",
-	"yEhMvY730twy6jk1gnWkkCSgBgQmqJZDmmNUguIMwTSDkE/cWt2YhsokgJ4ZRBD9gjYPbw+VUQFTJ2cG",
-	"FCRChUJ6nU+fPZ2oe/9I0CxLWcfhmXW0lBvEUjEmSaicwmfrW+YqC683U+uoDa9vGtUD8vFYYs2IxfHa",
-	"5S22Gk9163BZGVo+3JINV7+Zl6t9+auKCLXrqiyzl9ersKvuEVlwt/7ONEJZv2pU70W7bTdPmULrL0kc",
-	"hxqaKGcbv0tb95IPcms5Zqk61FjNAiZl2quNYusehy9XZFUM3WczEtIAXAmVHX/z8cZ/T6XUUMEFUEcK",
-	"yRHaa3hTJIExzs/ex48fmxrukCnjJyo2B/KnlDOw8GUXxEgYooAokQpigRKZapU0JV+kfmewDgSSMPrL",
-	"qTeJJ023Ztp0wHvqVWiRntv244pOO3ISgqYKBdgt9KKfNIhW9JCfzrSyyzT812BYgE7zrsPdtBSnEnZ1",
-	"Fgdpra7xoiQMQSouMADzZh3q7tuHD2ZuiyVGFWwzxPOxpfNJ3b8ndTei16qayj7mskK9bZQPBHQs4+JU",
-	"s0+iNd3xZknDB1wuqLgB1Hc8mN+ndrsM5KYcVmt/f7NkVpv3OfAq0ezjHOxxCwzApVzjJAznT+7syb4f",
-	"0b4zw2V4lRqqNtxFx7Zxvd1+a7L41fY/2N8Z/ulNCQIIC+C31nb7LRQSVgMMASriTzGwb70Gn0cRVRkZ",
-	"zyZUwSSetGxI+hdNwo+rUeQ3TeXDIEl5PeOR0WRxLesJUZ4Q5VtAFGv3q3Dls1nduslPDixLwJw5QCCF",
-	"cHkJBWybDAf20yWziqWKmKhpngKni2tlW66WYnfz3Yudl7tbve1fXu29/vXNIyfGVccvaoAgPTPxZHrf",
-	"k+llhrLC0DZiU1xfm6jq/NaUFplmWQxP8pIpfcuc1KvPV4352Sr+r98IY4yahcikaTYVyoJdXp8vdTCJ",
-	"m2nyX//OksAHOYefDfYG4M5ImJrH5Xjp2aD3/scne/6X7HmrvfV4rNMwzLiCMU+YAeJvcaUrR4EinhRr",
-	"qutXu2wFobLVXXnZLmV+mARaqdKSPZ0g2D1eU6JZvxQ2TMd9QCdbVVRewd+MlCeL/O6Ww1KVNluUsqAI",
-	"1bmx7okL+k/tmHf6QAPNcDUHxU1g3IIuzFDQMU27tBuNptA3FnyGrsxY8gjhiovLccivgDMgDIjvY6xp",
-	"sdVzQKQ2KO2weSLMOjUy31Xv2qpf29BWjcop0TY3mldUsrPFHVdjpaZZLLip/LdtDsgorVkl+aEArTYj",
-	"zFiF11qqVIXzVn0CXzLv+0/gy6fHHjmBrzkGVY8sKeuesvdvPOR4+3isS1VHR9UNw0CHCiyti4eYUNEA",
-	"EgokwRzwmkoLXd8aEJuicY2ARRCuilE2PtPVqwu2wLCAXaM50KAFJ1Mq8/NEDH2UkggazkEqHhePIqXr",
-	"G53iaQ1FLlHWnfNpWLQcCa5V2RwJMBBPQsnTgytUuT70pUFYd6SKKHemJDuH0oCrKfWnpYMo7sjCLeck",
-	"svMLiidmJdYQEdrzKCkYunMG5sgBZXBRLuN3B8SWS/kvfrI+LD+vcPtJhdpFndQ3rLmqQ1dnk7d98OTs",
-	"4QPMhbrWFdbsJPYExN9O7pcBcZr/gdnwt6BbkOe3hroZVlaFwEX0zcvS6/NDUwBRrK2TP4FEX6A5U4qC",
-	"khCYjjghRDJzYLr7rjY7PElL8B7MdJfr8SvY7Mh4stbvLi8sK3N9QmiTACAmMmjqsCAA23mhyHanD3Iu",
-	"FUa2PJMnebRjozrro+PyCRWgEgSqRDCTdOXHVFakXQW7uf+kq3jO6pFTrsozS3UG6+p6n7Ktp2xrXdZZ",
-	"vdEB579BPvWeMqVzoCKELTv09ZMpi0YmlfrJRDxOJagEGkUYUIOAOi9FERE931XRv4Wobz/2rzrRVqtZ",
-	"T3H/Nxf3O0j4d436K9DBfjmyNtDfmaJ/aaRtG2Yfq7A9VcXy9huVDxnGL3yftCp/cxOlEtJPYxq5vfxj",
-	"aMg+ymnElsnF9gHme59WGna7rnlpPwX4Jfv72pyISgS6vQg7qSr5ZB/nW+8kUPZR5kfZyq/ciV8lh+VP",
-	"Ddbv1Os5P+0iiwUtrNomNt+Ury0WHdIJgwlVab2nORKRGJ9jsMFWee0N9iorvXTeMrTfrH949UvPTVmX",
-	"l3f7W9N9S7FpKmG+MLqoS7N0HrdhMrovWE4sfNdxrQSrfW+DrjCYvYE50WgQ5dFzqnckgOM/Np9qpKGT",
-	"2YZJWFYF4SohfYFmG5iE31489fKPiKdIGPIrDEBxSCTaD8tdfg14vPXi/lLOhW/TVgyvW4A5XAt47SMG",
-	"f2REObROwRF7v/HR7UvsLjz6wMiMUHuIdymqzc+cfzrTWL58Cnwx1jW+qeCXjNb/XwAAAP//",
+	"0La9C8Y1vBkK6ZxRTJRCwbyO9/fT0+D/nZ62Cv/9cKsAHMllkEy7b6TsrZfMMJtyapFTc3+ueYUTQQIM",
+	"KpV1H+e7GKJG4HrpBroFBtVCXOE4FifpWjayDqsmtI/zAypVX2FU4f3DCRdUTaNKvLUBS9BVlU/HlE1Q",
+	"xIIyVY/oFU+W9dC4pGJ3xaEbBSJXzK+e25c4L/uVVVpc5NZtvtB0XENSPTmrWb7A1IhcpxC11W4UEUtf",
+	"FozkU7f5C2mO2823Z5+32jc/eCvjpbzXzVelXvVlTa+br6p7XRnoJBLF3ZUgZ1XWUw27P9iwfJnZIuIC",
+	"g4GgM6JwH+eL02+322W+brbbj8S6BRYsk5oOWzXnQTIKqb+gaHhNoliHR15T/3vX2+sfwmBvAIMP7w76",
+	"O7Df+xu8Ozja2TePT1mr1aqS6DFReEAjqnqpp3w0j6vEvDtWNvrHaz9MJJ3h+zS/sVHfqnRnlR8u9V/F",
+	"0yGdsGPr9MvcVAIRXrwdjzdf+W/9zS188Wr7xejFi/Gb0es3o1H7Ddkm7ddvX7b9za3XpywmApkCy91b",
+	"pmzHXEOEOgbrnnw47q2WnQtRd2yquSQ6vI6pQNlnu8SCYkSuLTNfvtpuF3i7WZVK5plZHg4JWgs1ZdS9",
+	"V9CJKOvbjje/tjTAZQCLyZdrXal3RZkFKzyHr+isJvRb7aqd2O3TmiyqkIBXZ2i59B8keQuJVB9kOoVb",
+	"ibyDkO1yy7oDPFBmWKMXGQ/LoU8uuCL5JWY1Ur1YoVqrAyRHyfpBkut1mEQREfNb46Ss/xUUHjpxFlDi",
+	"1dYiehZBgjT/2W3+lwaJ/GfrfKN59vyHFbiYSzNA6Qsa28UvrwshVShICLFpAXwMaopgVvL+LOFCJqOL",
+	"BjCugMAk5CP43//+H7h4ftGAi7/qP58ugLAALs4ugAgEgeNEYtCCLrjZQ0SUP0UJV1NkQBVIRYSScEXV",
+	"FNSUSrDEmm700AyvFfhTIoivUACVQCDAUPtlFPDsoqOH/Vn/2bj4EbgwLyELUtLduA2QHC4ExrzDrxiK",
+	"DTnzLyDgKO1sgoiqxedNnNHwQhPvuKGmROm+JRBVIoNKM9YVDQOfiKBT6ukClEikkoAzFHPQTyRVXMwt",
+	"iUSBadeCj1MUCFI3IyEIfiUttxqm85CzCUoFIZ1hStAVZbJl7CN1l4Vx84G0/80V6sX29iqN+vvpqXz+",
+	"10+np2dnzz91ft44K9/RF52fN9x16dkqjTs2VltvfDVgexcfpmgYmuU3DN7Nl3X8QPPPMPdqymXGSl+/",
+	"YcXoEAY4wwZEXCqQMfp0TH0YUyFVC060sKc8zNtKn8cIl4ixBEknjLJJAxIWoIBLnMNEEKaklXZE5jDS",
+	"yqIfqilhpUEFv/qzhGcWBjug8RkiJCxVn0uc/2gJMLQAMiXmWgGvdN8CJQ8TPVOIqX8pgbNwDmNnFjER",
+	"KrMLQzDjYPh1ojUUg49UTSnTNIAfEhpJY9/K8EnbM0PdqgFTZL7TSDcFp9v8CrQSN4z5ljQ2VdW1kHVx",
+	"9fRm2U8uk71K1JZwJ5Aiu630G8AThcLI2rC1o/FJoFYB8DlThDIJhHE1RWHN0d21xh9S0z0Z8RkCVS04",
+	"1oNSBgGVv3PKlGW3tEzkCrgItH4CmeieFSDxp2B6NxwneuCmNmArC8I0oT4GCAQUkqiptcdQp5tLDgKJ",
+	"xUurlpqgFhxp4RugHXE1NTctCRjFag5XpKjvMKaMhPcqojss4ZRWj8uWXCnzFb409ctPAeRTAPmvBpAn",
+	"OgB6mGzyq88Rzdyt7KtyvFvYtSKRuxdreqwNswIX3M72sr8ZhEQL9lrZgPknkFN+xQCvia/COXDmr7mn",
+	"6XTcDlNQ6ZxjtVxfneOYHtfPcEyP6+Y3ru9ayh46tzGD3DHOvKOrqp1rre95BP/ylTqRkgF9iQtZYSB3",
+	"xfoquf223X77ne1YZKUJ92IPt29epCOuYH/dDoavf46pTxQO7A7eHbYv/Cmh7O6vP4wY4myn466U1Wwi",
+	"lTtuLLJwWQha7ugngqr5UBut5fwIiUDRTfTo6dUv6br3//94YvZdS4tIQUSZ9YAm89wg+sbGc0AWxDoZ",
+	"0spiUMHolekwZ8xUqVizhdPA/4JBj/q7O+mYgkewR9WvyQhsrZYELvSdAzKCnf46o0sUM+qjwawaKiZS",
+	"ndvdhzIlQ/uqIybSAUEAM0pgcDQ8SZnhfOWtlGiZUDbmxhCpMks8e4M9GNolBkgH6w76hZ39jrfZarfa",
+	"ho0xMhJTr+O9NLeMek6NYB0pJAmoAYEJquWQ5hiVoDhDMM0g5BO3VjemoTIJoGcGEUS/oM3D20NlVMAU",
+	"y5kBBYlQoZBe59NnTyfq3j8SNMtS1nF4Zh0t5QaxVIxJEiqn8Nn6lrnKwuvN1Dpqw+ubRvWAfDyWWDNi",
+	"cbx2eZ+txlPdOlxWi5YPt2TD1W/mNWtf/qoiQu26Usvs5fXK7Kp7RBbcrb8zjVDWrxrVe9Fu2x1UptD6",
+	"SxLHoYYmytnG79IWv+SD3FqTWSoRNVazgEmZ9mqj2LrH4ctlWRVD99mMhDQAV0dlx998vPHfUyk1VHAB",
+	"1JFCcoT2Gt4USWCM87P38ePHpoY7ZMr4iYodgvwp5QwsfNkFMRKGKCBKpIJYoESmWiVNyRep3xmsA4Ek",
+	"jP5y6k3iSdOtmTYd8J56FVqk57b9uKLTjpyEoKlCAXYfvegnDaIVPeSnM63sMg3/NRgWoNO863A3rcep",
+	"hF2dxUFasGu8KAlDkIoLDMC8WYe6+/bhg5nbYp1RBdsM8Xxs6XxS9+9J3Y3otaqmso+5rFBvG+UDAR3L",
+	"uDjV7JNoTXe8WdLwAZcLKm4A9R0P5vep3S4DuSmH1drf3yyZ1eZ9DrxKNPs4B3vmAgNwKdc4CcP5kzt7",
+	"su9HtO/McBlepYaqDXfRsW1cb7ffmix+tf0P9neGf3pTggDCAvittd1+C4WE1QBDgIr4UwzsW6/B51FE",
+	"VUbGswlVMIknLRuS/kWT8ONqFPlNU/kwSFJez3hkNFlcy3pClCdE+RYQxdr9Klz5bFa3bvLjA8sSMAcP",
+	"EEghXF5CAdsmw4H9dMmsYqkiJmqap8Dp4lrZlqul2N1892Ln5e5Wb/uXV3uvf33zyIlx1RmMGiBID048",
+	"md73ZHqZoawwtI3YVNjXJqo6vzWlRaZZFsOTvGRK3zLH9erzVWN+tpT/6zfCGKNmITJpmk2FsmCX1+dL",
+	"HUziZpr817+zJPBBzuFng70BuIMSpuZxOV56Nui9//HJnv8le95qbz0e6zQMM65gzBNmgPhbXOnKUaCI",
+	"J8XC6vrVLltBqGx1V162S5kfJoFWqrRkTycIdo/XlGjWL4UN03Ef0MlWVZZX8Dcj5ckiv7vlsFSlzRal",
+	"LChCdW6se+KC/lM75p0+0EAzXM1BcRMYt6ALMxR0TNMu7UajKfSNBZ+hKzOWPEK44uJyHPIr4AwIA+L7",
+	"GGtabPUcEKkNSjtsngizTo3Md9W7turXNrRVo3JKtM2N5hWV7Gxxx9VYqWkWC24q/22bAzJKa1ZJfihA",
+	"q80IM1bhtZYqVeG8VZ/Al8z7/hP48hGyR07ga85C1SNLyrqn7P0bDznePh7rUtXRUXXDMNChAkvr4iEm",
+	"VDSAhAJJMAe8ptJC17cGxKZoXCNgEYSrYpSNz3T16oItMCxg12gONGjByZTK/DwRQx+lJIKGc5CKx8Wj",
+	"SOn6Rqd4WkORS5R153waFi1HgmtVNkcCDMSTUPL04ApVrg99aRDWHakiyp0pyc6hNOBqSv1p6SCKO7Jw",
+	"yzmJ7PyC4olZiTVEhPY8SgqG7pyBOXJAGVyUy/jdAbHlUv6Ln6wPy88r3H5SoXZRJ/UNa67q0NXZ5G1f",
+	"PTl7+ABzoa51hTU7iT0B8beT+2VAnOZ/YDb8LegW5PmtoW6GlVUhcBF987L0+vzQFEAUa+vkTyDRF2jO",
+	"lKKgJASmI04IkcwcmO6+q80OT9ISvAcz3eV6/Ao2OzKerPW7ywvLylyfENokAIiJDJo6LAjAdl4ost3p",
+	"g5xLhZEtz+RJHu3YqM766Lh8QgWoBIEqEcwkXfkxlRVpV8Fu7j/pKp6zeuSUq/LMUp3Burrep2zrKdta",
+	"l3VWb3TA+W+QT72nTOkcqAhhyw59/WTKopFJpX4yEY9TCSqBRhEG1CCgzktRRETPd1X0byHq24/9q060",
+	"1WrWU9z/zcX9DhL+XaP+CnSwn4+sDfR3puhfGmnbhtnHKmxPVbG8/VDlQ4bxCx8prcrf3ESphPT7mEZu",
+	"L/8YGrIvcxqxZXKxfYD56KeVht2ua17a7wF+yf6+NieiEoFuL8JOqko+2Rf61jsJlH2Z+VG28it34lfJ",
+	"Yfl7g/U79XrOT7vIYkELq7aJzYfla4tFh3TCYEJVWu9pjkQkxucYbLBVXnuDvcpKL523DO2H6x9e/dJz",
+	"U9bl5d3+1nQfVGyaSpgvjC7q0iydx22YjO4LlhMLH3dcK8Fq39ugKwxmb2BONBpEefSc6h0J4PiPzaca",
+	"aehktmESllVBuEpIX6DZBibhtxdPvfwj4ikShvwKA1AcEon2w3KXXwMeb724v5Rz4QO1FcPrFmAO1wJe",
+	"+4jBHxlRDq1TcMTeb3x0+xK7C48+MDIj1B7iXYpq8zPnn840li+fAl+MdY1vKvglo/X/FwAA//8=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/client/pkg/api/api.gen.go
+++ b/client/pkg/api/api.gen.go
@@ -162,8 +162,8 @@ type CoveringSubject struct {
 	KeyIds *[]string   `json:"keyIds"`
 	Name   SubjectName `json:"name"`
 
-	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?`, `[` and `]` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
-	SubjectPrefix SubjectPrefix `json:"subjectPrefix"`
+	// SubjectPrefix A stored `sub` prefix. Matching is `startsWith` plus a delimiter (`:`, `@`, `/`) or end-of-subject boundary; the longest live prefix wins. No `pattern` is published here on purpose: new prefixes must satisfy `SubjectPrefix`, but rows created before that rule existed are returned as they were stored, so a client that must list and revoke them can still read this response.
+	SubjectPrefix StoredSubjectPrefix `json:"subjectPrefix"`
 }
 
 // ErrorCode defines model for ErrorCode.
@@ -240,6 +240,9 @@ type SignRequest = string
 // SignResponse defines model for SignResponse.
 type SignResponse = string
 
+// StoredSubjectPrefix A stored `sub` prefix. Matching is `startsWith` plus a delimiter (`:`, `@`, `/`) or end-of-subject boundary; the longest live prefix wins. No `pattern` is published here on purpose: new prefixes must satisfy `SubjectPrefix`, but rows created before that rule existed are returned as they were stored, so a client that must list and revoke them can still read this response.
+type StoredSubjectPrefix = string
+
 // SubjectCreate defines model for SubjectCreate.
 type SubjectCreate struct {
 	ExpiresInDays *int        `json:"expiresInDays,omitempty"`
@@ -263,8 +266,8 @@ type SubjectCreatedResponse struct {
 	Name       SubjectName `json:"name"`
 	RevokedAt  *string     `json:"revokedAt"`
 
-	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?`, `[` and `]` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
-	SubjectPrefix SubjectPrefix `json:"subjectPrefix"`
+	// SubjectPrefix A stored `sub` prefix. Matching is `startsWith` plus a delimiter (`:`, `@`, `/`) or end-of-subject boundary; the longest live prefix wins. No `pattern` is published here on purpose: new prefixes must satisfy `SubjectPrefix`, but rows created before that rule existed are returned as they were stored, so a client that must list and revoke them can still read this response.
+	SubjectPrefix StoredSubjectPrefix `json:"subjectPrefix"`
 }
 
 // SubjectListResponse defines model for SubjectListResponse.
@@ -303,8 +306,8 @@ type SubjectSummary struct {
 	Name       SubjectName `json:"name"`
 	RevokedAt  *string     `json:"revokedAt"`
 
-	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?`, `[` and `]` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
-	SubjectPrefix SubjectPrefix `json:"subjectPrefix"`
+	// SubjectPrefix A stored `sub` prefix. Matching is `startsWith` plus a delimiter (`:`, `@`, `/`) or end-of-subject boundary; the longest live prefix wins. No `pattern` is published here on purpose: new prefixes must satisfy `SubjectPrefix`, but rows created before that rule existed are returned as they were stored, so a client that must list and revoke them can still read this response.
+	SubjectPrefix StoredSubjectPrefix `json:"subjectPrefix"`
 }
 
 // TokenCreate defines model for TokenCreate.
@@ -2882,75 +2885,78 @@ func ParsePostSignResponse(rsp *http.Response) (*PostSignResponse, error) {
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7Hz7cts4sverdHGnajP5JFlO7Fw0tbWj2BqPPju2juWczJ7Ya0NkS8KYBLgAKFubctV5iPOE50lO4cKb",
-	"RMqK1/YkG+cPRyRBoNGXX3cDDX72fB7FnCFT0ut89qQ/xYiYn90koKrrK8qZvkSWRF7nkyfphHkN7xLn",
-	"50kcchK4C8EVUeg1PMUvkZ37AouXAmf8Ul/KZPQ7+ip/nt5wLc4anprH6HU8qQRlE++mYSk54BN5jDLm",
-	"TKKmJxY8RqEoGmJ9njClf0SU0UhT2s46okzhBIXuKeQT05wqjORyLySb7Q8Cx17H+9NGzp4Nx5uNImNu",
-	"Gh4KwcUOD/C293pZw5uGRwPdfMxFRJTX8ZKEakYuTZ1KmaBwEztANlFTr7NZ0fAS5/1gjXYRKhIQRXTT",
-	"pYcC/5GgVP31aHOSW2NQmfg+SlkYc8R5iMTwT9EIpSJRXBo0IAqb+tHyyI5QKjDQCmmJyzopzqKRSjRj",
-	"ZE51yrKculz1uG1yk90gQpD50shGmxpO96re3uEz1DQPc06VFc5qQbUwy4q61IYlYUhGIXodJRJcpLTh",
-	"MRLdqpGOrkPdNBfoQOCYXq/5rmtcKRRDwmK32eyqGNYr2lKKON0PJ7+ev+8Ph/3DPa9hL/uH/9k96O96",
-	"DW+/97fzw6OT81+OPhwWr7sHB0cfe+mdwfHRTs/0cN47Pj46drcP+sOT0o0Pg4Oj7m7p1m7voHfSy24N",
-	"+3uH2cVx96R3ftB/3z+puGUGd4SeH/f+40NveGLo3y00L5LePzzpHR92D9zDKig0DFoFg18IQwa81rDg",
-	"L0GGBVWwQzQsbVVC/xVJqKYrJjVF/7ICrTWMjYh9YxlWLnE+VFyQSeXzBRoLjRt5v1XESkVUIm/jsZ3S",
-	"0La9C8Y1vBkK6ZxRTJRCwbyO9/fT0+D/nZ62Cv/9cKsAHMllkEy7b6TsrZfMMJtyapFTc3+ueYUTQQIM",
-	"KpV1H+e7GKJG4HrpBroFBtVCXOE4FifpWjayDqsmtI/zAypVX2FU4f3DCRdUTaNKvLUBS9BVlU/HlE1Q",
-	"xIIyVY/oFU+W9dC4pGJ3xaEbBSJXzK+e25c4L/uVVVpc5NZtvtB0XENSPTmrWb7A1IhcpxC11W4UEUtf",
-	"FozkU7f5C2mO2823Z5+32jc/eCvjpbzXzVelXvVlTa+br6p7XRnoJBLF3ZUgZ1XWUw27P9iwfJnZIuIC",
-	"g4GgM6JwH+eL02+322W+brbbj8S6BRYsk5oOWzXnQTIKqb+gaHhNoliHR15T/3vX2+sfwmBvAIMP7w76",
-	"O7Df+xu8Ozja2TePT1mr1aqS6DFReEAjqnqpp3w0j6vEvDtWNvrHaz9MJJ3h+zS/sVHfqnRnlR8u9V/F",
-	"0yGdsGPr9MvcVAIRXrwdjzdf+W/9zS188Wr7xejFi/Gb0es3o1H7Ddkm7ddvX7b9za3XpywmApkCy91b",
-	"pmzHXEOEOgbrnnw47q2WnQtRd2yquSQ6vI6pQNlnu8SCYkSuLTNfvtpuF3i7WZVK5plZHg4JWgs1ZdS9",
-	"V9CJKOvbjje/tjTAZQCLyZdrXal3RZkFKzyHr+isJvRb7aqd2O3TmiyqkIBXZ2i59B8keQuJVB9kOoVb",
-	"ibyDkO1yy7oDPFBmWKMXGQ/LoU8uuCL5JWY1Ur1YoVqrAyRHyfpBkut1mEQREfNb46Ss/xUUHjpxFlDi",
-	"1dYiehZBgjT/2W3+lwaJ/GfrfKN59vyHFbiYSzNA6Qsa28UvrwshVShICLFpAXwMaopgVvL+LOFCJqOL",
-	"BjCugMAk5CP43//+H7h4ftGAi7/qP58ugLAALs4ugAgEgeNEYtCCLrjZQ0SUP0UJV1NkQBVIRYSScEXV",
-	"FNSUSrDEmm700AyvFfhTIoivUACVQCDAUPtlFPDsoqOH/Vn/2bj4EbgwLyELUtLduA2QHC4ExrzDrxiK",
-	"DTnzLyDgKO1sgoiqxedNnNHwQhPvuKGmROm+JRBVIoNKM9YVDQOfiKBT6ukClEikkoAzFHPQTyRVXMwt",
-	"iUSBadeCj1MUCFI3IyEIfiUttxqm85CzCUoFIZ1hStAVZbJl7CN1l4Vx84G0/80V6sX29iqN+vvpqXz+",
-	"10+np2dnzz91ft44K9/RF52fN9x16dkqjTs2VltvfDVgexcfpmgYmuU3DN7Nl3X8QPPPMPdqymXGSl+/",
-	"YcXoEAY4wwZEXCqQMfp0TH0YUyFVC060sKc8zNtKn8cIl4ixBEknjLJJAxIWoIBLnMNEEKaklXZE5jDS",
-	"yqIfqilhpUEFv/qzhGcWBjug8RkiJCxVn0uc/2gJMLQAMiXmWgGvdN8CJQ8TPVOIqX8pgbNwDmNnFjER",
-	"KrMLQzDjYPh1ojUUg49UTSnTNIAfEhpJY9/K8EnbM0PdqgFTZL7TSDcFp9v8CrQSN4z5ljQ2VdW1kHVx",
-	"9fRm2U8uk71K1JZwJ5Aiu630G8AThcLI2rC1o/FJoFYB8DlThDIJhHE1RWHN0d21xh9S0z0Z8RkCVS04",
-	"1oNSBgGVv3PKlGW3tEzkCrgItH4CmeieFSDxp2B6NxwneuCmNmArC8I0oT4GCAQUkqiptcdQp5tLDgKJ",
-	"xUurlpqgFhxp4RugHXE1NTctCRjFag5XpKjvMKaMhPcqojss4ZRWj8uWXCnzFb409ctPAeRTAPmvBpAn",
-	"OgB6mGzyq88Rzdyt7KtyvFvYtSKRuxdreqwNswIX3M72sr8ZhEQL9lrZgPknkFN+xQCvia/COXDmr7mn",
-	"6XTcDlNQ6ZxjtVxfneOYHtfPcEyP6+Y3ru9ayh46tzGD3DHOvKOrqp1rre95BP/ylTqRkgF9iQtZYSB3",
-	"xfoquf223X77ne1YZKUJ92IPt29epCOuYH/dDoavf46pTxQO7A7eHbYv/Cmh7O6vP4wY4myn466U1Wwi",
-	"lTtuLLJwWQha7ugngqr5UBut5fwIiUDRTfTo6dUv6br3//94YvZdS4tIQUSZ9YAm89wg+sbGc0AWxDoZ",
-	"0spiUMHolekwZ8xUqVizhdPA/4JBj/q7O+mYgkewR9WvyQhsrZYELvSdAzKCnf46o0sUM+qjwawaKiZS",
-	"ndvdhzIlQ/uqIybSAUEAM0pgcDQ8SZnhfOWtlGiZUDbmxhCpMks8e4M9GNolBkgH6w76hZ39jrfZarfa",
-	"ho0xMhJTr+O9NLeMek6NYB0pJAmoAYEJquWQ5hiVoDhDMM0g5BO3VjemoTIJoGcGEUS/oM3D20NlVMAU",
-	"y5kBBYlQoZBe59NnTyfq3j8SNMtS1nF4Zh0t5QaxVIxJEiqn8Nn6lrnKwuvN1Dpqw+ubRvWAfDyWWDNi",
-	"cbx2eZ+txlPdOlxWi5YPt2TD1W/mNWtf/qoiQu26Usvs5fXK7Kp7RBbcrb8zjVDWrxrVe9Fu2x1UptD6",
-	"SxLHoYYmytnG79IWv+SD3FqTWSoRNVazgEmZ9mqj2LrH4ctlWRVD99mMhDQAV0dlx998vPHfUyk1VHAB",
-	"1JFCcoT2Gt4USWCM87P38ePHpoY7ZMr4iYodgvwp5QwsfNkFMRKGKCBKpIJYoESmWiVNyRep3xmsA4Ek",
-	"jP5y6k3iSdOtmTYd8J56FVqk57b9uKLTjpyEoKlCAXYfvegnDaIVPeSnM63sMg3/NRgWoNO863A3rcep",
-	"hF2dxUFasGu8KAlDkIoLDMC8WYe6+/bhg5nbYp1RBdsM8Xxs6XxS9+9J3Y3otaqmso+5rFBvG+UDAR3L",
-	"uDjV7JNoTXe8WdLwAZcLKm4A9R0P5vep3S4DuSmH1drf3yyZ1eZ9DrxKNPs4B3vmAgNwKdc4CcP5kzt7",
-	"su9HtO/McBlepYaqDXfRsW1cb7ffmix+tf0P9neGf3pTggDCAvittd1+C4WE1QBDgIr4UwzsW6/B51FE",
-	"VUbGswlVMIknLRuS/kWT8ONqFPlNU/kwSFJez3hkNFlcy3pClCdE+RYQxdr9Klz5bFa3bvLjA8sSMAcP",
-	"EEghXF5CAdsmw4H9dMmsYqkiJmqap8Dp4lrZlqul2N1892Ln5e5Wb/uXV3uvf33zyIlx1RmMGiBID048",
-	"md73ZHqZoawwtI3YVNjXJqo6vzWlRaZZFsOTvGRK3zLH9erzVWN+tpT/6zfCGKNmITJpmk2FsmCX1+dL",
-	"HUziZpr817+zJPBBzuFng70BuIMSpuZxOV56Nui9//HJnv8le95qbz0e6zQMM65gzBNmgPhbXOnKUaCI",
-	"J8XC6vrVLltBqGx1V162S5kfJoFWqrRkTycIdo/XlGjWL4UN03Ef0MlWVZZX8Dcj5ckiv7vlsFSlzRal",
-	"LChCdW6se+KC/lM75p0+0EAzXM1BcRMYt6ALMxR0TNMu7UajKfSNBZ+hKzOWPEK44uJyHPIr4AwIA+L7",
-	"GGtabPUcEKkNSjtsngizTo3Md9W7turXNrRVo3JKtM2N5hWV7Gxxx9VYqWkWC24q/22bAzJKa1ZJfihA",
-	"q80IM1bhtZYqVeG8VZ/Al8z7/hP48hGyR07ga85C1SNLyrqn7P0bDznePh7rUtXRUXXDMNChAkvr4iEm",
-	"VDSAhAJJMAe8ptJC17cGxKZoXCNgEYSrYpSNz3T16oItMCxg12gONGjByZTK/DwRQx+lJIKGc5CKx8Wj",
-	"SOn6Rqd4WkORS5R153waFi1HgmtVNkcCDMSTUPL04ApVrg99aRDWHakiyp0pyc6hNOBqSv1p6SCKO7Jw",
-	"yzmJ7PyC4olZiTVEhPY8SgqG7pyBOXJAGVyUy/jdAbHlUv6Ln6wPy88r3H5SoXZRJ/UNa67q0NXZ5G1f",
-	"PTl7+ABzoa51hTU7iT0B8beT+2VAnOZ/YDb8LegW5PmtoW6GlVUhcBF987L0+vzQFEAUa+vkTyDRF2jO",
-	"lKKgJASmI04IkcwcmO6+q80OT9ISvAcz3eV6/Ao2OzKerPW7ywvLylyfENokAIiJDJo6LAjAdl4ost3p",
-	"g5xLhZEtz+RJHu3YqM766Lh8QgWoBIEqEcwkXfkxlRVpV8Fu7j/pKp6zeuSUq/LMUp3Burrep2zrKdta",
-	"l3VWb3TA+W+QT72nTOkcqAhhyw59/WTKopFJpX4yEY9TCSqBRhEG1CCgzktRRETPd1X0byHq24/9q060",
-	"1WrWU9z/zcX9DhL+XaP+CnSwn4+sDfR3puhfGmnbhtnHKmxPVbG8/VDlQ4bxCx8prcrf3ESphPT7mEZu",
-	"L/8YGrIvcxqxZXKxfYD56KeVht2ua17a7wF+yf6+NieiEoFuL8JOqko+2Rf61jsJlH2Z+VG28it34lfJ",
-	"Yfl7g/U79XrOT7vIYkELq7aJzYfla4tFh3TCYEJVWu9pjkQkxucYbLBVXnuDvcpKL523DO2H6x9e/dJz",
-	"U9bl5d3+1nQfVGyaSpgvjC7q0iydx22YjO4LlhMLH3dcK8Fq39ugKwxmb2BONBpEefSc6h0J4PiPzaca",
-	"aehktmESllVBuEpIX6DZBibhtxdPvfwj4ikShvwKA1AcEon2w3KXXwMeb724v5Rz4QO1FcPrFmAO1wJe",
-	"+4jBHxlRDq1TcMTeb3x0+xK7C48+MDIj1B7iXYpq8zPnn840li+fAl+MdY1vKvglo/X/FwAA//8=",
+	"7F39cts4kn+VLu5WbSYnyXJi58OprV3H1nh0dmyd5VxmL/ZaENmSMCYBLgBK1qZcdQ9xT3hPcoUPfkmk",
+	"5PhsZ7Lx/JERSRBo9Mevu4EG/cXzeRRzhkxJb+eLJ/0JRsT83E0CqnZ9RTnTl8iSyNv57Ek6Zl7Du8L5",
+	"ZRKHnATuQnBFFHoNT/ErZJe+wOKlwCm/0pcyGf6Gvsqfpzdci4uGp+YxejueVIKysXfTsJQc8bE8RRlz",
+	"JlHTEwseo1AUDbE+T5jSPyLKaKQpbWcdUaZwjEL3FPKxaU4VRnK5F5LN9o8CR96O94eNnD0bjjcbRcbc",
+	"NDwUgos9HuC69zpZw5uGRwPdfMRFRJS34yUJ1YxcmjqVMkHhJnaEbKwm3s5mRcMrnHeDW7SLUJGAKKKb",
+	"Lj0U+I8EperejjYnuVsMKhPfRykLYw45D5EY/ikaoVQkikuDBkRhUz9aHtkRSgUGWiEtcVknxVk0Uolm",
+	"jMypTlmWU5erHrdNbrIbRAgyXxrZaFPD6V7V23t8iprmfs6pssJZLagWZllRl9qwJAzJMERvR4kEFylt",
+	"eIxEazXS0XWsm+YC7Qkc0eu17youMOiXXqkUjSFksfNsjlVs6xQtKsWd3Y9nv1x+6Pb73eMDr2Evu8f/",
+	"uXvU3fca3mHnb5fHJ2eXP598PC5e7x4dnXzqpHd6pyd7HdPDZef09OTU3T7q9s9KNz72jk5290u39jtH",
+	"nbNOdqvfPTjOLk53zzqXR90P3bOKW2ZwR+jlaec/Pnb6Z4b+/ULzIund47PO6fHukXtYBYiGQavA8CvB",
+	"yEDYLez4a/BhQRXsEA1LW5XQf0ESqsmKSU3Qv6rAbA1mQ2LfWAaXK5xrRSXjyucLNBYaN/J+q4iViqhE",
+	"ruOxnVLftr0L0jW8KQrpXFJMlELBvB3v7+fnwb+dn7cK//vjWgE4kstQmXbfSNlbL5l+NuXUIifm/lzz",
+	"CseCBBhUKushzvcxRI3D9dINdAsMqoW4wn0sTtK1bGQdVk3oEOdHVKquwqgiBgjHXFA1iSpR14Ytwa6q",
+	"fDqibIwiFpSpelyveLKsh8YxFbsrDt0oELlifvXcvsJ52bus0uIit9Z5RNNxDUn15Kxm+QJTI3KdQtRW",
+	"u1FELH1ZMJLPu82fSXPUbr69+LLVvvmjtzJqynvdfFXqVV/W9Lr5qrrXleFOIlHcXQlyVmU91bD7ow3O",
+	"l5ktIu24e4JOicJDnC9Ov91ul/m62W4/EusWWLBMajps1Zx7yTCk/oKi4TWJYh0keU393/vOQfcYegc9",
+	"6H18f9Tdg8PO3+D90cneoXl8zlqtVpVET4nCIxpR1Uk95aN5XCXmuyNlcwC89sNE0il+SLMcG/utSnpW",
+	"+eFS/1U87dMxO7VOv8xNJRDhxdvRaPOV/9bf3MIXr7ZfDF+8GL0Zvn4zHLbfkG3Sfv32Zdvf3Hp9zmIi",
+	"kCmw3F0zZTvmLUSoY7Dds4+nndWyqwpUjceRvqCxTfi8XZCmGQxkMhxAbJq14ANR/oSyMVAJA6mIUPIT",
+	"VZMBxGEigUCAodYKFPBssDNowOCv+p+NwU/ABSALmnzUdIEvDHnCAiLm70BNEELOxigVhHSKbjiYUSZb",
+	"cMxh4KxmoMeNtV7LCQYwQYHAGcSJiLnEHWA4c++ihCiRCiRRVI7mMCjNd9CAYaJA8JkE50ZgiCMuENSE",
+	"KBBJiIDXVOoHRCAIVIlg+kJqaucw00NbFjVAciDgh1SL1Lxvhg6pVEBYADaT1+9F4BMGUtEwBIEkADWh",
+	"EoQTrpZWLlyBMd/hM4ZiQ/+UVHGhDb4ALy+2t9drj533nl1eWDJUvI6pQNll+8S6wIhcW9N5+Wq7XbCk",
+	"zarlgzwbz4NfQWsdS9nH3quLiSjr2o43v0HqtzLpc/neYsLtWleiTFFmwYo4wVd0WhPorw7MnNjt05rM",
+	"ubDoUp2V59J/kIQ9JFJ9lOkU1hJ5ByFbw7ztAA+6GlCjHRkny+FuLr7iJEosa6TasULBVgfFjpLbB8au",
+	"134SRUTM18bGWf8rKDx2Qi1gxautRcwrQgVp/nO3+V8aKvKfrcuN5sXzSthY6wVD7cxImHokPjLOyqzh",
+	"/kla59gAxhUQGId8CP/73/8Dg+fa6f1F//N5YDzA4GLg3MgokRi0YBdSLxhpj4oSZhNkQBVYpwozqibW",
+	"O1hiTTd6aIbXCvwJEcTXbpau9br6JWRBSrob1zitQcHHyKk/gICjtLMJIqoWnzdxSsOBJt5xw/g6ZIEE",
+	"okpkUOMlYUbDwCci2Cn1NAAlEqkk4BTFHHLnZkkkCky7Fnwy/l3qZiS0ztpwq7E6YLgHL1rUqL+fn8vn",
+	"fzk//3x+fnHx/PPOX8/PNy4W7+pL8yS7t9BilfadGguuN8Qa+L2LV9ORh1mExeD9fFnfjzQvDaNnEy4z",
+	"tvr6DStShzbAGTYg4jrCitGnI+rDiAqpWnCmBT/hYd5W+jxGuEKMJUg6ZpSNG5CwAAVc4RzGgjAlXeBE",
+	"5jDUiqMfqglhpUEFn/1JwjMLiTugERsiJCxVpSuc/2QJMLQAMiXmWhlnJqhDycNEzxRi6l9J4Cycw8iZ",
+	"SEyEymzEEMy4jdTOtLZioONcyjQN4IeERtLYujJ80rbNULdqwASZ77TTTcHpOZ+ZgLVhTLmkvana3gpl",
+	"F9fQb5Y95zLZq0RtCXcCKbLbSr8BPFEojKwNW3c0VpnAG8HnTBHKJBDG1QSFNU131wJB6KLoIZ8iUNWC",
+	"Uz0oZRBQ+RunTFl2S8tEroCLQOsnkLHuWQESfwKmd8NxogduamO2siBME+pjgEBAIYmaWnsMdbq55Gmk",
+	"naqlJqgFJ1r4BnSHXE3MTUsCRrGaw4wU9R1GlJHwXkV0hyW80u5B2ZIrZb7Cr6Y++imkfAop7yekPNMh",
+	"0cNkmb/73NHM3WpAVe63hl0rErx7sanH2jwtcMFVOSx7nV5ItGCvlQ2h34Gc8BkDvCa+CufAmX/L/W2n",
+	"43aYgkrnHKvl+uqsx/R4+5zH9HjbjMf1XUvZQ2c7ZpA7Rpt3dFi1c631QI/gZX6nrqRkQF/jSFYYyF2x",
+	"vkpuv2633/5g+1ZZmcq92MP6Lax0xBXsr9vH8vXPEfWJwp7dx73DJpY/IZTd/fWHEUOc7XfdlbKarcRy",
+	"x41FFi4LQcsd/URQNe9ro7WcHyIRKHYTPXp69XO6Hv7vn87M7ntpWSmIKLMe0OSfG0Tf2HgOyIJYp0Ra",
+	"WQwqGL0yHeaMmSgVa7ZwGvhfMehJd38vHVPwCA6o+iUZgq3bk8CFvnNEhrDXvc3oEsWU+mgwq4aKsVSX",
+	"dg+qTEnfvuqIiXRAEMCUEuid9M9SZjhfuZYSLRPKRtwYIlVm0eegdwB9u9AA6WC7vW6hvmPH22y1W23D",
+	"xhgZiam34700t4x6ToxgHSkkCagBgTGq5ZDmFJWgOEUwzSDkY7d6N6KhMmmgZwYRRL+gzcM7QGVUwBRO",
+	"mgEFiVChkN7O5y+eTte9fyRoFqqs4/DMylrKDWKpGJEkVE7hsxUvc5WF15upddSG1zeN6gH5aCSxZsTi",
+	"eO3ybmuNp1o7XFaXmA+3ZMPVb+b1i1//qiJC7buy2+zl25VcVveILLhbfxcaoaxfNar3ot22++hMofWX",
+	"JI5DDU2Us43fpC2BygdZW59bKhc2VrOASZn2aqPYusfhy8V5FUN32ZSENABXTWfH33y88T9QKTVUcAHU",
+	"kUJyhPYa3gRJYIzzi/fp06emhjtkyviJij2D/CnlDCx82WUxEoYo7OZwLFAiU62SpuTL1u8N1oFAEkZ/",
+	"PvfG8bjpVk6bDnjPvQot0nPbflzRaUdOQtBUoQBbTVH0kwbRih7y84VWdpmG/xoMC9Bp3nW4m1ZlVcKu",
+	"zuIgLd42XpSEYVq0YN6sQ91D+/DBzG2x2qyCbYZ4PrJ0Pqn7j6TuRvRaVVPZx1xWqLeN8oGAjmVcnGp2",
+	"S7SmO94saXiPywUVN4D6ngfz+9Rul4HclMNq7e9vlsxq8z4HXiWaQ5yDPX+DAbiUa5SE4fzJnT3Z9yPa",
+	"d2a4DGepoWrDXXRsG9fb7bcmi19t/73Dvf4f3pQggLAAfm1tt99CIWE1wBCgIv4EA/vWa/B5FFGVkfFs",
+	"TBWM43HLhqR/1iT8tBpFftVUPgySlNczHhlNFteynhDlCVG+B0Sxdr8KV76Y1a2b/BDJsgTM8RMEUgiX",
+	"l1DAtslw4DBdMqtYqoiJmuQpcLq4Vrblainubr5/sfdyf6uz/fOrg9e/vHnkxLjqJE4NEKTHZ55M70cy",
+	"vcxQVhjahqlH92sTVZ3fmgIj0yyL4UleOKVvmUOb9fmqMT97oOP3b4QxRs1CZNI0mwplwS6vz5c6GMfN",
+	"NPmvf2dJ4L2cw896Bz1wx2VMFeRyvPSs1/nw05M9/7/seau99Xis0zDMuIIRT5gB4u9xpStHgSKeFEut",
+	"61e7bB2hsjVeeSEvZX6YBFqp0sI9nSDYPV5TqFm/FNZPx31AJ1tVa17B34yUJ4v84ZbDUpU2W5SyoAjV",
+	"ubHuiQv6T+2Y97pAA81wNQfFTWDcgl2YoqAjmnZpNxpNuW8s+BRdsbHkEcKMi6tRyGfAGRAGxPcx1rTY",
+	"6jkgUhuUdtg8EWadGpnvanht7a9taGtH5YRomxvOK2rb2eKOq7FS0ywW3JwFsG2OyDCtXCX5MQGtNkPM",
+	"WIXXWqpUhfNWfQJfMu/7T+DLR8seOYGvOSNVjywp656y9+885Hj7eKxLVUdH1Q3DQIcKLK2Oh5hQ0QAS",
+	"CiTB3J4Zld9jcGJKxzUCFkG4KkbZ+EJXry7YAsMCdg3nQIMWnE2ozE8YMfRRSiJoOAepeFw8nJSub+wU",
+	"z2wocoWy7uSPO4M7FFyrsjkYYCCehJKnx1eocn3oS4Ow7pAVUe5kSXYapQGzCfUnpeMo7uDCmtMS2SkG",
+	"xROzEmuICO2plBQM3WkDc/CAMhiUi/ndkbHlgv7BO+vD8lML688r1C7qpL7hlqs6dHU2ue7bNxcPH2Au",
+	"1LWusGYnsScg/n5yvwyI0/wPzIa/Bd2CPL831M2wsioELqJvXpZenx+aAohibZ18BxJ9geaUKQpKQmA6",
+	"4oQQydSB6f772uzwLC3BezDTXa7Hr2CzI+PJWn+4vLCszPUJoU0CgJjIoKnDggBs54Ui270uyLlUGNny",
+	"TJ7k0Y6N6qyPjssnVMB8n8N9/KN4TGVF2lWwm/tPuornrB455ao8s1RnsK6u9ynbesq2bss6qzc64PwX",
+	"yKc+UKZ0DlSEsGWHfvtkyqKRSaXemYjHqQSVQKMIA2oQUOelKCKi57sq+rcQ9f3H/lUn2mo16ynu/+7i",
+	"fgcJ/6pRfwU62I+I1gb6exP0r4y0bcPskxW2p6pY3n6u9CHD+IVP1Vblb26iVEL6lVQjt5ffhobs+6xG",
+	"bJlcbB9gPv1qpWG365pX9quQX7O/r82JqESg24uwk6qST/adxtudBMq+0v0oW/mVO/Gr5LD81cn6nXo9",
+	"56ddZLGghVXbxOaPDNQWi/bpmMGYqrTe0xyJSIzPMdhgq7wOegeVlV46b+nbP2Lw8OqXnpuyLi/v9tem",
+	"+6xm01TCfGV0UZdm6Txuw2R0X7GcWPjE560SrPa9DbrCYA565kSjQZRHz6nekwBOv20+1UhDJ7MNk7Cs",
+	"CsJVQvoCzTYwCb+/eOrlt4inSBjyGQagOCQS7afmrn4PeLz14v5SzoXPFFcMr1uAOVwLeO0jBt8youxb",
+	"p+CIvd/4aP0SuwuPPjIyJdQe4l2KavMz558vNJYvnwJfjHWNbyr4JaP1/xcAAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/client/pkg/api/api.gen.go
+++ b/client/pkg/api/api.gen.go
@@ -158,9 +158,11 @@ type AuditLogsResponse struct {
 
 // CoveringSubject defines model for CoveringSubject.
 type CoveringSubject struct {
-	Id            string        `json:"id"`
-	KeyIds        *[]string     `json:"keyIds"`
-	Name          SubjectName   `json:"name"`
+	Id     string      `json:"id"`
+	KeyIds *[]string   `json:"keyIds"`
+	Name   SubjectName `json:"name"`
+
+	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?` and `[` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
 	SubjectPrefix SubjectPrefix `json:"subjectPrefix"`
 }
 
@@ -240,24 +242,28 @@ type SignResponse = string
 
 // SubjectCreate defines model for SubjectCreate.
 type SubjectCreate struct {
-	ExpiresInDays *int          `json:"expiresInDays,omitempty"`
-	Issuer        string        `json:"issuer"`
-	KeyIds        *[]string     `json:"keyIds,omitempty"`
-	Name          SubjectName   `json:"name"`
+	ExpiresInDays *int        `json:"expiresInDays,omitempty"`
+	Issuer        string      `json:"issuer"`
+	KeyIds        *[]string   `json:"keyIds,omitempty"`
+	Name          SubjectName `json:"name"`
+
+	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?` and `[` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
 	SubjectPrefix SubjectPrefix `json:"subjectPrefix"`
 }
 
 // SubjectCreatedResponse defines model for SubjectCreatedResponse.
 type SubjectCreatedResponse struct {
-	Active        bool          `json:"active"`
-	CreatedAt     string        `json:"createdAt"`
-	ExpiresAt     *string       `json:"expiresAt"`
-	Id            string        `json:"id"`
-	Issuer        string        `json:"issuer"`
-	KeyIds        *[]string     `json:"keyIds"`
-	LastUsedAt    *string       `json:"lastUsedAt"`
-	Name          SubjectName   `json:"name"`
-	RevokedAt     *string       `json:"revokedAt"`
+	Active     bool        `json:"active"`
+	CreatedAt  string      `json:"createdAt"`
+	ExpiresAt  *string     `json:"expiresAt"`
+	Id         string      `json:"id"`
+	Issuer     string      `json:"issuer"`
+	KeyIds     *[]string   `json:"keyIds"`
+	LastUsedAt *string     `json:"lastUsedAt"`
+	Name       SubjectName `json:"name"`
+	RevokedAt  *string     `json:"revokedAt"`
+
+	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?` and `[` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
 	SubjectPrefix SubjectPrefix `json:"subjectPrefix"`
 }
 
@@ -269,7 +275,7 @@ type SubjectListResponse struct {
 // SubjectName defines model for SubjectName.
 type SubjectName = string
 
-// SubjectPrefix defines model for SubjectPrefix.
+// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?` and `[` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
 type SubjectPrefix = string
 
 // SubjectRevokeResponse defines model for SubjectRevokeResponse.
@@ -287,15 +293,17 @@ type SubjectRevokeResponse struct {
 
 // SubjectSummary defines model for SubjectSummary.
 type SubjectSummary struct {
-	Active        bool          `json:"active"`
-	CreatedAt     string        `json:"createdAt"`
-	ExpiresAt     *string       `json:"expiresAt"`
-	Id            string        `json:"id"`
-	Issuer        string        `json:"issuer"`
-	KeyIds        *[]string     `json:"keyIds"`
-	LastUsedAt    *string       `json:"lastUsedAt"`
-	Name          SubjectName   `json:"name"`
-	RevokedAt     *string       `json:"revokedAt"`
+	Active     bool        `json:"active"`
+	CreatedAt  string      `json:"createdAt"`
+	ExpiresAt  *string     `json:"expiresAt"`
+	Id         string      `json:"id"`
+	Issuer     string      `json:"issuer"`
+	KeyIds     *[]string   `json:"keyIds"`
+	LastUsedAt *string     `json:"lastUsedAt"`
+	Name       SubjectName `json:"name"`
+	RevokedAt  *string     `json:"revokedAt"`
+
+	// SubjectPrefix A literal prefix of the token's `sub`, not a glob — `*`, `?` and `[` are refused. A subject matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. Where several rows match, the longest live prefix wins.
 	SubjectPrefix SubjectPrefix `json:"subjectPrefix"`
 }
 
@@ -2874,72 +2882,75 @@ func ParsePostSignResponse(rsp *http.Response) (*PostSignResponse, error) {
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7Fz9UuO4ln+VU75TtTOzCQQa+oOpW7UBMkwWGrIEtudu05dR7JNEgy35SnLAt4uqfYh9wn2SW5L8mdhO",
-	"mgv0cDv8Q2zL0tH5+J1zpCN/dlwehJwhU9LZ++xId4oBMT+7kUdV11WUM32JLAqcvY+OpBPmtJwbjK+j",
-	"0OfESy4EV0Sh03IUv0F27QosXgqc8Rt9KaPR7+iq/Hl6I2nxqeWoOERnz5FKUDZx7luWkhM+kecoQ84k",
-	"anpCwUMUiqIh1uURU/pHQBkNNKWdrCPKFE5Q6J58PjHNqcJALvZCstl+J3Ds7Dl/2szZs5nwZrPImPuW",
-	"g0JwccA9XPZeL2t433Kop5uPuQiIcvacKKKakQtTp1JGKJKJnSCbqKmzt1XR8AbjvrdCuwAV8YgiuunC",
-	"Q4F/i1Cq/mq0JZJbYVAZuS5KWRhzxLmPxPBP0QClIkFYGtQjCtv60eLICaFUoKcV0hKXdVKcRSuVaMbI",
-	"nOqUZTl1uepx2+Q+u0GEIPHCyEabWonuVb19wGeoaR7mnCornNWCamGWFXWhDYt8n4x8dPaUiHCe0pbD",
-	"SLBUIxO6TnXTXKADgWN6t+K7SeNKoRgS5rvNZlfFsF7RllLE6V5e/HL9vj8c9k+PnJa97J/+d/ekf+i0",
-	"nOPeX65Pzy6ufz67PC1ed09Ozj700juD87ODnunhund+fnae3D7pDy9KNy4HJ2fdw9Ktw95J76KX3Rr2",
-	"j06zi/PuRe/6pP++f1FxywyeEHp93vuvy97wwtB/WGheJL1/etE7P+2eJA+roNAwqAkGvxCGDHitYMFf",
-	"ggxzqmCHaFnaqoT+CxJfTRsmNUX3pgKtNYyNiH1jEVZuMB4qLsik8vkcjYXGrbzfKmKlIiqSy3hspzS0",
-	"bR+CcS1nhkImzigkSqFgzp7z16sr79+vrjYK/75bKoCE5DJIpt23UvbWS2aYTTm1yKm5H2te4UQQD71K",
-	"ZT3G+BB91AhcL11Pt0CvWogNjmN+kknLVtZh1YSOMT6hUvUVBhXe359wQdU0qMRbG7B4XVX5dEzZBEUo",
-	"KFP1iF7xZFEPjUsqdlcculUgsmF+9dy+wbjsV5q0uMitZb7QdFxDUj05zSyfY2pA7lKI2um0ioilLwtG",
-	"8rHb/pm0x532u0+fdzr33zmN8VLe69brUq/6sqbXrdfVvTYGOpFE8XAlyFmV9VTD7ksbli8yWwRcoDcQ",
-	"dEYUHmM8P/1Op1Pm61an80ysm2PBIqnpsFVzHkQjn7pzioZ3JAh1eOS09d9+76h/CoOjAQwu90/6B3Dc",
-	"+wvsn5wdHJvHV2xjY6NKoudE4QkNqOqlnvLZPK4ScXesbPSPd64fSTrD92l+Y6O+pnSnyQ+X+q/i6ZBO",
-	"2Ll1+mVuKoEI2+/G463X7jt3awe3X+9uj7a3x29Hb96ORp23ZJd03rx71XG3dt5csZAIZAosd5dM2Y65",
-	"ggh1DNa9uDzvNcsuCVEPbKq5IDq8C6lA2WeHxIJiQO4sM1+93u0UeLtVlUrmmVkeDglaCzVl1H1U0Ako",
-	"69uOt/5oaUCSAcwnX0nrSr0rysxr8ByuorOa0K/ZVSdit09rsqhCAl6doeXSf5LkzSdSXcp0CkuJfICQ",
-	"7XLLqgM8UWZYoxcZD8uhTy64IvklZrVSvWhQreYAKaFk9SAp6XUYBQER8dI4Keu/gcLTRJwFlHi9M4+e",
-	"RZAg7b932/+jQSL/uXG92f7043cNuJhLszDQ9u5uw0hXV8MfP+79x+Yn8+OvV1cyvWga6NwIq57nNTb2",
-	"EOhS1PfNqgt6+7FNL6QraGjX9ZwTOkMQ/FbC7ZRLhNCwAFz9hgQ1RUgUCzjDFgRcKpAhunRMXRhTIdUG",
-	"XExRv+3nbaXLQ4QbxFCCpBNG2aQFEfNQwA3GMBGEKd07URCQGEYIt1Q/VFPCSoMKfvtvEr632r8H2iwh",
-	"QMIk4AxFrHv7wRJgaAFkSsRA9WyIAoGS+5GeKYTUvZHAmR/DmAszRkiEAj42vy3BjIPh14WIpELvA1VT",
-	"yjQN4PqEBhL+/3//D5ThExEIDHWrFkyRuQg+18GpnYIlTr84RYEtIMyzz6UCX3P8ljKpPfRKBjW/aHa/",
-	"CI+LZDeJ2hKeCKTIbiv9FvBIoTCyNmzdg1s9D60C4HKmCGUSCONqiqJlOkjuotC896npnoz4DIGqDTjX",
-	"g1IGHpW/c8qUZbe0TOQKuPC0fgKZ6J4VIHGnYHo3HCd64LbAkFtZEKYJddFDIKCQBG2tPYY63VxyEEg8",
-	"Q5dVS03QBpxp4d9OkcGIq6m5aUnAIFQx3JKivsOYMuI/qogekLmXFg3Lllwp8wYITeF4HTes44Z/Nm64",
-	"4DfIniaJ+MOnBmbuVvZVof0SdjXE749iTc+1T1LgQrKhuehvBj7Rgr1TYBr8BHLKbxngHXGVHwNn7opb",
-	"WYmO22EKKp1zrJbrzaGt6XH1wNb0uGpYm/RdS9lTh7RmkAfGmQ90VbVzrfU9z+Bf/qBOpGRAX+JCGgzk",
-	"oVhfJbdfdzvvvrGF6mxH+lHsYfmadTpiA/vrFq5d/XNMXaJwYDduHrBq7U4JZQ9//WnEEGYL3A+lrGbv",
-	"oNxxa56Fi0LQckc3ElTFQ220lvMjJAJFN9Kjp1c/p8ud//nhwmy3Fb1g1wsosx7QZJ6bRN/Y/BGQeaFO",
-	"hrSyGFQwemU6zBkzVSrUbOHUc79g0LP+4UE6puABHFH1SzQCW6IjgQt954SM4KC/yugSxYy6aDCrhoqJ",
-	"VNd20blMydC+mhAT6IDAgxklMDgbXqTMSHzlUkq0TCgbc2OIVJmF8KPBEQztEgOkg3UH/cKG7p6ztdHZ",
-	"6Bg2hshISJ0955W5ZdRzagSbkEIijxoQmKBaDGnOUQmKMwTTDHw+kXBL1RTG1FcmAXTMIILoF7R5OEeo",
-	"jAqYGikzoCABKhTS2fv42dGJuvO3CEWc4vie49PANLW+wlIxJpGvEoXPdgHMVRZeb6XWURte37eqB+Tj",
-	"scSaEYvjdcrbKzWeaulwWQlSPtyCDVe/mZcqffmrigh1mFTYZS+vVl1V3SMy72H9fdIIZf2qUb3tTsdu",
-	"nDGF1l+SMPQ1NFHONn+XtuYhH2RpKV6pMtBYzRwmZdqrjWLnEYcvV+NUDN1nM+JTD5LyGTv+1vON/55K",
-	"qaGCC6AJKSRHaKflTJF4xjg/Ox8+fGhruEOmjJ9YxIPCU8oZWPiyC2LE91FAEEkFoUCJTG2UNCXfyts3",
-	"WAcCiR/8+cqZhJN2smbaToD3yqnQIj233ecVnXbkxAdNFQqw26dFP2kQreghP37Syi7T8F+DYQE6zbsJ",
-	"7qZlGJWwq7M4SOs0jRclvg9ScYEemDfrUPfYPnwyc5svL6lgmyGejy2da3X/ltTdiF6rair7kMsK9bZR",
-	"PhDQsUwSp5p9Eq3pCW8WNHzA5ZyKG0Dd5178mNqdZCD35bBa+/v7BbPaesyBm0RzjDHYUnv0IEm5xpHv",
-	"x2t3trbvZ7TvzHAZ3qaGqg133rFt3u123pksvtn+B8cHwz+9LUEAYR78urHbeQeFhNUAg4eKuFP07Ftv",
-	"wOVBQFVGxvcTqmASTjZsSPpnTcIPzSjyq6byaZCkvJ7xzGgyv5a1RpQ1orwERLF234Qrn83q1n1eNb4o",
-	"AVNvjkAK4fICCtg2GQ4cp0tmFUsVIVHTPAVOF9fKtlwtxe7W/vbBq8Od3u7Pr4/e/PL2mRPjqtL7GiBI",
-	"6+XXpvctmV5mKA2GthmawuraRFXnt6a0yDTLYniSl0zpW+aUVn2+aszPVnD/8Y0wxKBdiEzaZlOhLNjF",
-	"9flSB5OwnSb/9e8sCHyQc/j7wdEAkvr4H7TxLMZL3w96739Y2/M/Zc87nZ3nY52GYcYVjHnEDBC/xJWu",
-	"HAWKeFKsp61f7bIVhMpWd0HyTgsoc/3I00qVluzpBMHu8ZoSzfqlsGE67hM62aqC4gr+ZqSsLfKbWw5L",
-	"VdpsUcqCIlTnxronLujftWM+6AP1NMNVDIqbwHgDujBDQcc07dJuNJpC31DwGSZlxpIHCLdc3Ix9fguc",
-	"AWFAXBdDTYutngMitUFph80jYdapkblJ9a6t+rUNbdWonBJtc6M4rfbFkEuquIh193M7rsZKTbNQcD3l",
-	"pM0JGaU1qyTlhlWbEWaswjstVar8eKM+gS+Z9+Mn8OWTQ8+cwNccgalHlpR16+z9hYcc756Pdanq6Ki6",
-	"ZRiYoAJL6+IhJFS0gPgCiRcD3lFpoeulAbEpGtcIWAThqhhl8zNtXl2wBYYF7BrFQL0NuJhSCR5HaaI4",
-	"hi5KSQT1Y5CKh/bIRfJGogx7xdMaitygrcYvnZpIjycYtBwJrlXZHAkwEE98ydODK1QlfehLg7CmTMO0",
-	"s2dKsnMoLbidUndaOoiSHFlYck4iO7+geGRWYg0Rvj2PkoJhcs7AHDmgDH4rl/H/ZtTrt8VS/t9+sj4s",
-	"P6+w/KRC7aJO6htWXNWhzdnkso9dfHr6AHOurrXBmhOJrYH45eR+GRCn+R+YDX8LugV5vjTUzbCyKgQu",
-	"om9ell6fH5oCiGJtnfwJJLoCFQREoaDEB6YjTvCRzBIwPdyvzQ4v0hK8JzPdxXr8CjYnZKyt9ZvLC8vK",
-	"XJ8Q2iQAiIkM2jos8MB2XiiyPeiDjKXCwJZn8iiPdmxUZ310WD6hAlSCQBUJZpKu/JhKQ9pVsJvHT7qK",
-	"56yeOeWqPLNUZ7BJXe8621pnW6uyzuqNDjj/BfKp95QpnQMVIWzRoa+eTFk0MqnUTybiSVSCSqBBgB41",
-	"CKjzUhQB0fNtiv4tRL382L/qRFutZq3j/hcX9yeQ8K8a9Vegg/1qYG2gfzBF98ZI2zbMPlZhe6qK5e33",
-	"CZ8yjJ/7NmVV/pZMlEpIP4to5Pbq69CQfZDRiC2Ti+0DzLcerTTsdl37xn4G7kv297U5ERUJTPYi7KSq",
-	"5JN9mG21k0DZB3mfZSu/cie+SQ6Ln5mr36nXc17vIos5LazaJjbfE68tFh3SCYMJVWm9pzkSERmfY7DB",
-	"VnkdDY4qK7103jK03yt/evVLz01Zl5d3+2s7+Y5e21TCfGF0UZdm6Txu02R0X7CcWPim30oJVufRBm0w",
-	"mKOBOdFoEOXZc6p94sH5182nWmnoZLZhIpZVQSSVkK5Asw1M/JcXT736GvEU8X1+ix4oDpHU86XSws3X",
-	"xuOd7cdLOee+S1oxvG4B5nAt4J2L6H3NiHJonUJC7OPGR8uX2JPw6JKRGaH2EO9CVJufOf/4SWP54inw",
-	"+VjX+KaCXzJa/48AAAD//w==",
+	"7Hz7cts4sverdHGnajP5JFlO7Fw0tbWj2BqPPju2juWczJ7Ya0NkS8KYBLgAKFubctV5iPOE50lO4cKb",
+	"RMqK1/YkG+ePWCRBoNGXX3cDDX72fB7FnCFT0ut89qQ/xYiYn90koKrrK8qZvkSWRF7nkyfphHkN7xLn",
+	"50kcchK4C8EVUeg1PMUvkZ37AouXAmf8Ul/KZPQ7+ip/nt5wLc4anprH6HU8qQRlE++mYSk54BN5jDLm",
+	"TKKmJxY8RqEoGmJ9njClf0SU0UhT2s46okzhBIXuKeQT05wqjORyLySb7Q8Cx17H+9NGzp4Nx5uNImNu",
+	"Gh4KwcUOD/C293pZw5uGRwPdfMxFRJTX8ZKEakYuTZ1KmaBwEztANlFTr7NZ0fAS5/1gjXYRKhIQRXTT",
+	"pYcC/5GgVP31aHOSW2NQmfg+SlkYc8R5iMTwT9EIpSJRXBo0IAqb+tHyyI5QKjDQCmmJyzopzqKRSjRj",
+	"ZE51yrKculz1uG1yk90gQpD50shGmxpO96re3uEz1DQPc06VFc5qQbUwy4q61IYlYUhGIXodJRJcpLTh",
+	"MRLdqpGOrkPdNBfoQOCYXq/5rmtcKRRDwmK32eyqGNYr2lKKON0PJ7+ev+8Ph/3DPa9hL/uH/9k96O96",
+	"DW+/97fzw6OT81+OPhwWr7sHB0cfe+mdwfHRTs/0cN47Pj46drcP+sOT0o0Pg4Oj7m7p1m7voHfSy24N",
+	"+3uH2cVx96R3ftB/3z+puGUGd4SeH/f+40NveGLo3y00L5LePzzpHR92D9zDKig0DFoFg18IQwa81rDg",
+	"L0GGBVWwQzQsbVVC/xVJqKYrJjVF/7ICrTWMjYh9YxlWLnE+VFyQSeXzBRoLjRt5v1XESkVUIm/jsZ3S",
+	"0La9C8Y1vBkK6ZxRTJRCwbyO9/fT0+D/nZ62Cn9+uFUAjuQySKbdN1L21ktmmE05tcipuT/XvMKJIAEG",
+	"lcq6j/NdDFEjcL10A90Cg2ohrnAci5N0LRtZh1UT2sf5AZWqrzCq8P7hhAuqplEl3tqAJeiqyqdjyiYo",
+	"YkGZqkf0iifLemhcUrG74tCNApEr5lfP7Uucl/3KKi0ucus2X2g6riGpnpzVLF9gakSuU4jaajeKiKUv",
+	"C0byqdv8hTTH7ebbs89b7ZsfvJXxUt7r5qtSr/qyptfNV9W9rgx0Eoni7kqQsyrrqYbdH2xYvsxsEXGB",
+	"wUDQGVG4j/PF6bfb7TJfN9vtR2LdAguWSU2HrZrzIBmF1F9QNLwmUazDI6+p/73r7fUPYbA3gMGHdwf9",
+	"Hdjv/Q3eHRzt7JvHp6zValVJ9JgoPKARVb3UUz6ax1Vi3h0rG/3jtR8mks7wfZrf2KhvVbqzyg+X+q/i",
+	"6ZBO2LF1+mVuKoEIL96Ox5uv/Lf+5ha+eLX9YvTixfjN6PWb0aj9hmyT9uu3L9v+5tbrUxYTgUyB5e4t",
+	"U7ZjriFCHYN1Tz4c91bLzoWoOzbVXBIdXsdUoOyzXWJBMSLXlpkvX223C7zdrEol88wsD4cErYWaMure",
+	"K+hElPVtx5tfWxrgMoDF5Mu1rtS7osyCFZ7DV3RWE/qtdtVO7PZpTRZVSMCrM7Rc+g+SvIVEqg8yncKt",
+	"RN5ByHa5Zd0BHigzrNGLjIfl0CcXXJH8ErMaqV6sUK3VAZKjZP0gyfU6TKKIiPmtcVLW/woKD504Cyjx",
+	"amsRPYsgQZr/7Db/S4NE/rN1vtE8e/7DClzMpRmg9AWN7eKX14WQKhQkhNi0AD4GNUUwK3l/lnAhk9FF",
+	"AxhXQGAS8hH873//D1w8v2jAxV8vgLAALj5dABEIAseJxKAFXXATh4gof4oSrqbIgCqQiggl4YqqKagp",
+	"lWDpNN3oURleK/CnRBBfoQAqgUCAoXbJKODZRUcP+7P+b+PiR+DCvIQsSKl24zZAcrgQGPMOv2IoNuTM",
+	"v4CAo7QTCSKqFp83cUbDC028Y4SaEqX7lkBUiQwqzVhXNAx8IoJOqacLUCKRSgLOUMxBP5FUcTG3JBIF",
+	"pl0LPk5RIEjdjIQg+JW03GqYzkPOJigVhHSGKUFXlMmWMY3UUxbGzQfSrjfXpRfb26uU6e+np/L5Xz+d",
+	"np6dPf/U+XnjrHxHX3R+3nDXpWerlO3YGGy93dXg7F3cl6JhaFbeMHg3X1bvA80/w9yrKZcZK339hhWj",
+	"AxfgDBsQcalAxujTMfVhTIVULTjRwp7yMG8rfR4jXCLGEiSdMMomDUhYgAIucQ4TQZiSVtoRmcNIK4t+",
+	"qKaElQYV/OrPEp5ZBOyAhmaIkLBUfS5x/qMlwNACyJSYawW80n0LlDxM9Ewhpv6lBM7COYydWcREqMwu",
+	"DMGMg+HXidZQDD5SNaVM0wB+SGgkjWkrwydtzwx1qwZMkflOI90UnG7zK9BK3DDmW9LYVFXXAtXFhdOb",
+	"ZRe5TPYqUVvCnUCK7LbSbwBPFAoja8PWjsYngVoFwOdMEcokEMbVFIU1R3fXGn9ITfdkxGcIVLXgWA9K",
+	"GQRU/s4pU5bd0jKRK+Ai0PoJZKJ7VoDEn4Lp3XCc6IGb2oCtLAjThPoYIBBQSKKm1h5DnW4uOQgkFi+t",
+	"WmqCWnCkhW+AdsTV1Ny0JGAUqzlckaK+w5gyEt6riO6welNaOC5bcqXMV7jR1CU/xY5PseO/Gjue6Njn",
+	"YRLJrz49NHO3sq9K725h14oc7l6s6bH2ygpccJvay/5mEBIt2GtlY+WfQE75FQO8Jr4K58CZv+Z2ptNx",
+	"O0xBpXOO1XJ9dXpjelw/uTE9rpvauL5rKXvotMYMcsc4846uqnautb7nEfzLV+pESgb0JS5khYHcFeur",
+	"5Pbbdvvtd7ZZkVUl3Is93L5vkY64gv11mxe+/jmmPlE4sJt3d9i58KeEsru//jBiiLNNjrtSVrN/VO64",
+	"scjCZSFouaOfCKrmQ220lvMjJAJFN9Gjp1e/pEve///jidlyLa0fBRFl1gOazHOD6BsbzwFZEOtkSCuL",
+	"QQWjV6bDnDFTpWLNFk4D/wsGPerv7qRjCh7BHlW/JiOwZVoSuNB3DsgIdvrrjC5RzKiPBrNqqJhIdW43",
+	"HsqUDO2rjphIBwQBzCiBwdHwJGWG85W3UqJlQtmYG0Okyizx7A32YGiXGCAdrDvoFzb1O95mq91qGzbG",
+	"yEhMvY730twy6jk1gnWkkCSgBgQmqJZDmmNUguIMwTSDkE/cWt2YhsokgJ4ZRBD9gjYPbw+VUQFTJ2cG",
+	"FCRChUJ6nU+fPZ2oe/9I0CxLWcfhmXW0lBvEUjEmSaicwmfrW+YqC683U+uoDa9vGtUD8vFYYs2IxfHa",
+	"5S22Gk9163BZGVo+3JINV7+Zl6t9+auKCLXrqiyzl9ersKvuEVlwt/7ONEJZv2pU70W7bTdPmULrL0kc",
+	"hxqaKGcbv0tb95IPcms5Zqk61FjNAiZl2quNYusehy9XZFUM3WczEtIAXAmVHX/z8cZ/T6XUUMEFUEcK",
+	"yRHaa3hTJIExzs/ex48fmxrukCnjJyo2B/KnlDOw8GUXxEgYooAokQpigRKZapU0JV+kfmewDgSSMPrL",
+	"qTeJJ023Ztp0wHvqVWiRntv244pOO3ISgqYKBdgt9KKfNIhW9JCfzrSyyzT812BYgE7zrsPdtBSnEnZ1",
+	"Fgdpra7xoiQMQSouMADzZh3q7tuHD2ZuiyVGFWwzxPOxpfNJ3b8ndTei16qayj7mskK9bZQPBHQs4+JU",
+	"s0+iNd3xZknDB1wuqLgB1Hc8mN+ndrsM5KYcVmt/f7NkVpv3OfAq0ezjHOxxCwzApVzjJAznT+7syb4f",
+	"0b4zw2V4lRqqNtxFx7Zxvd1+a7L41fY/2N8Z/ulNCQIIC+C31nb7LRQSVgMMASriTzGwb70Gn0cRVRkZ",
+	"zyZUwSSetGxI+hdNwo+rUeQ3TeXDIEl5PeOR0WRxLesJUZ4Q5VtAFGv3q3Dls1nduslPDixLwJw5QCCF",
+	"cHkJBWybDAf20yWziqWKmKhpngKni2tlW66WYnfz3Yudl7tbve1fXu29/vXNIyfGVccvaoAgPTPxZHrf",
+	"k+llhrLC0DZiU1xfm6jq/NaUFplmWQxP8pIpfcuc1KvPV4352Sr+r98IY4yahcikaTYVyoJdXp8vdTCJ",
+	"m2nyX//OksAHOYefDfYG4M5ImJrH5Xjp2aD3/scne/6X7HmrvfV4rNMwzLiCMU+YAeJvcaUrR4EinhRr",
+	"qutXu2wFobLVXXnZLmV+mARaqdKSPZ0g2D1eU6JZvxQ2TMd9QCdbVVRewd+MlCeL/O6Ww1KVNluUsqAI",
+	"1bmx7okL+k/tmHf6QAPNcDUHxU1g3IIuzFDQMU27tBuNptA3FnyGrsxY8gjhiovLccivgDMgDIjvY6xp",
+	"sdVzQKQ2KO2weSLMOjUy31Xv2qpf29BWjcop0TY3mldUsrPFHVdjpaZZLLip/LdtDsgorVkl+aEArTYj",
+	"zFiF11qqVIXzVn0CXzLv+0/gy6fHHjmBrzkGVY8sKeuesvdvPOR4+3isS1VHR9UNw0CHCiyti4eYUNEA",
+	"EgokwRzwmkoLXd8aEJuicY2ARRCuilE2PtPVqwu2wLCAXaM50KAFJ1Mq8/NEDH2UkggazkEqHhePIqXr",
+	"G53iaQ1FLlHWnfNpWLQcCa5V2RwJMBBPQsnTgytUuT70pUFYd6SKKHemJDuH0oCrKfWnpYMo7sjCLeck",
+	"svMLiidmJdYQEdrzKCkYunMG5sgBZXBRLuN3B8SWS/kvfrI+LD+vcPtJhdpFndQ3rLmqQ1dnk7d98OTs",
+	"4QPMhbrWFdbsJPYExN9O7pcBcZr/gdnwt6BbkOe3hroZVlaFwEX0zcvS6/NDUwBRrK2TP4FEX6A5U4qC",
+	"khCYjjghRDJzYLr7rjY7PElL8B7MdJfr8SvY7Mh4stbvLi8sK3N9QmiTACAmMmjqsCAA23mhyHanD3Iu",
+	"FUa2PJMnebRjozrro+PyCRWgEgSqRDCTdOXHVFakXQW7uf+kq3jO6pFTrsozS3UG6+p6n7Ktp2xrXdZZ",
+	"vdEB579BPvWeMqVzoCKELTv09ZMpi0YmlfrJRDxOJagEGkUYUIOAOi9FERE931XRv4Wobz/2rzrRVqtZ",
+	"T3H/Nxf3O0j4d436K9DBfjmyNtDfmaJ/aaRtG2Yfq7A9VcXy9huVDxnGL3yftCp/cxOlEtJPYxq5vfxj",
+	"aMg+ymnElsnF9gHme59WGna7rnlpPwX4Jfv72pyISgS6vQg7qSr5ZB/nW+8kUPZR5kfZyq/ciV8lh+VP",
+	"Ddbv1Os5P+0iiwUtrNomNt+Ury0WHdIJgwlVab2nORKRGJ9jsMFWee0N9iorvXTeMrTfrH949UvPTVmX",
+	"l3f7W9N9S7FpKmG+MLqoS7N0HrdhMrovWE4sfNdxrQSrfW+DrjCYvYE50WgQ5dFzqnckgOM/Np9qpKGT",
+	"2YZJWFYF4SohfYFmG5iE31489fKPiKdIGPIrDEBxSCTaD8tdfg14vPXi/lLOhW/TVgyvW4A5XAt47SMG",
+	"f2REObROwRF7v/HR7UvsLjz6wMiMUHuIdymqzc+cfzrTWL58Cnwx1jW+qeCXjNb/XwAAAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/client/pkg/api/spec_drift_test.go
+++ b/client/pkg/api/spec_drift_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+)
+
+// normalizeGeneratorRewrites undoes the three edits oapi-codegen and
+// kin-openapi make to a spec on the way into the embedded blob, so that a
+// comparison against the source document is a comparison of contracts rather
+// than of the generator's serialization habits.
+//
+// Applied to *both* documents, so each rewrite costs the test only its own
+// field: an `operationId` is never written by the Hono app, and the values
+// codegen derives for it come from the method and path, which are compared.
+// Deliberately targeted rather than a general "drop empty and false" sweep —
+// such a sweep would also erase `security: [{"bearerAuth": []}]`, where the
+// empty array is the scope list and its disappearance would be real drift.
+//
+// A rewrite this does not know about surfaces as a test failure, not as a
+// silent pass.
+func normalizeGeneratorRewrites(doc map[string]any) {
+	// kin-openapi marshals an empty component map away entirely.
+	if components, ok := doc["components"].(map[string]any); ok {
+		for key, value := range components {
+			if sub, ok := value.(map[string]any); ok && len(sub) == 0 {
+				delete(components, key)
+			}
+		}
+	}
+
+	paths, _ := doc["paths"].(map[string]any)
+	for _, item := range paths {
+		operations, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, value := range operations {
+			operation, ok := value.(map[string]any)
+			if !ok {
+				continue
+			}
+			// Synthesized by codegen when the source omits it, which the Hono
+			// app always does.
+			delete(operation, "operationId")
+
+			parameters, _ := operation["parameters"].([]any)
+			for _, entry := range parameters {
+				parameter, ok := entry.(map[string]any)
+				if !ok {
+					continue
+				}
+				// `omitempty` on kin-openapi's Parameter.Required.
+				if required, ok := parameter["required"].(bool); ok && !required {
+					delete(parameter, "required")
+				}
+			}
+		}
+	}
+}
+
+// TestEmbeddedSpecMatchesSource guards the second half of the generated-artifact
+// chain. A sibling TypeScript test (src/__tests__/openapi-spec.test.ts) checks
+// that client/openapi.json is what the Hono app produces; this one checks that
+// api.gen.go was generated from that same openapi.json.
+//
+// Without it, running only the first half of `task generate:api` — or resolving
+// a merge conflict in openapi.json by hand — leaves a client whose types, method
+// set and embedded spec describe an older contract, and every other test still
+// passes, because the code compiles and the spec parses.
+//
+// The embedded spec is the right proxy for the whole file: oapi-codegen writes
+// it from the same in-memory document it generates the types from, so an
+// embedded copy that is current means types that are current.
+func TestEmbeddedSpecMatchesSource(t *testing.T) {
+	const sourcePath = "../../openapi.json"
+
+	sourceBytes, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", sourcePath, err)
+	}
+	embeddedBytes, err := GetSpecJSON()
+	if err != nil {
+		t.Fatalf("decode embedded spec: %v", err)
+	}
+
+	// Compared as parsed documents rather than bytes: codegen re-serializes the
+	// spec into the blob, so key order and spacing are its choice, not drift.
+	var source, embedded map[string]any
+	if err := json.Unmarshal(sourceBytes, &source); err != nil {
+		t.Fatalf("parse %s: %v", sourcePath, err)
+	}
+	if err := json.Unmarshal(embeddedBytes, &embedded); err != nil {
+		t.Fatalf("parse embedded spec: %v", err)
+	}
+	normalizeGeneratorRewrites(source)
+	normalizeGeneratorRewrites(embedded)
+
+	if !reflect.DeepEqual(source, embedded) {
+		t.Errorf("pkg/api/api.gen.go was generated from a different %s than the one committed; "+
+			"run `task generate:api` and commit the result", sourcePath)
+	}
+}

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -75,6 +75,61 @@ entry in `ALLOWED_ISSUERS` might.
 Omit `keyIds` to allow every key. Omit `expiresInDays` for a trust that does
 not expire.
 
+### `subjectPrefix` is not a glob
+
+There is no pattern syntax. A `sub` is admitted when it **starts with** the
+stored string and the next character is a delimiter (`:`, `@` or `/`) or the
+end of the subject — nothing else. `*`, `?` and `[` are therefore refused with
+`400`, because a stored `repo:kjanat/*` would be compared literally and match
+only a repository actually named `*`: a row that lists as `active`, authorizes
+nobody, and surfaces days later as `Subject is not trusted for signing` on some
+unrelated run.
+
+The trailing delimiter **is** the wildcard. `repo:kjanat/` is what
+`repo:kjanat/*` was reaching for:
+
+| You want                             | Write                | Not                    |
+| ------------------------------------ | -------------------- | ---------------------- |
+| Every repo of an owner               | `repo:kjanat`        | `repo:kjanat/*`        |
+| Every repo of an owner, `/` boundary | `repo:kjanat/`       | `repo:kjanat/*`        |
+| One repository, any ref              | `repo:kjanat/kjanat` | `repo:kjanat/kjanat:*` |
+| Every repository on the issuer       | _not possible_       | `repo:*`, `repo:`      |
+
+`repo:kjanat` and `repo:kjanat/` differ only in which boundary they accept —
+prefer the first, per the tip above.
+
+What a prefix **cannot** express is a cut anywhere but the start. Trusting only
+tagged builds — `repo:kjanat/kjanat:ref:refs/tags/…` but not
+`refs/heads/master` — would need a suffix or middle match, and there is none.
+Write the prefix as far right as it stays constant
+(`repo:kjanat/kjanat:ref:refs/tags/`) and it will admit exactly the tag refs,
+but understand that this only works because the varying part happens to be at
+the end. Anything else has to be enforced in the workflow, not here.
+
+### Names and prefixes are separate unique keys
+
+Two different `409`s come out of `POST /admin/subjects`, and they want opposite
+fixes:
+
+| Error message begins                               | What collided                              | Fix                                                            |
+| -------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------- |
+| `Subject name already exists: …`                   | `name`, against **every** row ever created | Pick a different `name`. The prefix in your request was fine.  |
+| `Issuer and subject prefix are already claimed: …` | `(issuer, subjectPrefix)`, unrevoked rows  | Revoke the row named in the error, then re-POST. Do not widen. |
+
+`name` is a label for one generation of a trust, not a slot: it is unique
+across revoked and expired rows too and is never freed, because every OIDC
+`sign` audit event is keyed by it. The message says which row is holding it and
+whether that row is still live, revoked or merely expired — an expired row
+trusts nobody but still owns its name and its prefix.
+
+So a `Subject name already exists` when you were changing the **prefix** means
+the previous trust under that name is still there, untouched, and your new
+prefix was never stored. `GET /admin/subjects` shows what is actually live; use
+a fresh name such as `statute-oidc-2` for the replacement, and revoke the old
+row if you meant to replace rather than add — see
+[Renewing an expired trust](#renewing-an-expired-trust) for the full sequence
+and why the name can never be reused.
+
 ### Immutable subject claims change `sub` under a live row
 
 A GitHub repository that enables immutable subject claims stops issuing

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -98,6 +98,13 @@ The trailing delimiter **is** the wildcard. `repo:kjanat/` is what
 `repo:kjanat` and `repo:kjanat/` differ only in which boundary they accept —
 prefer the first, per the tip above.
 
+The `400` guards new rows only. A glob created before this rule existed is
+still in the table, and `GET /admin/subjects` still lists it — as `active`,
+matching nothing — so that you can find it and `DELETE` it. That is also why
+the response schema publishes no pattern for `subjectPrefix` while the request
+schema does: a client that validated responses against the create rule could
+not read the listing containing the row it needs to revoke.
+
 What a prefix **cannot** express is a cut anywhere but the start. Trusting only
 tagged builds — `repo:kjanat/kjanat:ref:refs/tags/…` but not
 `refs/heads/master` — would need a suffix or middle match, and there is none.
@@ -118,9 +125,13 @@ fixes:
 
 `name` is a label for one generation of a trust, not a slot: it is unique
 across revoked and expired rows too and is never freed, because every OIDC
-`sign` audit event is keyed by it. The message says which row is holding it and
-whether that row is still live, revoked or merely expired — an expired row
-trusts nobody but still owns its name and its prefix.
+`sign` audit event is keyed by it. The message normally goes on to say which row
+is holding it and whether that row is still live, revoked or merely expired — an
+expired row trusts nobody but still owns its name and its prefix. That second
+clause comes from a lookup made after the insert failed, and it is deliberately
+best-effort: rather than let a read error turn the `409` into a `500`, it drops
+back to the bare `Subject name already exists: <name>`. So treat the id as a
+convenience, not a guarantee; the fix — pick a new name — does not depend on it.
 
 So a `Subject name already exists` when you were changing the **prefix** means
 the previous trust under that name is still there, untouched, and your new

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -79,11 +79,11 @@ not expire.
 
 There is no pattern syntax. A `sub` is admitted when it **starts with** the
 stored string and the next character is a delimiter (`:`, `@` or `/`) or the
-end of the subject — nothing else. `*`, `?` and `[` are therefore refused with
-`400`, because a stored `repo:kjanat/*` would be compared literally and match
-only a repository actually named `*`: a row that lists as `active`, authorizes
-nobody, and surfaces days later as `Subject is not trusted for signing` on some
-unrelated run.
+end of the subject — nothing else. `*`, `?`, `[` and `]` are therefore refused
+with `400`, because a stored `repo:kjanat/*` would be compared literally and
+match only a repository actually named `*`: a row that lists as `active`,
+authorizes nobody, and surfaces days later as `Subject is not trusted for
+signing` on some unrelated run.
 
 The trailing delimiter **is** the wildcard. `repo:kjanat/` is what
 `repo:kjanat/*` was reaching for:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -89,8 +89,14 @@ the one people hit while editing a **prefix** is the **name** rule:
   message, then re-POST. **Do not edit the prefix to dodge the collision** —
   the nearest string that avoids it is a broader one, which widens access.
 
-Either message names the blocking row's id and its state, so the fix comes
-straight out of the error. Full rules in
+Both messages normally go on to name the blocking row's id and whether it is
+live, revoked or merely expired, so the fix comes straight out of the error.
+That lookup is best-effort — it runs after the insert has already failed and is
+allowed to give up rather than turn a `409` into a `500` — so if the row cannot
+be read you get the first sentence and nothing more. That is not a different
+problem: `GET /admin/subjects` lists the same row, and for a name collision the
+row may be revoked or expired and so absent from the live view, in which case
+the name is simply taken and a new one is the fix either way. Full rules in
 [names and prefixes are separate unique keys](authentication.md#names-and-prefixes-are-separate-unique-keys).
 
 ### `400 Subject prefix is a literal prefix, not a glob`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -76,6 +76,49 @@ database. The plaintext cannot be recovered; mint a replacement when lost.
 The service token has a key allowlist that does not contain the selected key.
 Mint a correctly scoped token or select an allowed key.
 
+### `409` from `POST /admin/subjects`
+
+Read which of the two uniqueness rules fired — they want opposite fixes, and
+the one people hit while editing a **prefix** is the **name** rule:
+
+- `Subject name already exists: <name>` — the `name` is taken, by a row that
+  may be live, revoked or expired. Names are never freed. Your prefix was not
+  stored; POST again under a new name.
+- `Issuer and subject prefix are already claimed: <issuer> <prefix>` — that
+  `(issuer, prefix)` pair is held by an unrevoked row. Revoke the id in the
+  message, then re-POST. **Do not edit the prefix to dodge the collision** —
+  the nearest string that avoids it is a broader one, which widens access.
+
+Either message names the blocking row's id and its state, so the fix comes
+straight out of the error. Full rules in
+[names and prefixes are separate unique keys](authentication.md#names-and-prefixes-are-separate-unique-keys).
+
+### `400 Subject prefix is a literal prefix, not a glob`
+
+`subjectPrefix` has no pattern syntax, so `repo:owner/*` is refused rather than
+stored as a row that would match nothing. Use the trailing-delimiter form —
+`repo:owner` or `repo:owner/` — which is what the glob was reaching for. See
+[`subjectPrefix` is not a glob](authentication.md#subjectprefix-is-not-a-glob).
+
+### The subject was created but signing still returns `401`
+
+The row exists and does not match. Compare the failing run's `sub` against
+`GET /admin/subjects` character by character:
+
+- the prefix must match from the **start** of the subject and end on a `:`, `@`
+  or `/` boundary — `repo:owner/svc` never admits `repo:owner/svc-two`;
+- a repository with immutable subject claims issues
+  `repo:owner@<id>/name@<id>:…`, which an exact-repository row written for the
+  old shape stops matching (see
+  [immutable subject claims](authentication.md#immutable-subject-claims-change-sub-under-a-live-row));
+- `issuer` must match `iss` exactly, trailing slash included; and
+- the row must be `active` — `expiresInDays` lapses silently.
+
+A shell footgun worth ruling out first: `-d '{"keyIds": ["${MY_KEY_ID}"]}'` in
+**single** quotes sends the literal `${MY_KEY_ID}`, so the variable never
+expands. That one is caught at create time with a `400` naming the key id, but
+the same quoting mistake in `subjectPrefix` stores a prefix nothing will match.
+
 ## Keys and signatures
 
 ### Invalid key ID

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -116,8 +116,10 @@ The row exists and does not match. Compare the failing run's `sub` against
 
 A shell footgun worth ruling out first: `-d '{"keyIds": ["${MY_KEY_ID}"]}'` in
 **single** quotes sends the literal `${MY_KEY_ID}`, so the variable never
-expands. That one is caught at create time with a `400` naming the key id, but
-the same quoting mistake in `subjectPrefix` stores a prefix nothing will match.
+expands. That one is caught at create time with a `400` whose `issues[].path` is
+`["keyIds", 0]` — the response never echoes the value, so read the path, not the
+message — but the same quoting mistake in `subjectPrefix` stores a prefix nothing
+will match.
 
 ## Keys and signatures
 

--- a/src/__tests__/oidc-subjects.test.ts
+++ b/src/__tests__/oidc-subjects.test.ts
@@ -925,6 +925,11 @@ describe("admin subject management", () => {
 			{ name: "ci/schemeonly", issuer: GITHUB, subjectPrefix: "repo" },
 			{ name: "ci/gitlabbare", issuer: GITHUB, subjectPrefix: "project_path:" },
 			{ name: "ci/delimsonly", issuer: GITHUB, subjectPrefix: "repo:/" },
+			// Matching is startsWith plus a delimiter check, never a pattern match,
+			// so a glob would store verbatim and match nothing.
+			{ name: "ci/glob", issuer: GITHUB, subjectPrefix: "repo:kjanat/*" },
+			{ name: "ci/globq", issuer: GITHUB, subjectPrefix: "repo:kjanat/svc?" },
+			{ name: "ci/globclass", issuer: GITHUB, subjectPrefix: "repo:kjanat/[ab]" },
 		];
 		for (const body of cases) {
 			const response = await adminRequest("/admin/subjects", {
@@ -934,6 +939,21 @@ describe("admin subject management", () => {
 			});
 			expect(response.status).toBe(400);
 		}
+	});
+
+	it("tells a caller who typed a glob which form to use instead", async () => {
+		// The whole point of refusing a glob is that the 400 teaches the
+		// trailing-delimiter form; a bare "invalid prefix" would send the operator
+		// looking for a pattern syntax that does not exist.
+		const response = await adminRequest("/admin/subjects", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name: "ci/globhint", issuer: GITHUB, subjectPrefix: "repo:kjanat/*" }),
+		});
+		expect(response.status).toBe(400);
+		const error = JSON.stringify(await response.json());
+		expect(error).toContain("not a glob");
+		expect(error).toContain("repo:owner/");
 	});
 
 	it("refuses an issuer that is not in ALLOWED_ISSUERS", async () => {

--- a/src/__tests__/openapi-spec.test.ts
+++ b/src/__tests__/openapi-spec.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import app from "#gpg-signing-service";
+import { openApiConfig } from "#lib/openapi";
+import { SUBJECT_PREFIX_PATTERN } from "#schemas";
+import committedSpec from "../../client/openapi.json";
+
+/**
+ * `client/openapi.json` and the Go client generated from it are build outputs
+ * that live in the tree, and nothing regenerates them on the way into CI. Until
+ * this test, the only thing standing between a schema edit and a spec that
+ * documents a rule the service no longer enforces was remembering to run
+ * `task generate:api` — and the failure is silent in both directions, because
+ * the committed spec parses fine and the generated client compiles fine.
+ *
+ * Comparison is on the parsed documents rather than the bytes: whitespace in
+ * the committed file is not a contract, and a byte check would fail for
+ * anybody's editor rather than for drift.
+ */
+describe("published OpenAPI spec", () => {
+	it("matches the document the app generates", () => {
+		// `JSON.parse(JSON.stringify(...))` and not the document itself: the
+		// generated object carries `undefined` properties that survive `toEqual`
+		// as present-but-undefined and vanish on the way through JSON, which is
+		// the form the committed file was written from.
+		const generated = JSON.parse(JSON.stringify(app.getOpenAPIDocument(openApiConfig)));
+		expect(generated, "client/openapi.json is stale — run `task generate:api` and commit the result").toEqual(
+			committedSpec,
+		);
+	});
+
+	// The request and response views of a subject prefix have to differ, and the
+	// difference is only visible in the published document: nothing validates a
+	// response at runtime, so a mistake here is invisible until a third-party
+	// client refuses a listing.
+	describe("subject prefix components", () => {
+		const schemas = (committedSpec as { components: { schemas: Record<string, Record<string, unknown>> } }).components
+			.schemas;
+		// A missing component would otherwise read as "no pattern published",
+		// which is what half of these assert.
+		const component = (name: string) => {
+			const schema = schemas[name];
+			expect(schema, `${name} is missing from the published spec`).toBeDefined();
+			return schema as Record<string, unknown>;
+		};
+
+		it("constrains what may be created", () => {
+			expect(component("SubjectPrefix").pattern).toBe(SUBJECT_PREFIX_PATTERN);
+			expect(component("SubjectCreate").properties).toMatchObject({
+				subjectPrefix: { $ref: "#/components/schemas/SubjectPrefix" },
+			});
+		});
+
+		it("does not constrain what may be read back", () => {
+			// A pattern on the stored view would re-impose the create rule on the
+			// read path, and rows predating the rule are exactly the ones somebody
+			// is listing in order to revoke.
+			expect(component("StoredSubjectPrefix")).not.toHaveProperty("pattern");
+			expect(component("StoredSubjectPrefix")).toMatchObject({ type: "string", minLength: 1, maxLength: 255 });
+			for (const name of ["SubjectSummary", "SubjectCreatedResponse", "CoveringSubject"]) {
+				expect([name, component(name).properties]).toEqual([
+					name,
+					expect.objectContaining({ subjectPrefix: { $ref: "#/components/schemas/StoredSubjectPrefix" } }),
+				]);
+			}
+		});
+	});
+});

--- a/src/__tests__/schemas.test.ts
+++ b/src/__tests__/schemas.test.ts
@@ -13,6 +13,7 @@ import {
 	KeyUploadSchema,
 	RequestHeadersSchema,
 	RequestIdSchema,
+	StoredSubjectPrefixSchema,
 	SUBJECT_PREFIX_PATTERN,
 	SubjectPrefixSchema,
 	TimestampSchema,
@@ -826,6 +827,28 @@ KIr+J8gAkl0Ny1G8TnlMq0M9xN3Vx1qb+QD/elKMaKzX3u8d9zvIykjW8K/WKWwy
 			}
 		});
 
+		it("publishes a pattern every engine that might compile it accepts", () => {
+			// JSON Schema's `pattern` is ECMA-262 without `u` or `v`, so nothing in
+			// this toolchain compiles it in `v` mode today — but a client is free
+			// to, and `v` mode reclassifies `[`, `]` and `/` inside a character
+			// class as set syntax and throws on the unescaped form. That is a
+			// startup crash in somebody else's client, caused by a character we
+			// only had to escape, so escape it and pin the property here rather
+			// than rediscover it from a bug report.
+			for (const flags of ["", "u", "v"]) {
+				expect(() => new RegExp(SUBJECT_PREFIX_PATTERN, flags)).not.toThrow();
+			}
+			// The escapes must be inert, not merely legal: `v` mode is stricter
+			// about syntax but must accept and refuse exactly what the unflagged
+			// engine does, or the spec means two different things depending on how
+			// a client chose to compile it.
+			const unflagged = new RegExp(SUBJECT_PREFIX_PATTERN);
+			const unicodeSets = new RegExp(SUBJECT_PREFIX_PATTERN, "v");
+			for (const prefix of ["repo:kjanat/svc", "repo:kjanat/", "repo:kjanat/*", "repo:kjanat/[ab]", "repo:", "a b"]) {
+				expect([prefix, unicodeSets.test(prefix)]).toEqual([prefix, unflagged.test(prefix)]);
+			}
+		});
+
 		it("agrees with both checks on every short string over the interesting alphabet", () => {
 			// The corpus above only covers characters somebody thought to list, so it
 			// would stay green if a later rule added, say, `\\` to the glob class and
@@ -835,10 +858,16 @@ KIr+J8gAkl0Ny1G8TnlMq0M9xN3Vx1qb+QD/elKMaKzX3u8d9zvIykjW8K/WKWwy
 			// makes the round trip exhaustive rather than illustrative.
 			const alphabet = [":", "@", "/", "*", "?", "[", "]", " ", "\t", "a"];
 			const published = new RegExp(SUBJECT_PREFIX_PATTERN);
+			// Same corpus under `v`, so the escapes stay inert across the whole
+			// enumeration rather than only the handful of strings above.
+			const unicodeSets = new RegExp(SUBJECT_PREFIX_PATTERN, "v");
 			const disagreements: string[] = [];
 			const walk = (prefix: string, depth: number) => {
-				if (prefix && published.test(prefix) !== SubjectPrefixSchema.safeParse(prefix).success) {
-					disagreements.push(prefix);
+				if (prefix) {
+					const enforced = SubjectPrefixSchema.safeParse(prefix).success;
+					if (published.test(prefix) !== enforced || unicodeSets.test(prefix) !== enforced) {
+						disagreements.push(prefix);
+					}
 				}
 				if (depth === 0) {
 					return;
@@ -849,6 +878,28 @@ KIr+J8gAkl0Ny1G8TnlMq0M9xN3Vx1qb+QD/elKMaKzX3u8d9zvIykjW8K/WKWwy
 			};
 			walk("", 4);
 			expect(disagreements).toEqual([]);
+		});
+	});
+
+	describe("StoredSubjectPrefixSchema", () => {
+		// The glob rule is a rule about creates. Rows written before it exist, and
+		// listing them is how an operator finds one to revoke — so the response
+		// schema must not refuse what the table can hold, or a spec-validating
+		// client would be blind to exactly the rows it needs to clean up.
+		it("accepts prefixes the create schema now refuses", () => {
+			for (const prefix of ["repo:kjanat/*", "repo:kjanat/[ab]", "repo:", "repo"]) {
+				expect(SubjectPrefixSchema.safeParse(prefix).success).toBe(false);
+				expect(StoredSubjectPrefixSchema.safeParse(prefix).success).toBe(true);
+			}
+		});
+
+		it("keeps the bounds the column has always had", () => {
+			// Dropping the create rule is not dropping every rule: the length bounds
+			// have been enforced for every row ever written, so unlike the glob
+			// class they cannot be violated by anything already in the table.
+			expect(StoredSubjectPrefixSchema.safeParse("").success).toBe(false);
+			expect(StoredSubjectPrefixSchema.safeParse(`repo:kjanat/${"r".repeat(255)}`).success).toBe(false);
+			expect(StoredSubjectPrefixSchema.safeParse("repo:kjanat/svc").success).toBe(true);
 		});
 	});
 });

--- a/src/__tests__/schemas.test.ts
+++ b/src/__tests__/schemas.test.ts
@@ -13,6 +13,8 @@ import {
 	KeyUploadSchema,
 	RequestHeadersSchema,
 	RequestIdSchema,
+	SUBJECT_PREFIX_PATTERN,
+	SubjectPrefixSchema,
 	TimestampSchema,
 } from "#schemas";
 
@@ -771,6 +773,57 @@ KIr+J8gAkl0Ny1G8TnlMq0M9xN3Vx1qb+QD/elKMaKzX3u8d9zvIykjW8K/WKWwy
 
 		it("should reject missing fields", () => {
 			expect(() => KeyResponseSchema.parse({ success: true, keyId: "ABC" })).toThrow();
+		});
+	});
+
+	describe("SubjectPrefixSchema", () => {
+		// A prefix is compared with startsWith and a delimiter check, never a
+		// pattern match, so a glob is not a wider rule — it is a row that matches
+		// nothing while listing as active. The refusal has to name the form that
+		// does work, or the operator's next guess is another pattern syntax.
+		it.each(["repo:kjanat/*", "repo:kjanat/svc?", "repo:kjanat/[ab]", "project_path:group/*"])(
+			"rejects the glob %s and names the trailing-delimiter form",
+			(prefix) => {
+				const result = SubjectPrefixSchema.safeParse(prefix);
+				expect(result.success).toBe(false);
+				const message = result.error?.issues.map((issue) => issue.message).join(" ");
+				expect(message).toContain("not a glob");
+				expect(message).toContain("repo:owner/");
+			},
+		);
+
+		it("accepts the cut-off a glob was reaching for", () => {
+			for (const prefix of ["repo:kjanat", "repo:kjanat/", "repo:kjanat/kjanat", "repo:kjanat@1/svc@2"]) {
+				expect(SubjectPrefixSchema.safeParse(prefix).success).toBe(true);
+			}
+		});
+
+		it("publishes a pattern that agrees with both checks", () => {
+			// client/openapi.json carries one `pattern` per string, so the two
+			// `.regex()` calls are restated as one there. Nothing keeps them in step
+			// but this: drift means the spec and the generated clients document a
+			// rule the service does not enforce, in whichever direction.
+			const published = new RegExp(SUBJECT_PREFIX_PATTERN);
+			const corpus = [
+				"repo:kjanat",
+				"repo:kjanat/",
+				"repo:kjanat/kjanat",
+				"repo:kjanat@1/svc@2:ref:refs/heads/main",
+				"project_path:group/project",
+				"repo:kjanat/*",
+				"repo:*",
+				"repo:kjanat/svc?",
+				"repo:kjanat/[ab]",
+				"repo:kjanat/svc]",
+				"repo:",
+				"repo",
+				"repo:/",
+				"has spaces",
+				"",
+			];
+			for (const prefix of corpus) {
+				expect([prefix, published.test(prefix)]).toEqual([prefix, SubjectPrefixSchema.safeParse(prefix).success]);
+			}
 		});
 	});
 });

--- a/src/__tests__/schemas.test.ts
+++ b/src/__tests__/schemas.test.ts
@@ -825,5 +825,30 @@ KIr+J8gAkl0Ny1G8TnlMq0M9xN3Vx1qb+QD/elKMaKzX3u8d9zvIykjW8K/WKWwy
 				expect([prefix, published.test(prefix)]).toEqual([prefix, SubjectPrefixSchema.safeParse(prefix).success]);
 			}
 		});
+
+		it("agrees with both checks on every short string over the interesting alphabet", () => {
+			// The corpus above only covers characters somebody thought to list, so it
+			// would stay green if a later rule added, say, `\\` to the glob class and
+			// the published pattern was not updated with it. Enumerating every string
+			// up to length 4 over one representative of each character role — the
+			// delimiters, each refused character, whitespace and an ordinary letter —
+			// makes the round trip exhaustive rather than illustrative.
+			const alphabet = [":", "@", "/", "*", "?", "[", "]", " ", "\t", "a"];
+			const published = new RegExp(SUBJECT_PREFIX_PATTERN);
+			const disagreements: string[] = [];
+			const walk = (prefix: string, depth: number) => {
+				if (prefix && published.test(prefix) !== SubjectPrefixSchema.safeParse(prefix).success) {
+					disagreements.push(prefix);
+				}
+				if (depth === 0) {
+					return;
+				}
+				for (const character of alphabet) {
+					walk(prefix + character, depth - 1);
+				}
+			};
+			walk("", 4);
+			expect(disagreements).toEqual([]);
+		});
 	});
 });

--- a/src/schemas/oidc-subjects.ts
+++ b/src/schemas/oidc-subjects.ts
@@ -60,17 +60,19 @@ export const SubjectPrefixSchema = z
 	//
 	// `*`, `?` and `[` cannot appear in a real subject: git-check-ref-format
 	// forbids all three in a ref name, and neither GitHub's `repo:owner/name:…`
-	// nor GitLab's `project_path:group/project:…` puts them anywhere else. So
-	// nothing legitimate is refused here.
+	// nor GitLab's `project_path:group/project:…` puts them anywhere else. `]`
+	// goes with them even though a ref name may contain one: on its own it opens
+	// nothing, but it only ever reaches this field as the tail of a `[…]` somebody
+	// typed, and refusing it keeps rule and message to a single set of characters.
 	//
 	// A second `.regex()` rather than one combined pattern, so each rule keeps its
 	// own message: a caller who typed a glob is told about globs, not handed the
 	// bare-scheme rule to decode. Only the first check reaches `pattern` in
 	// client/openapi.json — a JSON Schema string has one — so the combined
 	// expression is restated in `.openapi()` below, and the two must be kept in
-	// step. The whole-string alternation is written out rather than a lookahead so
-	// the published pattern stays readable to whoever is debugging a 400 against
-	// it.
+	// step. The exclusions are written into each character class rather than as a
+	// leading lookahead so the published pattern stays readable to whoever is
+	// debugging a 400 against it.
 	.regex(
 		/^[^*?[\]]*$/,
 		"Subject prefix is a literal prefix, not a glob — remove * ? [ ]. A prefix ending at a delimiter is already the wildcard: repo:owner/ trusts every repository of that owner",
@@ -80,7 +82,7 @@ export const SubjectPrefixSchema = z
 		// The rule is only obvious once you know matching is startsWith, so state
 		// it where the spec is read. TSDoc above does not reach openapi.json.
 		description:
-			"A literal prefix of the token's `sub`, not a glob — `*`, `?` and `[` are refused. A subject " +
+			"A literal prefix of the token's `sub`, not a glob — `*`, `?`, `[` and `]` are refused. A subject " +
 			"matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) " +
 			"or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix " +
 			"that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. " +

--- a/src/schemas/oidc-subjects.ts
+++ b/src/schemas/oidc-subjects.ts
@@ -11,6 +11,21 @@ export const SubjectNameSchema = z
 	.openapi("SubjectName");
 
 /**
+ * Both prefix rules below as one expression, for the published JSON Schema.
+ *
+ * A JSON Schema string carries a single `pattern`, so the two `.regex()` checks
+ * — which exist separately to keep their error messages apart — collapse to this
+ * for `client/openapi.json`. It is the intersection: `\S` narrowed to exclude
+ * the glob characters as well as whitespace. Written as an explicit character
+ * class rather than a lookahead so it stays legible to somebody reading the spec
+ * to work out why their prefix was refused.
+ *
+ * Change either `.regex()` and this must change with it; the round trip is
+ * covered in `schemas.test.ts`.
+ */
+export const SUBJECT_PREFIX_PATTERN = "^[^\\s*?[\\]]*[:@/][^\\s*?[\\]]*[^\\s:@/*?[\\]][^\\s*?[\\]]*$";
+
+/**
  * A `sub` prefix. Matched with a delimiter boundary, so `repo:owner/name`
  * does not admit `repo:owner/name-evil`, while `repo:owner/` is owner-wide.
  */
@@ -35,7 +50,43 @@ export const SubjectPrefixSchema = z
 		/^\S*[:@/]\S*[^\s:@/]\S*$/,
 		"Subject prefix must have no whitespace and must name an identity after its scheme, e.g. repo:owner — not repo: or repo",
 	)
-	.openapi("SubjectPrefix");
+	// Globs are the other degenerate input, and the one an operator reaches for
+	// first: matching is `startsWith` plus a delimiter check, never a pattern
+	// match, so `repo:owner/*` is stored and compared verbatim and matches only a
+	// repository literally called `*`. That row lists as active, never authorizes
+	// anybody, and the failure surfaces as `Subject is not trusted for signing` on
+	// some later run with nothing tying it back to the create. Fail at the point
+	// of the typo instead, and name the form that actually does what was meant.
+	//
+	// `*`, `?` and `[` cannot appear in a real subject: git-check-ref-format
+	// forbids all three in a ref name, and neither GitHub's `repo:owner/name:…`
+	// nor GitLab's `project_path:group/project:…` puts them anywhere else. So
+	// nothing legitimate is refused here.
+	//
+	// A second `.regex()` rather than one combined pattern, so each rule keeps its
+	// own message: a caller who typed a glob is told about globs, not handed the
+	// bare-scheme rule to decode. Only the first check reaches `pattern` in
+	// client/openapi.json — a JSON Schema string has one — so the combined
+	// expression is restated in `.openapi()` below, and the two must be kept in
+	// step. The whole-string alternation is written out rather than a lookahead so
+	// the published pattern stays readable to whoever is debugging a 400 against
+	// it.
+	.regex(
+		/^[^*?[\]]*$/,
+		"Subject prefix is a literal prefix, not a glob — remove * ? [ ]. A prefix ending at a delimiter is already the wildcard: repo:owner/ trusts every repository of that owner",
+	)
+	.openapi("SubjectPrefix", {
+		pattern: SUBJECT_PREFIX_PATTERN,
+		// The rule is only obvious once you know matching is startsWith, so state
+		// it where the spec is read. TSDoc above does not reach openapi.json.
+		description:
+			"A literal prefix of the token's `sub`, not a glob — `*`, `?` and `[` are refused. A subject " +
+			"matches when it starts with this string and the next character is a delimiter (`:`, `@`, `/`) " +
+			"or the end of the subject, so `repo:owner/svc` does not admit `repo:owner/svc-evil`. A prefix " +
+			"that ends at a delimiter is the wildcard: `repo:owner/` trusts every repository of that owner. " +
+			"Where several rows match, the longest live prefix wins.",
+		example: "repo:owner/repository",
+	});
 
 /** Request body for trusting an OIDC subject. */
 export const SubjectCreateSchema = z

--- a/src/schemas/oidc-subjects.ts
+++ b/src/schemas/oidc-subjects.ts
@@ -20,14 +20,31 @@ export const SubjectNameSchema = z
  * class rather than a lookahead so it stays legible to somebody reading the spec
  * to work out why their prefix was refused.
  *
+ * `[`, `]` and `/` are backslash-escaped inside the classes even though none of
+ * the three needs it in an ordinary JavaScript regex. JSON Schema's `pattern` is
+ * ECMA-262 without `u` or `v`, so a validator that is only reading the spec is
+ * unaffected either way — but a client is free to hand the string to
+ * `new RegExp(pattern, "v")`, and `v` mode reclassifies all three as class-set
+ * syntax and throws `invalid class set character` on the unescaped form. That is
+ * a compile error, not a mismatch: the client fails to start rather than
+ * mis-validating one prefix. The escapes have to be inert as well as legal, or
+ * the spec would mean two things depending on how a client compiled it —
+ * `schemas.test.ts` compiles the pattern under no flags, `u` and `v`, and runs
+ * the whole enumerated corpus through the unflagged and `v` forms. Go's `regexp`
+ * and Python's `re`, the engines behind kin-openapi and jsonschema, also read
+ * `\[`, `\]` and `\/` as those literal characters.
+ *
  * Change either `.regex()` and this must change with it; the round trip is
  * covered in `schemas.test.ts`.
  */
-export const SUBJECT_PREFIX_PATTERN = "^[^\\s*?[\\]]*[:@/][^\\s*?[\\]]*[^\\s:@/*?[\\]][^\\s*?[\\]]*$";
+export const SUBJECT_PREFIX_PATTERN = "^[^\\s*?\\[\\]]*[:@\\/][^\\s*?\\[\\]]*[^\\s:@\\/*?\\[\\]][^\\s*?\\[\\]]*$";
 
 /**
  * A `sub` prefix. Matched with a delimiter boundary, so `repo:owner/name`
  * does not admit `repo:owner/name-evil`, while `repo:owner/` is owner-wide.
+ *
+ * Request bodies only. Responses echo what is in the table, which may predate
+ * the rules below — see {@link StoredSubjectPrefixSchema}.
  */
 export const SubjectPrefixSchema = z
 	.string()
@@ -90,6 +107,36 @@ export const SubjectPrefixSchema = z
 		example: "repo:owner/repository",
 	});
 
+/**
+ * A `sub` prefix as it came back out of the table, for response bodies.
+ *
+ * Deliberately *not* {@link SubjectPrefixSchema}: that one is a rule about what
+ * may be created from now on, and the table predates it. A row written before
+ * the glob check — `repo:owner/*`, stored verbatim, matching nothing — is still
+ * in `oidc_subjects`, still listed by `GET /admin/subjects`, and still the thing
+ * an operator has to find in order to revoke it. Publishing the create-time
+ * `pattern` on the response would tell a spec-validating client to reject that
+ * listing, so the only view of the bad row would be unreadable to exactly the
+ * client trying to clean it up. Nothing validates responses at runtime here
+ * (`@hono/zod-openapi` does not, and the generated Go client does not check
+ * patterns), so this is a statement about the published contract only.
+ *
+ * The length bounds stay: those have been enforced since the column existed.
+ */
+export const StoredSubjectPrefixSchema = z
+	.string()
+	.min(1)
+	.max(255)
+	.openapi("StoredSubjectPrefix", {
+		description:
+			"A stored `sub` prefix. Matching is `startsWith` plus a delimiter (`:`, `@`, `/`) or " +
+			"end-of-subject boundary; the longest live prefix wins. No `pattern` is published here on " +
+			"purpose: new prefixes must satisfy `SubjectPrefix`, but rows created before that rule existed " +
+			"are returned as they were stored, so a client that must list and revoke them can still read " +
+			"this response.",
+		example: "repo:owner/repository",
+	});
+
 /** Request body for trusting an OIDC subject. */
 export const SubjectCreateSchema = z
 	.object({
@@ -119,7 +166,7 @@ export const SubjectSummarySchema = z
 		id: z.string(),
 		name: SubjectNameSchema,
 		issuer: z.string(),
-		subjectPrefix: SubjectPrefixSchema,
+		subjectPrefix: StoredSubjectPrefixSchema,
 		keyIds: z.array(z.string()).nullable(),
 		createdAt: z.string(),
 		expiresAt: z.string().nullable(),
@@ -146,7 +193,7 @@ export const CoveringSubjectSchema = z
 	.object({
 		id: z.string(),
 		name: SubjectNameSchema,
-		subjectPrefix: SubjectPrefixSchema,
+		subjectPrefix: StoredSubjectPrefixSchema,
 		keyIds: z.array(z.string()).nullable(),
 	})
 	.openapi("CoveringSubject");


### PR DESCRIPTION
Refuses `*`, `?` and `[` in `subjectPrefix` at create time with a message naming the trailing-delimiter form the glob was reaching for, publishes the combined pattern and a description into `client/openapi.json` (and the generated Go client godoc), and documents the two different 409s from POST /admin/subjects.

Closes #63