### PR TITLE
test(gitsign): make the git fixtures independent of the host

### DIFF
--- a/client/cmd/gpg-sign/consts_test.go
+++ b/client/cmd/gpg-sign/consts_test.go
@@ -6,3 +6,13 @@ const (
 	testEnvToken  = "env-token"
 	flagHelp      = "--help"
 )
+
+// The environment git reads an identity from, and the name every fixture
+// commit carries.
+const (
+	envAuthorName     = "GIT_AUTHOR_NAME"
+	envAuthorEmail    = "GIT_AUTHOR_EMAIL"
+	envCommitterName  = "GIT_COMMITTER_NAME"
+	envCommitterEmail = "GIT_COMMITTER_EMAIL"
+	fixtureName       = "Test"
+)

--- a/client/cmd/gpg-sign/signcommit_test.go
+++ b/client/cmd/gpg-sign/signcommit_test.go
@@ -214,16 +214,15 @@ func newSignCommitFixture(t *testing.T) (dir, base string) {
 	apiURL, timeout = server.URL, 30*time.Second
 	t.Cleanup(func() { apiURL, timeout = previousURL, previousTimeout })
 
+	// No identity is passed: gitEnv pins the fixture's own, so a caller that
+	// repeated it here would only be shadowing an identical value and the pin
+	// itself would go unexercised.
 	dir = t.TempDir()
-	env := []string{
-		envAuthorName + "=" + fixtureName, envAuthorEmail + "=" + testSignCommitEmail,
-		envCommitterName + "=" + fixtureName, envCommitterEmail + "=" + testSignCommitEmail,
-	}
-	gitRun(t, dir, env, "init", "--initial-branch=master")
-	gitRun(t, dir, env, "config", "commit.gpgsign", "false")
-	gitRun(t, dir, env, "commit", "--allow-empty", "-m", "root")
-	base = strings.TrimSpace(gitRun(t, dir, env, "rev-parse", "HEAD"))
-	gitRun(t, dir, env, "commit", "--allow-empty", "-m", "signable")
+	gitRun(t, dir, "init", "--initial-branch=master")
+	gitRun(t, dir, "config", "commit.gpgsign", "false")
+	gitRun(t, dir, "commit", "--allow-empty", "-m", "root")
+	base = strings.TrimSpace(gitRun(t, dir, "rev-parse", "HEAD"))
+	gitRun(t, dir, "commit", "--allow-empty", "-m", "signable")
 	return dir, base
 }
 
