### PR TITLE
fix(build): make every artifact producer explicit and pinned

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,17 +1,35 @@
 #:schema https://mise.jdx.dev/schema/mise.json
 
+# Anything that can rewrite a file this repository commits is pinned; anything
+# that only reads is free to float. A floating linter reports a new finding and
+# someone looks at it, but a floating *producer* silently rewrites the tree from
+# whatever the machine resolved that day, which is #123/#125: `wrangler = "latest"`
+# and `biome = "latest"` each turned `mise install` into a repository mutation.
+#
+#   * wrangler  writes worker-configuration.d.ts (`wrangler types`)
+#   * biome     rewrites imports (`biome check --fix` in the pre-commit lint:fix)
+#   * tombi     rewrites TOML -- .dprint.jsonc shells out to it for *.toml
+#   * golangci-lint  rewrites Go -- .dprint.jsonc shells out to `golangci-lint fmt`
+#
+# wrangler is deliberately the same version bun.lock resolves, not merely some
+# fixed one: `wrangler types` stamps its own workerd into the generated header,
+# so two channels at two versions are two producers again. The two channels
+# exist because they reach different places -- .github/workflows/d1-migrate.yml
+# and scripts/cf.sh's WORKERS_CI branch run wrangler on a checkout that has no
+# node_modules -- but they are one version, and scripts/test-tool-pins.sh fails
+# if they drift apart.
 [tools]
 "cargo:runner-run" = "latest"
 actionlint         = "latest"
-biome              = "latest"
+biome              = "2.5.11"
 cargo-binstall     = "latest"
 golangci-lint      = "2.13.2"
 lefthook           = "latest"
 shellcheck         = "latest"
 task               = "latest"
-tombi              = "latest"
+tombi              = "1.5.0"
 uv                 = "latest"
-wrangler           = "latest"
+wrangler           = "4.123.0"
 
 [settings]
 idiomatic_version_file_enable_tools = ["go"]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -60,6 +60,7 @@ tasks:
       - task: test:session-start
       - task: test:go-modernize-gate
       - task: test:typegen-pin
+      - task: test:tool-pins
 
   test:sentry:
     desc: Run the Sentry boundary suite alone — the inner loop of the mutation set
@@ -127,6 +128,11 @@ tasks:
     aliases: [tgp]
     cmd: bash scripts/test-typegen-pin.sh
 
+  test:tool-pins:
+    desc: Test that every tool which rewrites a committed file is explicit and pinned
+    aliases: [tp, pins]
+    cmd: bash scripts/test-tool-pins.sh
+
   test:coverage:
     desc: Run tests with coverage
     aliases: [tc]
@@ -149,6 +155,7 @@ tasks:
       - task: test:session-start
       - task: test:go-modernize-gate
       - task: test:typegen-pin
+      - task: test:tool-pins
 
   test:watch:
     desc: Run tests in watch mode
@@ -163,7 +170,13 @@ tasks:
     cmds:
       - task: format
       - bun eslint src/
-      - mise exec -- biome lint
+      # `check`, not `lint`: biome.jsonc turns the formatter off but leaves the
+      # organizeImports assist on, and `biome lint` does not run assists. So a
+      # tree with imports the pinned biome would reorder linted green here while
+      # the pre-commit `lint:fix` -- which is `biome check --fix` -- silently
+      # rewrote it, which is the mutation half of #125. This is the same command
+      # package.json's `lint:biome` runs, minus the fix.
+      - mise exec -- biome check
       - task: lint:shell
       - task: lint:actions
 
@@ -247,19 +260,23 @@ tasks:
     generates: [worker-configuration.d.ts]
     # Spelled through the package.json script, not `mise exec -- wrangler`, so
     # that this and the `prepare` hook are the same command. They were not, and
-    # the two resolved different wranglers: `.mise.toml` carries an unpinned
+    # the two resolved different wranglers: `.mise.toml` carried an unpinned
     # `wrangler = "latest"`, while `run typegen` picks up node_modules/.bin,
