### PR TITLE
fix(ci): wire fork-safe Claude review gate

### DIFF
--- a/.github/scripts/test-claude-review-gate.sh
+++ b/.github/scripts/test-claude-review-gate.sh
@@ -135,4 +135,68 @@ for name in ("claude.yml", "claude-scheduled.yml"):
     )
 TRUSTED
 
+# --- the review workflow actually wires this up ------------------------------
+#
+# Everything above tests the gate script in isolation, which proves nothing
+# about the workflow that has to call it. #46 was not a broken script; it was a
+# correct script the workflow never ran, with signing setup still unconditional
+# in front of it. So assert the wiring: checkout before the gate (the script
+# lives in the tree being reviewed), the gate before both steps that read its
+# decision, and one shared condition so the two can never drift apart.
+python3 - "${repo_root}" <<'REVIEW'
+import sys, pathlib, yaml
+
+wf = yaml.safe_load(
+    (pathlib.Path(sys.argv[1]) / ".github/workflows/claude-code-review.yml").read_text()
+)
+steps = wf["jobs"]["claude-review"]["steps"]
+
+
+def index_of(predicate, what):
+    for i, step in enumerate(steps):
+        if predicate(step):
+            return i
+    raise AssertionError(f"claude-code-review.yml has no {what}")
+
+
+gate = index_of(lambda s: "claude-review-gate.sh" in s.get("run", ""), "gate step")
+signing = index_of(
+    lambda s: s.get("uses", "").endswith("setup-claude-signing"), "signing setup step"
+)
+review = index_of(
+    lambda s: s.get("uses", "").startswith("anthropics/claude-code-action"),
+    "claude-code-action step",
+)
+checkout = index_of(
+    lambda s: s.get("uses", "").startswith("actions/checkout"), "checkout step"
+)
+
+assert checkout < gate, "the gate step runs before actions/checkout"
+assert gate < signing < review, (
+    "the gate must run before the signing setup, which must run before the review"
+)
+
+condition = "env.HAS_CLAUDE_TOKEN == 'true'"
+assert steps[signing].get("if") == condition, (
+    "the signing setup is no longer gated on HAS_CLAUDE_TOKEN — a fork pull "
+    "request will fail on setup it was never going to use"
+)
+assert steps[review].get("if") == condition, (
+    "the review step and the signing setup no longer share a condition"
+)
+
+gate_env = steps[gate].get("env", {})
+assert "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}" in gate_env.get(
+    "CLAUDE_CODE_OAUTH_TOKEN", ""
+), "the gate step no longer receives CLAUDE_CODE_OAUTH_TOKEN"
+assert "head.repo.full_name" in gate_env.get("PR_HEAD_REPO", ""), (
+    "the gate step no longer receives the head repository, so it cannot "
+    "distinguish a fork from a missing secret"
+)
+
+assert steps[signing]["with"]["disable-signing"] == "${{ vars.GPG_SIGN_DISABLE }}", (
+    "the GPG_SIGN_DISABLE escape hatch is no longer wired up"
+)
+REVIEW
+
 printf 'claude review gate tests passed\n'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -5,10 +5,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions: { contents: write, pull-requests: write, issues: write, id-token: write }
     steps:
-      - name: Check for Claude token
-        env: { CLAUDE_TOKEN: "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}" }
-        run: printf 'HAS_CLAUDE_TOKEN=%s\n' "${CLAUDE_TOKEN:+true}" >> "${GITHUB_ENV}"
       - { uses: actions/checkout@v7, with: { fetch-depth: 0 } }
+      # Decides once, for the whole job, whether this run is going to run Claude
+      # at all — the signing setup and the review step below both read
+      # HAS_CLAUDE_TOKEN, so the two can never disagree. It is a script rather
+      # than an inline `run:` because a fork pull request is the case that has to
+      # keep working and no workflow can be tested outside a workflow; see
+      # .github/scripts/test-claude-review-gate.sh. Skipping is exit 0 on
+      # purpose: this step is what decides a run is a deliberate no-op.
+      #
+      # SECURITY: this workflow intentionally uses `pull_request`, not
+      # `pull_request_target`. The gate is read from the checked-out PR ref. If
+      # the trigger ever changes to `pull_request_target`, executing that script
+      # would run untrusted fork code in a privileged context.
+      - name: Check for Claude token
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
+          PR_HEAD_REPO: "${{ github.event.pull_request.head.repo.full_name }}"
+        run: bash .github/scripts/claude-review-gate.sh
       - { uses: jdx/mise-action@v4 }
       - { uses: kjanat/install-dprint@v2 }
       - { uses: ./.github/actions/setup-bun, id: bun }
@@ -16,6 +30,19 @@ jobs:
       # Dogfood: fixes Claude pushes to PR branches get signed by our own service
       - uses: ./.github/actions/setup-claude-signing
         id: signing
+        # Gated with the review step below, never independently. Signing setup is
+        # fail-closed by design (#107), and a fork pull request has neither the
+        # OAuth token nor id-token: write — so unconditionally it failed the whole
+        # workflow on a run whose only intended outcome was to do nothing.
+        #
+        # This is not a missing-credential fallback. A run that HAS the token
+        # still fails here when the service is unreachable or the OIDC
+        # configuration is absent, and GPG_SIGN_DISABLE remains the only way to
+        # run Claude with signing deliberately off. It also keeps the OIDC
+        # request variables off a path where Claude will not run: the action
+        # exports them for the session, and a job that is not starting a session
+        # has no use for a token-minting endpoint.
+        if: env.HAS_CLAUDE_TOKEN == 'true'
         with:
           service-url: "${{ vars.SIGNING_SERVICE_URL }}"
           claude-settings: "${{ vars.CLAUDE_SETTINGS }}"


### PR DESCRIPTION
Closes #46

Completes the one workflow hunk that Claude could not push in #108 because the Claude GitHub App lacks `workflows` permission.

The review workflow now checks out the PR first, runs the already-reviewed `claude-review-gate.sh`, and gates both `setup-claude-signing` and `claude-code-action` on the exact same `HAS_CLAUDE_TOKEN == 'true'` condition. Trusted runs therefore keep #107's fail-closed signing behavior, while a fork/no-token review run becomes a deliberate no-op instead of dying in signing setup.

The regression suite now pins the workflow wiring itself, not merely the gate script: checkout must precede the gate, the gate must precede signing and review, signing and review must share the condition, the gate must receive the OAuth token plus PR head repo, and `GPG_SIGN_DISABLE` remains the only deliberate unsigned escape hatch.

I also added an explicit security comment documenting that this relies on the workflow remaining `pull_request`: the gate script comes from the checked-out PR ref and must not be carried unchanged into a privileged `pull_request_target` workflow.

This is the held-back patch from #46/#108, reviewed there before application.