@@ -281,7 +280,7 @@ func hermeticGit() []string {
 // GIT_* variable is dropped rather than shadowed: GIT_CONFIG_COUNT and its
 // GIT_CONFIG_KEY_n companions inject config outranking every file, so a host
 // that sets them could otherwise still reach into a fixture.
-func gitEnv(env []string) []string {
+func gitEnv() []string {
 	environ := os.Environ()
 	kept := make([]string, 0, len(environ))
 	for _, entry := range environ {
@@ -290,17 +289,17 @@ func gitEnv(env []string) []string {
 		}
 		kept = append(kept, entry)
 	}
-	return append(append(kept, hermeticGit()...), env...)
+	return append(kept, hermeticGit()...)
 }
 
-func gitRun(t *testing.T, dir string, env []string, args ...string) string {
+func gitRun(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 
 	var stdout, stderr bytes.Buffer
 	// #nosec G204 -- test fixture; every argument is a literal from this file.
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
-	cmd.Env = gitEnv(env)
+	cmd.Env = gitEnv()
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -315,12 +314,8 @@ func gitRun(t *testing.T, dir string, env []string, args ...string) string {
 func TestSignCommitCommandJSONOnRefusal(t *testing.T) {
 	dir, root := newSignCommitFixture(t)
 
-	env := []string{
-		envAuthorName + "=" + fixtureName, envAuthorEmail + "=" + testSignCommitEmail,
-		envCommitterName + "=" + fixtureName, envCommitterEmail + "=" + testSignCommitEmail,
-	}
-	first := strings.TrimSpace(gitRun(t, dir, env, "rev-parse", "HEAD"))
-	gitRun(t, dir, env, "commit", "--allow-empty", "-m", "second")
+	first := strings.TrimSpace(gitRun(t, dir, "rev-parse", "HEAD"))
+	gitRun(t, dir, "commit", "--allow-empty", "-m", "second")
 
 	// Sign only the top commit, so the one below it is still unsigned. The next
 	// run has to rewrite that one, which invalidates the signature above it.

--- a/client/cmd/gpg-sign/signcommit_test.go
+++ b/client/cmd/gpg-sign/signcommit_test.go
@@ -216,8 +216,8 @@ func newSignCommitFixture(t *testing.T) (dir, base string) {
 
 	dir = t.TempDir()
 	env := []string{
-		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=" + testSignCommitEmail,
-		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=" + testSignCommitEmail,
+		envAuthorName + "=" + fixtureName, envAuthorEmail + "=" + testSignCommitEmail,
+		envCommitterName + "=" + fixtureName, envCommitterEmail + "=" + testSignCommitEmail,
 	}
 	gitRun(t, dir, env, "init", "--initial-branch=master")
 	gitRun(t, dir, env, "config", "commit.gpgsign", "false")
@@ -256,6 +256,43 @@ func gpgRun(t *testing.T, home string, stdin []byte, args ...string) string {
 	return out
 }
 
+// hermeticGit is the environment every git command in this suite runs under.
+//
+// The developer's global and system config must not decide what the fixtures
+// look like, and a git command that writes an object otherwise guesses an
+// identity from the host's username and hostname — a guess that works on a
+// workstation and fails on a clean CI runner with "Author identity unknown".
+// Naming both here means no fixture depends on the host having either.
+//
+// Caller entries are appended after these and win, since for a duplicate
+// environment key the last occurrence is the one that takes effect.
+func hermeticGit() []string {
+	return []string{
+		"GIT_CONFIG_GLOBAL=" + os.DevNull,
+		"GIT_CONFIG_SYSTEM=" + os.DevNull,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_TERMINAL_PROMPT=0",
+		envAuthorName + "=" + fixtureName, envAuthorEmail + "=" + testSignCommitEmail,
+		envCommitterName + "=" + fixtureName, envCommitterEmail + "=" + testSignCommitEmail,
+	}
+}
+
+// gitEnv is the full environment for a fixture git command. Every ambient
+// GIT_* variable is dropped rather than shadowed: GIT_CONFIG_COUNT and its
+// GIT_CONFIG_KEY_n companions inject config outranking every file, so a host
+// that sets them could otherwise still reach into a fixture.
+func gitEnv(env []string) []string {
+	environ := os.Environ()
+	kept := make([]string, 0, len(environ))
+	for _, entry := range environ {
+		if strings.HasPrefix(entry, "GIT_") {
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	return append(append(kept, hermeticGit()...), env...)
+}
+
 func gitRun(t *testing.T, dir string, env []string, args ...string) string {
 	t.Helper()
 
@@ -263,7 +300,7 @@ func gitRun(t *testing.T, dir string, env []string, args ...string) string {
 	// #nosec G204 -- test fixture; every argument is a literal from this file.
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), env...)
+	cmd.Env = gitEnv(env)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -279,8 +316,8 @@ func TestSignCommitCommandJSONOnRefusal(t *testing.T) {
 	dir, root := newSignCommitFixture(t)
 
 	env := []string{
-		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=" + testSignCommitEmail,
-		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=" + testSignCommitEmail,
+		envAuthorName + "=" + fixtureName, envAuthorEmail + "=" + testSignCommitEmail,
+		envCommitterName + "=" + fixtureName, envCommitterEmail + "=" + testSignCommitEmail,
 	}
 	first := strings.TrimSpace(gitRun(t, dir, env, "rev-parse", "HEAD"))
 	gitRun(t, dir, env, "commit", "--allow-empty", "-m", "second")

--- a/client/pkg/gitsign/harness_test.go
+++ b/client/pkg/gitsign/harness_test.go
@@ -23,6 +23,17 @@ const (
 	foreignEmail = "someone@example.test"
 )
 
+// The environment git reads an identity from, and the name every fixture
+// commit carries. Named rather than repeated so the hermeticity guard in
+// hermetic_test.go asserts on the same strings the harness sets.
+const (
+	envAuthorName     = "GIT_AUTHOR_NAME"
+	envAuthorEmail    = "GIT_AUTHOR_EMAIL"
+	envCommitterName  = "GIT_COMMITTER_NAME"
+	envCommitterEmail = "GIT_COMMITTER_EMAIL"
+	fixtureName       = "Test"
+)
+
 // requireGit skips tests that need a real git binary, so the suite still runs
 // on a machine that has none. Nothing here needs gpg: keys are generated,
 // signed with, and verified in-process.
@@ -124,12 +135,68 @@ func readAll(r *http.Request) ([]byte, error) {
 	return buf.Bytes(), err
 }
 
+// hermeticGit is the environment every git command in this package runs under.
+//
+// Two host-dependent things would otherwise decide what the fixtures look
+// like. The developer's global and system config settles questions the tests
+// assert on — commit.gpgsign, core.hooksPath, init.defaultBranch — so it is
+// pointed at /dev/null rather than trusted to be empty. And a git command that
+// writes an object falls back to guessing an identity from the host's username
+// and hostname; that guess succeeds on a workstation and fails outright on a
+// clean CI runner with "Author identity unknown". Naming an identity here
+// means no fixture can depend on the host having one.
+//
+// Callers append their own entries after these and win, since for a duplicate
+// environment key it is the last occurrence that takes effect.
+func hermeticGit() []string {
+	return []string{
+		"GIT_CONFIG_GLOBAL=" + os.DevNull,
+		"GIT_CONFIG_SYSTEM=" + os.DevNull,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_TERMINAL_PROMPT=0",
+		envAuthorName + "=" + fixtureName, envAuthorEmail + "=" + serviceEmail,
+		envCommitterName + "=" + fixtureName, envCommitterEmail + "=" + serviceEmail,
+		"GIT_AUTHOR_DATE=2026-01-01T00:00:00Z", "GIT_COMMITTER_DATE=2026-01-01T00:00:00Z",
+	}
+}
+
+// scrubbedEnviron is the host environment with every GIT_* variable removed.
+//
+// Shadowing the ambient ones would be enough for the variables hermeticGit
+// happens to list, but not for the ones it does not: GIT_CONFIG_COUNT and its
+// GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n companions inject config that outranks
+// every file, so a host that sets them could still reach into a fixture. The
+// cheaper rule is that no GIT_* variable survives, and the fixture environment
+// is then whatever this file says it is.
+//
+// This matters more than it looks: the CI job that runs this suite inside a
+// GitHub Action inherits GIT_AUTHOR_* and GIT_COMMITTER_* from the action, so
+// a missing identity is invisible there and fatal in the plain test job.
+func scrubbedEnviron() []string {
+	environ := os.Environ()
+	kept := make([]string, 0, len(environ))
+	for _, entry := range environ {
+		if strings.HasPrefix(entry, "GIT_") {
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	return kept
+}
+
+// gitEnv is the full environment for a fixture git command: the host's, with
+// its git state scrubbed and this package's pinned in, then the caller's.
+func gitEnv(env []string) []string {
+	return append(append(scrubbedEnviron(), hermeticGit()...), env...)
+}
+
 // gitSucceeds reports whether a git command works in the fixture, for the
 // optional repository features not every git build carries.
 func gitSucceeds(dir string, args ...string) bool {
 	// #nosec G204 -- test fixture; the arguments come from this file's callers.
 	cmd := exec.Command(gitProgram, args...)
 	cmd.Dir = dir
+	cmd.Env = gitEnv(nil)
 	return cmd.Run() == nil
 }
 
@@ -141,7 +208,7 @@ func git(t *testing.T, dir string, env []string, args ...string) string {
 	// #nosec G204 -- test fixture; the arguments come from this file's helpers.
 	cmd := exec.Command(gitProgram, args...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), env...)
+	cmd.Env = gitEnv(env)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -159,6 +226,7 @@ func gitRaw(t *testing.T, dir string, stdin []byte, args ...string) []byte {
 	// #nosec G204 -- test fixture; the arguments come from this file's helpers.
 	cmd := exec.Command(gitProgram, args...)
 	cmd.Dir = dir
+	cmd.Env = gitEnv(nil)
 	if stdin != nil {
 		cmd.Stdin = bytes.NewReader(stdin)
 	}
@@ -203,8 +271,8 @@ func repoFormat(t *testing.T, dir string) objectFormat {
 // identity returns the environment that pins a commit's author and committer.
 func identity(email string) []string {
 	return []string{
-		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=" + email,
-		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=" + email,
+		envAuthorName + "=" + fixtureName, envAuthorEmail + "=" + email,
+		envCommitterName + "=" + fixtureName, envCommitterEmail + "=" + email,
 		"GIT_AUTHOR_DATE=2026-01-01T00:00:00Z", "GIT_COMMITTER_DATE=2026-01-01T00:00:00Z",
 	}
 }

--- a/client/pkg/gitsign/hermetic_test.go
+++ b/client/pkg/gitsign/hermetic_test.go
@@ -1,0 +1,177 @@
+package gitsign
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The fixtures in this package are built by shelling out to git, so every
+// question git answers from ambient state is a way for this suite to pass on
+// the machine that wrote it and fail somewhere else. That is not hypothetical:
+// TestRepairRefusesABaseTheTipDoesNotReach wrote a commit object with no
+// identity pinned and was green for everyone who ran it locally and green in
+// the Action that runs Claude — which exports GIT_AUTHOR_* and GIT_COMMITTER_*
+// — while failing the plain Go CI job with "Author identity unknown".
+//
+// These tests hold the fixture environment to that standard directly, so the
+// next helper that forgets is caught here rather than in someone's CI.
+
+// clearAmbientGit removes the identity a host may be exporting, reproducing a
+// clean CI runner inside a session that has one.
+//
+// t.Setenv cannot unset, and it is what registers the restore, so each variable
+// is blanked through it first and then removed outright.
+func clearAmbientGit(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		envAuthorName, envAuthorEmail, "GIT_AUTHOR_DATE",
+		envCommitterName, envCommitterEmail, "GIT_COMMITTER_DATE",
+		"EMAIL",
+	} {
+		t.Setenv(name, "")
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatalf("could not clear %s: %v", name, err)
+		}
+	}
+}
+
+// A git command that writes an object needs an identity, and on a clean runner
+// there is none to guess from. The fixture helpers must supply one themselves.
+func TestFixtureGitWritesObjectsWithoutAHostIdentity(t *testing.T) {
+	requireGit(t)
+	clearAmbientGit(t)
+	// The host's config must not be able to supply one either, or this would
+	// pass on a developer machine for the wrong reason.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	dir := initRepo(t)
+	root := head(t, dir)
+
+	// commit-tree is the bare case: no working tree, no config, just an object
+	// write. This is the exact call that failed in CI.
+	sha := git(t, dir, nil, "commit-tree", root+"^{tree}", "-p", root, "-m", "chore: no host identity")
+	if sha == "" {
+		t.Fatal("commit-tree produced no object")
+	}
+
+	author := git(t, dir, nil, "show", "--no-patch", "--format=%an <%ae>", sha)
+	if author != fixtureName+" <"+serviceEmail+">" {
+		t.Errorf("the fixture identity did not reach the object: %q", author)
+	}
+}
+
+// A host that exports an identity must not be able to lend it to a fixture
+// either, or a test asserting on authorship would read the developer's name.
+func TestFixtureGitIgnoresAnAmbientIdentity(t *testing.T) {
+	requireGit(t)
+	t.Setenv(envAuthorName, "Ambient")
+	t.Setenv(envAuthorEmail, "ambient@example.invalid")
+	t.Setenv(envCommitterName, "Ambient")
+	t.Setenv(envCommitterEmail, "ambient@example.invalid")
+
+	dir := initRepo(t)
+	sha := commit(t, dir, "chore: ambient", foreignEmail)
+
+	got := git(t, dir, nil, "show", "--no-patch", "--format=%an <%ae>|%cn <%ce>", sha)
+	want := fixtureName + " <" + foreignEmail + ">|" + fixtureName + " <" + foreignEmail + ">"
+	if got != want {
+		t.Errorf("an ambient identity reached the fixture:\n got %s\nwant %s", got, want)
+	}
+}
+
+// GIT_CONFIG_COUNT injects config that outranks every config file, so pinning
+// GIT_CONFIG_GLOBAL is not on its own enough to isolate a fixture from its
+// host. commit.gpgsign is the setting that matters most here: left on, every
+// fixture commit would be signed by whatever key the host happens to hold.
+func TestFixtureGitIgnoresInjectedHostConfig(t *testing.T) {
+	requireGit(t)
+	t.Setenv("GIT_CONFIG_COUNT", "2")
+	t.Setenv("GIT_CONFIG_KEY_0", "commit.gpgsign")
+	t.Setenv("GIT_CONFIG_VALUE_0", "true")
+	t.Setenv("GIT_CONFIG_KEY_1", "user.email")
+	t.Setenv("GIT_CONFIG_VALUE_1", "injected@example.invalid")
+
+	dir := initRepo(t)
+	sha := commit(t, dir, "chore: injected config", serviceEmail)
+
+	if raw := gitRaw(t, dir, nil, "cat-file", "commit", sha); strings.Contains(string(raw), "gpgsig") {
+		t.Errorf("injected config signed a fixture commit:\n%s", raw)
+	}
+	if email := git(t, dir, nil, "show", "--no-patch", "--format=%ae", sha); email != serviceEmail {
+		t.Errorf("injected config chose the fixture's author: %q", email)
+	}
+}
+
+// A global config file the host points at must not reach a fixture either.
+func TestFixtureGitIgnoresAHostGlobalConfig(t *testing.T) {
+	requireGit(t)
+
+	hostile := filepath.Join(t.TempDir(), "gitconfig")
+	if err := os.WriteFile(hostile, []byte("[user]\n\tname = Hostile\n\temail = hostile@example.invalid\n"+
+		"[commit]\n\tgpgsign = true\n"), 0o600); err != nil {
+		t.Fatalf("could not write the hostile config: %v", err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", hostile)
+
+	dir := initRepo(t)
+	sha := commit(t, dir, "chore: hostile global config", serviceEmail)
+
+	if email := git(t, dir, nil, "show", "--no-patch", "--format=%ae", sha); email != serviceEmail {
+		t.Errorf("a host global config chose the fixture's author: %q", email)
+	}
+}
+
+// The scrub is the mechanism the tests above rely on, so it is asserted
+// directly: nothing named GIT_* survives from the host, what this package pins
+// does, and the caller still gets the last word.
+func TestGitEnvScrubsHostGitVariables(t *testing.T) {
+	const callerAuthor = envAuthorName + "=Caller"
+
+	t.Setenv(envAuthorName, "Ambient")
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_TRACE", "1")
+
+	env := gitEnv([]string{callerAuthor})
+
+	for _, leaked := range []string{"GIT_TRACE=1", "GIT_CONFIG_COUNT=1", envAuthorName + "=Ambient"} {
+		if occurrences(env, leaked) != 0 {
+			t.Errorf("the host's %s survived the scrub", leaked)
+		}
+	}
+	if got := occurrences(env, envAuthorName+"="+fixtureName); got != 1 {
+		t.Errorf("the pinned identity appears %d time(s), want exactly 1", got)
+	}
+	if got := occurrences(env, callerAuthor); got != 1 {
+		t.Errorf("the caller's override appears %d time(s), want exactly 1", got)
+	}
+	// Order decides which one git uses, and the caller has to be able to win.
+	if last := lastValue(env, envAuthorName); last != "Caller" {
+		t.Errorf("the caller's override does not win: %s resolves to %q", envAuthorName, last)
+	}
+}
+
+// occurrences counts exact entries, since a duplicated pin would be as much a
+// bug as a missing one.
+func occurrences(env []string, entry string) int {
+	total := 0
+	for _, candidate := range env {
+		if candidate == entry {
+			total++
+		}
+	}
+	return total
+}
+
+// lastValue returns the value git would use for a name: the last occurrence.
+func lastValue(env []string, name string) string {
+	value := ""
+	for _, entry := range env {
+		if strings.HasPrefix(entry, name+"=") {
+			value = strings.TrimPrefix(entry, name+"=")
+		}
+	}
+	return value
+}

--- a/client/pkg/gitsign/interop_test.go
+++ b/client/pkg/gitsign/interop_test.go
@@ -154,7 +154,7 @@ func TestGitVerifiesTheCommitsARunWrites(t *testing.T) {
 			verify := exec.Command(gitProgram, "-c", "gpg.program=gpg", "-c", "gpg.format=openpgp",
 				"-c", "gpg.minTrustLevel=undefined", "verify-commit", "--raw", result.Tip)
 			verify.Dir = dir
-			verify.Env = append(os.Environ(), "GNUPGHOME="+home)
+			verify.Env = gitEnv([]string{"GNUPGHOME=" + home})
 			var stderr bytes.Buffer
 			verify.Stderr = &stderr
 			if err := verify.Run(); err != nil {

--- a/client/pkg/gitsign/repair_test.go
+++ b/client/pkg/gitsign/repair_test.go
@@ -301,7 +301,11 @@ func TestRepairRefusesABaseTheTipDoesNotReach(t *testing.T) {
 
 	// A commit off to one side of the fixture's chain, the shape a mistyped ref
 	// resolves to: a branch that forked earlier and went somewhere else.
-	sidetrack := git(t, f.dir, nil, "commit-tree", f.base+"^{tree}", "-p", f.base, "-m", "chore: sidetrack")
+	// The identity is named because commit-tree writes a commit object: with
+	// nothing pinned, git falls back to guessing one from the host and a clean
+	// CI runner has none to guess from.
+	sidetrack := git(t, f.dir, identity(serviceEmail), "commit-tree",
+		f.base+"^{tree}", "-p", f.base, "-m", "chore: sidetrack")
 
 	// Nothing about the walk itself would notice. rev-list sidetrack..tip is not
 	// empty — it silently starts at their merge base — so the range would come


### PR DESCRIPTION
Refs #111.

## The failure

`TestRepairRefusesABaseTheTipDoesNotReach` ran `git commit-tree` with no identity pinned. On a machine that has one to fall back on this writes a commit; on a clean Actions runner it fails with `Author identity unknown`, which is what run 33310510961 hit.

## Why it was invisible

The Claude Action exports `GIT_AUTHOR_*` and `GIT_COMMITTER_*` into the environment it runs the tests in, so fixtures in `pkg/gitsign` could quietly borrow the maintainer identity from the environment. Tests asserting authorship could therefore pass in the agent environment while failing on a clean runner.

## The fix

Build fixture Git environments rather than inheriting them. The helper drops ambient `GIT_*` variables, including injected config variables, pins config sources away from the host, and supplies an explicit fixture identity while still permitting per-call overrides.

Apply the same isolation to the Git helpers used by the `pkg/gitsign` and `cmd/gpg-sign` tests so no helper remains dependent on host Git configuration.

## Regression coverage

Add hermeticity coverage proving fixture-created objects work with no host identity, ambient identities/config do not leak in, hostile global config is ignored, and explicit caller overrides still win.

## Verification

Run the Go/client suite with host Git identity/config isolated, plus the repair-history and commit-provenance shell suites, lint, typecheck, and formatting checks.