-    # which bun.lock pins exactly as a transitive dep of vitest-pool-workers.
-    # Whichever one wrote worker-configuration.d.ts last stamped its own workerd
-    # into the header, so `bun install` inside CI -- which fires `prepare` and
-    # therefore the node_modules one -- rewrote a file generated here by the
-    # mise one and turned the whole-worktree `git diff --exit-code` in
-    # .github/actions/check-api-changes red, on a tree where `task generate:api`
-    # itself is clean (#123). Only this call site moves: the lockfile wrangler
-    # is the one whose workerd the vitest-pool-workers suite actually executes
-    # on, so it is the one whose types belong in the tree, whereas deploy/d1/kv
-    # emit no committed artifact and are better off current.
-    # scripts/test-typegen-pin.sh holds both halves of that down.
+    # which bun.lock pins exactly. Whichever one wrote worker-configuration.d.ts
+    # last stamped its own workerd into the header, so `bun install` inside CI
+    # -- which fires `prepare` and therefore the node_modules one -- rewrote a
+    # file generated here by the mise one and turned the whole-worktree
+    # `git diff --exit-code` in .github/actions/check-api-changes red, on a tree
+    # where `task generate:api` itself is clean (#123).
+    #
+    # #125 closed the other half: wrangler is now a direct devDependency rather
+    # than a hoisted transitive of @cloudflare/vitest-pool-workers, and the mise
+    # tool is pinned to the same version instead of "latest". This call site
+    # still names the lockfile binary rather than either -- that is the producer
+    # whose workerd the vitest-pool-workers suite actually executes on, so it is
+    # the one whose types belong in the tree, and it stays correct even if the
+    # two pins are ever allowed to drift apart again.
+    # scripts/test-typegen-pin.sh and scripts/test-tool-pins.sh hold that down.
     cmd: mise exec -- run typegen
 
   generate:api:

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "typescript": "<7.0.2",
         "typescript-eslint": "8.67.0",
         "vitest": "^4.1.0",
+        "wrangler": "4.123.0",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "jose": "6.2.8",
     "typescript": "<7.0.2",
     "typescript-eslint": "8.67.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0",
+    "wrangler": "4.123.0"
   },
   "overrides": {
     "typescript": {

--- a/scripts/test-tool-pins.sh
+++ b/scripts/test-tool-pins.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+# Covers the invariant that every tool which can rewrite a file this repository
+# commits resolves to exactly one explicit version.
+#
+# #123 was one instance of this: two wranglers, one of them `latest`, and
+# whichever ran last decided what was in worker-configuration.d.ts.
+# scripts/test-typegen-pin.sh holds that artifact down. This file holds down the
+# class, because the artifact gate only ever sees the producer it already knows
+# about:
+#
+#   * wrangler       writes worker-configuration.d.ts via `wrangler types`
+#   * biome          rewrites imports via `biome check --fix`, which is what the
+#                    pre-commit `lint:fix` job runs
+#   * tombi          rewrites *.toml -- .dprint.jsonc shells out to it
+#   * golangci-lint  rewrites *.go -- .dprint.jsonc shells out to it
+#
+# A floating linter is a nuisance; a floating producer is a repository mutation
+# that depends on the day you ran `mise install`. On clean master before #125,
+# `mise install` fetched biome 2.5.11, whose organizeImports orders differently
+# from whatever wrote the tree, and the very next pre-commit reordered imports in
+# two files that nobody had touched. `task lint` stayed green throughout, because
+# it ran `biome lint`, and `lint` does not run assists.
+#
+# The other half of the same hole was resolution by accident:
+# node_modules/.bin/wrangler existed only because bun hoisted a transitive
+# dependency of @cloudflare/vitest-pool-workers, while thirteen package.json
+# scripts spelled it as though it were ours. #124 then made that binary the
+# single producer of a committed artifact, so it had to become a real
+# devDependency rather than a hoist that a resolver change could take away.
+#
+# Every assertion below is made against a root directory rather than against the
+# repository, so the second half of this file can point them at deliberately
+# broken copies and require that they go red. A gate nobody has ever seen fail
+# is a gate nobody knows the failure mode of.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+failures=0
+case_name=""
+
+new_case() {
+	case_name="$1"
+	printf '  case: %s\n' "${case_name}"
+}
+
+fail() {
+	printf '    FAIL (%s): %s\n' "${case_name}" "$1" >&2
+	failures=$((failures + 1))
+}
+
+# --- readers -----------------------------------------------------------------
+#
+# Deliberately textual. A JSON/TOML parser would be a tool resolved at run time,
+# which is the thing this file exists to distrust, and bun.lock is not JSON
+# anyway -- it carries trailing commas.
+
+# The value of a `[tools]` entry in .mise.toml. Names are matched with the
+# optional quoting mise allows (`"cargo:runner-run" = ...`) so a quoted pin is
+# not read as absent.
+mise_tool() {
+	sed -nE "s/^[[:space:]]*\"?$2\"?[[:space:]]*=[[:space:]]*\"([^\"]+)\".*/\1/p" "$1/.mise.toml" | head -1
+}
+
+# A `"key": "value"` pair inside one named block, addressed by the block's own
+# indentation. Scoping matters here: package.json's scripts contain the *word*
+# wrangler thirteen times, and a file-wide grep for it would report a dependency
+# that does not exist.
+json_block_value() {
+	local file="$1" indent="$2" block="$3" want="$4"
+	awk -v ind="${indent}" -v block="${block}" -v want="${want}" '
+		index($0, ind "\"" block "\": {") == 1 { inside = 1; next }
+		inside && index($0, ind "}") == 1 { exit }
+		inside {
+			if (match($0, /"[^"]+": *"[^"]*"/)) {
+				seg = substr($0, RSTART, RLENGTH)
+				split(seg, p, "\"")
+				if (p[2] == want) { print p[4]; exit }
+			}
+		}
+	' "${file}"
+}
+
+# The version bun actually installed, read from the top-level entry in the
+# "packages" map -- the same address scripts/test-typegen-pin.sh uses, and for
+# the same reason: a package's own entry starts a line, a range it merely
+# declares is written inline inside some other package's entry.
+lock_resolved() {
+	grep -E "^[[:space:]]*\"$2\": \\[" "$1/bun.lock" \
+		| head -1 \
+		| sed -nE "s/.*\"$2@([^\"]+)\".*/\1/p"
+}
+
+# An exact release, not a range, not a channel. `latest` is the case that
+# prompted all of this; `^4.123.0` and `4.x` are the same bug wearing a version
+# number, because the thing that varies is still the day you resolved it.
+is_exact_version() {
+	[[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]
+}
+
+# --- the assertions, as a function of a root ---------------------------------
+#
+# Prints one line per problem and returns the count, so a caller can either
+# fold them into `failures` (the repository) or require that there were some
+# (the mutants). PRODUCERS is the list this repository has decided it cannot
+# afford to float; everything else in .mise.toml only ever reads.
+PRODUCERS=(wrangler biome tombi golangci-lint)
+
+check_root() {
+	local root="$1"
+	local problems=0
+	local tool version
+
+	note() {
+		printf '%s\n' "$1"
+		problems=$((problems + 1))
+	}
+
+	for tool in "${PRODUCERS[@]}"; do
+		version="$(mise_tool "${root}" "${tool}")"
+		if [[ -z ${version} ]]; then
+			note "${tool} is not in .mise.toml [tools] -- it rewrites committed files, so it cannot be left to whatever is on PATH"
+		elif ! is_exact_version "${version}"; then
+			note "${tool} is pinned to '${version}' in .mise.toml -- a producer has to name one release, or 'mise install' becomes a repository mutation"
+		fi
+	done
+
+	local declared_wrangler locked_wrangler mise_wrangler lock_direct
+	declared_wrangler="$(json_block_value "${root}/package.json" '  ' devDependencies wrangler)"
+	lock_direct="$(json_block_value "${root}/bun.lock" '      ' devDependencies wrangler)"
+	locked_wrangler="$(lock_resolved "${root}" wrangler)"
+	mise_wrangler="$(mise_tool "${root}" wrangler)"
+
+	if [[ -z ${declared_wrangler} ]]; then
+		note "package.json invokes wrangler but does not depend on it -- node_modules/.bin/wrangler then exists only while bun keeps hoisting it out of @cloudflare/vitest-pool-workers, and it is the producer of a committed artifact"
+	elif ! is_exact_version "${declared_wrangler}"; then
+		note "package.json depends on wrangler '${declared_wrangler}' -- the producer of worker-configuration.d.ts has to be an exact version"
+	fi
+
+	if [[ -z ${lock_direct} ]]; then
+		note "bun.lock does not carry wrangler as a root devDependency -- package.json and the lockfile disagree about whether it is ours; run 'bun install'"
+	fi
+
+	if [[ -z ${locked_wrangler} ]]; then
+		note "no resolved top-level wrangler entry in bun.lock"
+	elif [[ -n ${declared_wrangler} && ${declared_wrangler} != "${locked_wrangler}" ]]; then
+		note "package.json asks for wrangler ${declared_wrangler} but bun.lock resolved ${locked_wrangler}"
+	fi
+
+	# The two channels are allowed to exist; they are not allowed to be two
+	# versions. `wrangler types` stamps its own workerd into the header of the
+	# file it writes, so a split version is a split producer no matter which one
+	# the Taskfile happens to name today.
+	if [[ -n ${mise_wrangler} && -n ${locked_wrangler} && ${mise_wrangler} != "${locked_wrangler}" ]]; then
+		note "the mise wrangler is ${mise_wrangler} and the bun.lock one is ${locked_wrangler} -- two channels are fine, two versions are two producers"
+	fi
+
+	unset -f note
+	return "${problems}"
+}
+
+# --- the repository itself has to satisfy them -------------------------------
+
+new_case 'every producer in .mise.toml is pinned and the two wranglers agree'
+set +e
+check_output="$(check_root "${repo_root}")"
+set -e
+if [[ -n ${check_output} ]]; then
+	while IFS= read -r line; do
+		fail "${line}"
+	done <<<"${check_output}"
+else
+	printf '    wrangler %s (mise and bun.lock), biome %s, tombi %s\n' \
+		"$(lock_resolved "${repo_root}" wrangler)" \
+		"$(mise_tool "${repo_root}" biome)" \
+		"$(mise_tool "${repo_root}" tombi)"
+fi
+
+# --- and the second wrangler channel has to still be earning its keep --------
+#
+# The decision recorded here is "keep both, pin both", and it is only correct
+# for as long as something genuinely runs wrangler without node_modules. Today
+# two things do: .github/workflows/d1-migrate.yml, which is checkout + mise and
+# no bun at all, and scripts/cf.sh's WORKERS_CI branch, which installs mise
+# before bun install has run. If both of those go away the honest move is to
+# drop the tool from .mise.toml and let package.json own wrangler outright --
+# so this case fails when the reason disappears, not when it holds.
+new_case 'the mise wrangler channel still has a caller without node_modules'
+nodeless_callers=()
+d1_workflow="${repo_root}/.github/workflows/d1-migrate.yml"
+if [[ -f ${d1_workflow} ]] \
+	&& grep -qE '(^|[^[:alnum:]_-])wrangler[[:space:]]' "${d1_workflow}" \
+	&& ! grep -q 'setup-bun' "${d1_workflow}"; then
+	nodeless_callers+=('.github/workflows/d1-migrate.yml')
+fi
+if grep -q 'WORKERS_CI' "${repo_root}/scripts/cf.sh"; then
+	nodeless_callers+=('scripts/cf.sh (WORKERS_CI)')
+fi
+
+if ((${#nodeless_callers[@]} == 0)); then
+	fail "nothing runs wrangler outside a tree with node_modules any more -- the .mise.toml wrangler is now a second producer with no operational reason, so remove it and let package.json own it"
+else
+	printf '    kept for: %s\n' "${nodeless_callers[*]}"
+fi
+
+# --- a clean checkout has to stay clean --------------------------------------
+#
+# The pin is only half the fix. The tree also had to be normalised once at the
+# pinned version, because no biome in the 2.4/2.5 range agreed with the import
+# order that was committed -- so a fresh clone, having run nothing but `mise
+# install`, would still have had its first `git commit` rewrite two files.
+#
+# `check`, not `check --fix`: a fix would make this pass by mutating the very
+# thing it is asserting. Clean here is exactly the statement that pre-commit's
+# `biome check --fix` has nothing to do.
+new_case 'biome at the pinned version leaves the checkout alone'
+pinned_biome="$(mise_tool "${repo_root}" biome)"
+if ! command -v mise >/dev/null 2>&1 || ! mise which biome >/dev/null 2>&1; then
+	printf '    skip: no mise-provided biome\n'
+else
+	running_biome="$(mise exec -- biome --version 2>/dev/null | sed -nE 's/^Version: (.+)$/\1/p')"
+	if [[ ${running_biome} != "${pinned_biome}" ]]; then
+		fail "mise resolves biome ${running_biome} but .mise.toml pins ${pinned_biome} -- run 'mise install'"
+	elif ! biome_out="$(cd "${repo_root}" && mise exec -- biome check 2>&1)"; then
+		fail "biome ${pinned_biome} wants to change the checked-out tree, so the pre-commit lint:fix will rewrite it:"$'\n'"${biome_out}"
+	fi
+fi
+
+# --- the mutants --------------------------------------------------------------
+#
+# Each one is the repository with a single deliberate regression applied, and
+# each has to be caught by the assertion that names it. Copies are of the three
+# files check_root reads; nothing here can touch the working tree.
+
+mutant_root() {
+	local name="$1" root="${tmp_dir}/mutants/$1"
+	mkdir -p "${root}"
+	cp "${repo_root}/.mise.toml" "${repo_root}/package.json" "${repo_root}/bun.lock" "${root}/"
+	printf '%s' "${root}"
+}
+
+expect_caught() {
+	local label="$1" root="$2" expected="$3"
+	local out
+	new_case "${label}"
+	set +e
+	out="$(check_root "${root}")"
+	set -e
+	if [[ -z ${out} ]]; then
+		fail 'the mutation was not caught at all'
+	elif ! grep -qF -- "${expected}" <<<"${out}"; then
+		fail "caught something, but not the mutation: ${out}"
+	fi
+}
+
+root="$(mutant_root biome-latest)"
+sed -i -E 's/^([[:space:]]*biome[[:space:]]*=[[:space:]]*)".*"/\1"latest"/' "${root}/.mise.toml"
+expect_caught 'mutant: biome = "latest" is rejected' "${root}" "biome is pinned to 'latest'"
+
+root="$(mutant_root wrangler-latest)"
+sed -i -E 's/^([[:space:]]*wrangler[[:space:]]*=[[:space:]]*)".*"/\1"latest"/' "${root}/.mise.toml"
+expect_caught 'mutant: wrangler = "latest" is rejected' "${root}" "wrangler is pinned to 'latest'"
+
+root="$(mutant_root tombi-latest)"
+sed -i -E 's/^([[:space:]]*tombi[[:space:]]*=[[:space:]]*)".*"/\1"latest"/' "${root}/.mise.toml"
+expect_caught 'mutant: a floating dprint-invoked formatter is rejected' "${root}" "tombi is pinned to 'latest'"
+
+# The pre-#125 state exactly: scripts calling a binary that is only there while
+# some other package keeps depending on it.
+root="$(mutant_root wrangler-undeclared)"
+sed -i -E '/^[[:space:]]*"wrangler": "[^"]*",?$/d' "${root}/package.json"
+expect_caught 'mutant: dropping the direct wrangler dep is rejected' "${root}" 'does not depend on it'
+
+root="$(mutant_root wrangler-range)"
+sed -i -E 's/^([[:space:]]*"wrangler": )"[^"]*"/\1"^4.123.0"/' "${root}/package.json"
+expect_caught 'mutant: a floating wrangler range is rejected' "${root}" 'has to be an exact version'
+
+root="$(mutant_root wrangler-split)"
+sed -i -E 's/^([[:space:]]*wrangler[[:space:]]*=[[:space:]]*)".*"/\1"4.127.1"/' "${root}/.mise.toml"
+expect_caught 'mutant: two pinned-but-different wranglers are rejected' "${root}" 'two versions are two producers'
+
+# --- and the typegen gate has to read a resolution, not a declaration ---------
+#
+# scripts/test-typegen-pin.sh compares the workerd in the generated header
+# against bun.lock. Which workerd it reads is the whole question. Reading the
+# one inside wrangler's own dependency map is reading what wrangler *asked for*;
+# the fixtures below are built so that the asked-for and the installed versions
+# differ, which is the only condition under which the two readers disagree.
+#
+# The fixture is a real git repository because the gate reads the committed blob
+# out of the index rather than the worktree -- that is #124's fix, and it is
+# preserved here rather than worked around.
+
+typegen_fixture() {
+	local name="$1" declared_workerd="$2" resolved_workerd="$3" header_workerd="$4"
+	local root="${tmp_dir}/typegen/${name}"
+	mkdir -p "${root}/scripts"
+
+	cp "${repo_root}/Taskfile.yml" "${root}/Taskfile.yml"
+	cp "${repo_root}/scripts/cf.sh" "${root}/scripts/cf.sh"
+
+	cat >"${root}/bun.lock" <<EOF
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "devDependencies": {
+        "wrangler": "4.123.0",
+      },
+    },
+  },
+  "packages": {
+    "workerd": ["workerd@${resolved_workerd}", "", {}, "sha512-fixture"],
+    "wrangler": ["wrangler@4.123.0", "", { "dependencies": { "workerd": "${declared_workerd}" } }, "sha512-fixture"],
+  }
+}
+EOF
+
+	printf '// Runtime types generated with workerd@%s 2026-07-12 nodejs_compat\n' "${header_workerd}" \
+		>"${root}/worker-configuration.d.ts"
+
+	git -C "${root}" init -q
+	git -C "${root}" add -A
+	printf '%s' "${root}"
+}
+
+run_typegen_gate() {
+	TYPEGEN_PIN_ROOT="$1" bash "${repo_root}/scripts/test-typegen-pin.sh" >"$2" 2>&1
+}
+
+new_case 'typegen gate: a fixture whose header matches the resolution passes'
+root="$(typegen_fixture agreeing 1.20260811.1 1.20260811.1 1.20260811.1)"
+if ! run_typegen_gate "${root}" "${tmp_dir}/agreeing.log"; then
+	fail "the gate failed on a consistent fixture: $(cat "${tmp_dir}/agreeing.log")"
+fi
+
+new_case 'typegen gate: a header from another workerd is caught'
+root="$(typegen_fixture drifted 1.20260811.1 1.20260811.1 1.20260101.9)"
+if run_typegen_gate "${root}" "${tmp_dir}/drifted.log"; then
+	fail 'the gate passed a tree whose committed types came from a different workerd'
+elif ! grep -q 'regenerate with' "${tmp_dir}/drifted.log"; then
+	fail "the gate failed for some other reason: $(cat "${tmp_dir}/drifted.log")"
+fi
+
+# The regression this file was extended for. Everything installed is consistent
+# -- workerd 1.20260811.1 is what bun resolved and what wrote the header -- and
+# the only oddity is that wrangler declares a range. A gate reading that range
+# reports "committed with 1.20260811.1 but the lockfile says ^1.20260811.0",
+# which is not a fact about anything: the caret is not a build, no wrangler ever
+# stamped it into a header, and there is nothing the reader could do to make it
+# agree. Worse in the other direction, a range wide enough to spell a version
+# that is not installed would let a genuinely stale artifact through.
+new_case 'typegen gate: a declared range does not manufacture a mismatch'
+root="$(typegen_fixture ranged '^1.20260811.0' 1.20260811.1 1.20260811.1)"
+declared="$(grep -E '^[[:space:]]*"wrangler": \[' "${root}/bun.lock" | sed -nE 's/.*"workerd": ?"([^"]+)".*/\1/p')"
+if [[ ${declared} != '^1.20260811.0' ]]; then
+	fail "the fixture does not actually distinguish the two readers (declared '${declared}')"
+elif ! run_typegen_gate "${root}" "${tmp_dir}/ranged.log"; then
+	fail "the gate read wrangler's declared workerd spec rather than the resolved entry: $(cat "${tmp_dir}/ranged.log")"
+fi
+
+new_case 'typegen gate: a lockfile with no resolved workerd is an error, not a pass'
+root="$(typegen_fixture no-workerd 1.20260811.1 1.20260811.1 1.20260811.1)"
+sed -i -E '/^[[:space:]]*"workerd": \[/d' "${root}/bun.lock"
+git -C "${root}" add -A
+if run_typegen_gate "${root}" "${tmp_dir}/no-workerd.log"; then
+	fail 'the gate passed a lockfile it could not read a workerd out of'
+elif ! grep -q 'no resolved top-level "workerd" entry' "${tmp_dir}/no-workerd.log"; then
+	fail "the gate failed for some other reason: $(cat "${tmp_dir}/no-workerd.log")"
+fi
+
+if ((failures > 0)); then
+	printf '\n%d tool pin assertion(s) failed\n' "${failures}" >&2
+	exit 1
+fi
+
+printf '\ntool pin gate: all assertions passed\n'

--- a/scripts/test-typegen-pin.sh
+++ b/scripts/test-typegen-pin.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 # Covers the invariant that worker-configuration.d.ts has exactly one producer.
 #
-# There are two wranglers reachable from this repo and they ship different
-# workerd builds:
+# There are two wranglers reachable from this repo:
 #
-#   * `.mise.toml` has `wrangler = "latest"`, an unpinned tool whose version is
-#     whatever the machine resolved the day mise installed it
-#   * node_modules/.bin/wrangler, pinned to an exact version by bun.lock as a
-#     transitive dependency of @cloudflare/vitest-pool-workers
+#   * `.mise.toml`'s, which reaches checkouts that have no node_modules --
+#     .github/workflows/d1-migrate.yml and scripts/cf.sh's WORKERS_CI branch
+#   * node_modules/.bin/wrangler, pinned by bun.lock and now a *direct*
+#     devDependency rather than a hoisted transitive of vitest-pool-workers
+#
+# #125 pinned the first to the version the second resolves, so the two channels
+# ship one workerd; scripts/test-tool-pins.sh is what holds that down. This file
+# stays as it was written for #123/#124 -- it does not care what `.mise.toml`
+# says, only that the committed artifact matches the lockfile and that no task
+# regenerates it through anything but the lockfile binary. That is deliberate:
+# if the mise pin is ever lost these assertions still fail on the artifact.
 #
 # `wrangler types` stamps its own workerd into the header of the generated file,
 # so whichever one ran last decides what is in the tree. That is #123: the
@@ -22,11 +28,15 @@
 # the vitest-pool-workers suite actually executes on; types describing a
 # different runtime than the tests run against are wrong even when CI is green.
 # So the two assertions below are: the header records the lockfile's workerd,
-# and no task regenerates the file through the unpinned mise tool. Both fail on
+# and no task regenerates the file through the mise tool. Both fail on
 # the pre-fix tree. Neither needs a network or a wrangler run.
 set -euo pipefail
 
-repo_root="$(git rev-parse --show-toplevel)"
+# A fixture root so the gate itself is testable: scripts/test-tool-pins.sh
+# assembles mutated bun.lock/Taskfile/artifact trees under a temporary git repo
+# and asserts this script actually goes red on each of them. Unset -- which is
+# every real invocation -- it is the repository.
+repo_root="${TYPEGEN_PIN_ROOT:-$(git rev-parse --show-toplevel)}"
 
 failures=0
 case_name=""
@@ -52,25 +62,45 @@ for required in "${types_file}" "${lockfile}" "${taskfile}"; do
 	fi
 done
 
-# The resolved `wrangler` entry in bun.lock, e.g.
-#   "wrangler": ["wrangler@4.123.0", "", { "dependencies": { ..., "workerd": "1.20260811.1" }, ... }, "sha512-..."],
-# The address is the top-level key, so a nested "wrangler" under some other
-# package's dependency map cannot be picked up by accident.
-wrangler_entry="$(grep -E '^[[:space:]]*"wrangler": \[' "${lockfile}" || true)"
+# Entries in bun.lock's "packages" map are keyed by package name at the start of
+# a line, e.g.
+#   "wrangler": ["wrangler@4.123.0", "", { "dependencies": { ... } }, "sha512-..."],
+# while a dependency *of* some package is written inline inside that package's
+# own line. Anchoring the address to the line start is therefore what separates
+# "the version bun installed" from "a range someone declared".
+lock_entry() {
+	grep -E "^[[:space:]]*\"$1\": \\[" "${lockfile}" | head -1 || true
+}
+
+wrangler_entry="$(lock_entry wrangler)"
 if [[ -z ${wrangler_entry} ]]; then
 	printf 'no resolved "wrangler" entry in bun.lock -- did the dependency move?\n' >&2
 	exit 1
 fi
-
 locked_wrangler="$(sed -nE 's/.*"wrangler@([^"]+)".*/\1/p' <<<"${wrangler_entry}")"
-locked_workerd="$(sed -nE 's/.*"workerd": ?"([^"]+)".*/\1/p' <<<"${wrangler_entry}")"
+
+# Read workerd from its *own* resolved entry rather than from the "workerd":
+# "..." that appears inside wrangler's dependency map. Those are two different
+# things: the latter is the range wrangler asked for, the former is the single
+# build bun actually installed and therefore the one `wrangler types` runs and
+# stamps into the header. They are equal today only because wrangler happens to
+# declare an exact version; the day it declares "^1.2026...." or a workspace
+# override moves the resolution, comparing the header against the *declared*
+# spec starts reporting a mismatch that is not one -- or, worse, masks a real
+# one. This is the address of the thing on disk.
+workerd_entry="$(lock_entry workerd)"
+if [[ -z ${workerd_entry} ]]; then
+	printf 'no resolved top-level "workerd" entry in bun.lock -- did the dependency move?\n' >&2
+	exit 1
+fi
+locked_workerd="$(sed -nE 's/.*"workerd@([^"]+)".*/\1/p' <<<"${workerd_entry}")"
 
 if [[ -z ${locked_wrangler} || -z ${locked_workerd} ]]; then
 	printf 'could not read the wrangler/workerd pin out of bun.lock\n' >&2
 	exit 1
 fi
 
-printf 'bun.lock pins wrangler@%s (workerd %s)\n' "${locked_wrangler}" "${locked_workerd}"
+printf 'bun.lock resolves wrangler@%s and workerd@%s\n' "${locked_wrangler}" "${locked_workerd}"
 
 new_case 'the committed types record the lockfile wrangler workerd'
 # Read the *committed* blob out of the index, not the copy on disk. Every CI job
@@ -93,11 +123,11 @@ else
 	if [[ -z ${header_workerd} ]]; then
 		fail 'worker-configuration.d.ts has no "Runtime types generated with workerd@..." header'
 	elif [[ ${header_workerd} != "${locked_workerd}" ]]; then
-		fail "worker-configuration.d.ts is committed as generated with workerd ${header_workerd}, but bun.lock pins wrangler@${locked_wrangler} which ships workerd ${locked_workerd} -- regenerate with 'task typegen' and commit the result"
+		fail "worker-configuration.d.ts is committed as generated with workerd ${header_workerd}, but bun.lock resolves workerd@${locked_workerd} (under wrangler@${locked_wrangler}) -- regenerate with 'task typegen' and commit the result"
 	fi
 fi
 
-new_case 'typegen does not regenerate through the unpinned mise wrangler'
+new_case 'typegen does not regenerate through the mise wrangler'
 # Only the recipe matters, so read the command lines of the typegen task rather
 # than the whole file: `mise exec -- wrangler dev` and the d1/kv tasks are
 # deliberately on the current tool and emit no committed artifact.
@@ -114,7 +144,7 @@ fi
 # Comments in the recipe describe the trap; they are not what runs.
 typegen_cmds="$(grep -vE '^[[:space:]]*#' <<<"${typegen_recipe}")"
 if grep -q 'wrangler' <<<"${typegen_cmds}"; then
-	fail "the typegen task invokes wrangler directly -- that resolves .mise.toml's unpinned tool, not the bun.lock pin"
+	fail "the typegen task invokes wrangler directly -- that resolves .mise.toml's tool rather than the bun.lock pin, and the two are equal only for as long as someone keeps them equal"
 fi
 if ! grep -qE '\brun typegen\b' <<<"${typegen_cmds}"; then
 	fail 'the typegen task no longer runs the package.json "typegen" script, so it can drift from what the prepare hook fires on bun install'

--- a/src/__tests__/sentry.test.ts
+++ b/src/__tests__/sentry.test.ts
@@ -1,5 +1,5 @@
 import type { Breadcrumb, ErrorEvent, Event } from "@sentry/cloudflare";
-import { captureException, CloudflareClient, getCurrentScope, withScope } from "@sentry/cloudflare";
+import { CloudflareClient, captureException, getCurrentScope, withScope } from "@sentry/cloudflare";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "#types";
 import { logger } from "#utils/logger";

--- a/src/durable-objects/key-storage.ts
+++ b/src/durable-objects/key-storage.ts
@@ -1,6 +1,6 @@
 import type { AnyStoredKey } from "#schemas/keys";
-import { HTTP, MediaType } from "#types";
 import { isX509Key } from "#schemas/keys";
+import { HTTP, MediaType } from "#types";
 import { logger } from "#utils/logger";
 
 export class KeyStorage implements DurableObject {


### PR DESCRIPTION
Closes #125.

Makes generated-artifact producers deterministic instead of relying on floating or transitive resolution. This pins the repository's wrangler/Biome/Tombi producer versions, makes wrangler a direct devDependency, keeps the separate mise wrangler only where node_modules is unavailable, changes the typegen pin gate to inspect the resolved workerd entry, and adds regression/mutation coverage for the historical failure modes.

Verification reported by the implementation run: `task typegen`, `task generate:api` + clean-diff guard, `task format:check`, `task lint`, `task typecheck`, `task test`, and `task test:coverage` all pass; coverage reports 1262 tests with 99.49% statements / 95.64% branches / 99.62% lines.

The implementation also identified dprint as the same general determinism class but deliberately leaves it out of this PR because fixing it crosses into separate formatting-action tooling.