### PR TITLE
ci(lint): gate shell embedded in composite actions

### DIFF
--- a/.github/actions/check-api-changes/action.yml
+++ b/.github/actions/check-api-changes/action.yml
@@ -51,4 +51,4 @@ runs:
             | tee -a "${GITHUB_STEP_SUMMARY}"
           }
          	exit "${EXIT_CODE}"
-        else echo "::notice:API is up to date"; exit 0; fi
+        else echo "::notice::API is up to date"; exit 0; fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -61,6 +61,7 @@ tasks:
       - task: test:go-modernize-gate
       - task: test:typegen-pin
       - task: test:tool-pins
+      - task: test:composite-actions
 
   test:sentry:
     desc: Run the Sentry boundary suite alone — the inner loop of the mutation set
@@ -133,6 +134,12 @@ tasks:
     aliases: [tp, pins]
     cmd: bash scripts/test-tool-pins.sh
 
+  test:composite-actions:
+    desc: Test that composite-action shell regressions cannot bypass linting
+    aliases: [tca]
+    deps: [install:noscripts]
+    cmd: bash scripts/test-composite-action-lint.sh
+
   test:coverage:
     desc: Run tests with coverage
     aliases: [tc]
@@ -156,6 +163,7 @@ tasks:
       - task: test:go-modernize-gate
       - task: test:typegen-pin
       - task: test:tool-pins
+      - task: test:composite-actions
 
   test:watch:
     desc: Run tests in watch mode
@@ -202,9 +210,26 @@ tasks:
     # workflows-pending/ is included because that is where the workflows this
     # repository's own automation cannot push wait for a human `git mv`. They
     # are the ones nobody has run yet, so they are the ones most worth linting.
-    cmd: >-
-      find .github/workflows .github/workflows-pending -maxdepth 1 -name '*.yml' 2>/dev/null
-      | xargs -r mise exec -- actionlint
+    cmds:
+      - >-
+        find .github/workflows .github/workflows-pending -maxdepth 1 -name '*.yml' 2>/dev/null
+        | xargs -r mise exec -- actionlint
+      - task: lint:actions:composite
+
+  lint:actions:composite:
+    desc: Lint the shell embedded in composite action.yml files
+    aliases: [lac, composite]
+    deps: [install:noscripts]
+    # actionlint has no composite-action schema: pointed at an action.yml it
+    # stops at `"jobs" section is missing in workflow` and never reaches its own
+    # ShellCheck integration, and `lint:shell` globs *.sh, which an action.yml is
+    # not. So `runs.steps[*].run` was the one kind of shell this repo owns that
+    # nothing read -- both bugs #124 repaired had shipped through that hole.
+    #
+    # `mise exec` rather than a bare `bun` so the checker shells out to the same
+    # pinned shellcheck as lint:shell, and so a machine without it fails loudly
+    # instead of quietly reducing this gate to a YAML parse.
+    cmd: mise exec -- bun scripts/lint-composite-actions.ts
 
   lint:fix:
     desc: Lint and fix code

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "typescript-eslint": "8.67.0",
         "vitest": "^4.1.0",
         "wrangler": "4.123.0",
+        "yaml": "2.9.0",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "typescript": "<7.0.2",
     "typescript-eslint": "8.67.0",
     "vitest": "^4.1.0",
-    "wrangler": "4.123.0"
+    "wrangler": "4.123.0",
+    "yaml": "2.9.0"
   },
   "overrides": {
     "typescript": {

--- a/scripts/lint-composite-actions.ts
+++ b/scripts/lint-composite-actions.ts
@@ -1,0 +1,733 @@
+#!/usr/bin/env bun
+/**
+ * Lints the shell embedded in composite GitHub Actions (`runs.steps[*].run`).
+ *
+ * Nothing else in this repo reads that shell. `task lint:actions` feeds
+ * actionlint only `.github/workflows/**`, and actionlint has no composite-action
+ * schema -- pointed at an `action.yml` it stops at `"jobs" section is missing in
+ * workflow` and therefore never reaches its own ShellCheck integration.
+ * `task lint:shell` globs `*.sh`, which an `action.yml` is not. So every
+ * `run:` block under `.github/actions/` was unchecked, which is how both #124
+ * bugs shipped.
+ *
+ * ShellCheck alone would not have caught either of them, which is why this is a
+ * checker and not a two-line glob change:
+ *
+ *   * The runner executes `shell: bash` as `bash --noprofile --norc -e -o
+ *     pipefail {0}`. Under `-e`, `VAR="$(cmd)"` inherits `cmd`'s status and
+ *     aborts the step, so the `EXIT_CODE=$?` on the next statement is
+ *     unreachable -- the job fails while reporting nothing. ShellCheck models
+ *     errexit only loosely and stays silent on this shape even at
+ *     `-o all --enable=all`; it reports SC2250 about brace style and nothing
+ *     else. CA001 below is the rule that sees it.
+ *   * `::notice:msg` is not a workflow command -- GitHub wants `::notice::msg`
+ *     or `::notice title=x::msg` -- so it prints as literal text and the
+ *     annotation silently never appears. No shell linter has an opinion about
+ *     that string at all. CA002 is the rule that does.
+ *
+ * Checks, all deterministic and all reported as `file:line:col: [CODE] msg`:
+ *
+ *   CA001  `$?` read that errexit makes unreachable
+ *   CA002  malformed or unknown `::workflow-command::`
+ *   CA003  composite `run:` step with no `shell:` (the runner rejects it)
+ *   SC####  ShellCheck, on bash/sh blocks, with runner flags prepended
+ *
+ * Positions come from the `yaml` package's node ranges, so a finding points at
+ * the real line of the real `action.yml`, not at some extracted temporary.
+ *
+ * Usage:
+ *   bun scripts/lint-composite-actions.ts [--list] [paths...]
+ *
+ * With no paths it discovers `action.yml` at the repo root plus every
+ * `.github/actions/**\/action.{yml,yaml}`. `--list` prints the blocks it found
+ * and exits 0; that is the coverage assertion's hook, so a block silently
+ * dropping out of scope is itself detectable.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { isMap, isSeq, LineCounter, parseDocument } from "yaml";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Finding {
+	file: string;
+	line: number;
+	col: number;
+	code: string;
+	message: string;
+}
+
+interface RunBlock {
+	/** Repo-relative path of the action file. */
+	file: string;
+	/** 1-based step index within `runs.steps`, for messages. */
+	stepIndex: number;
+	/** `name:` or `id:` of the step, when it has one. */
+	stepName: string;
+	/** Declared `shell:`, or `null` when the step omits it. */
+	shell: string | null;
+	/** The script itself. */
+	script: string;
+	/** 1-based source line of the script's first line. */
+	startLine: number;
+	/** 0-based column the script's lines are indented to in the source. */
+	indent: number;
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+const ACTION_FILENAMES = new Set(["action.yml", "action.yaml"]);
+
+function discoverActionFiles(root: string): string[] {
+	const found: string[] = [];
+
+	for (const name of ACTION_FILENAMES) {
+		const candidate = join(root, name);
+		if (safeIsFile(candidate)) found.push(candidate);
+	}
+
+	const actionsDir = join(root, ".github", "actions");
+	if (safeIsDir(actionsDir)) walk(actionsDir, found);
+
+	return found.sort();
+}
+
+function walk(dir: string, out: string[]): void {
+	for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) walk(full, out);
+		else if (ACTION_FILENAMES.has(entry.name)) out.push(full);
+	}
+}
+
+function safeIsFile(path: string): boolean {
+	try {
+		return statSync(path).isFile();
+	} catch {
+		return false;
+	}
+}
+
+function safeIsDir(path: string): boolean {
+	try {
+		return statSync(path).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Pulls every `runs.steps[*].run` out of one composite action.
+ *
+ * Deliberately a real YAML parse rather than a regex sweep: `setup-bun`'s steps
+ * are a flow sequence of flow mappings on single lines, so anything keyed off
+ * `^\s*run:` at line starts would miss its `bun install` outright.
+ */
+function extractRunBlocks(relPath: string, source: string): { blocks: RunBlock[]; errors: Finding[] } {
+	const blocks: RunBlock[] = [];
+	const errors: Finding[] = [];
+	const lineCounter = new LineCounter();
+
+	let doc: ReturnType<typeof parseDocument>;
+	try {
+		doc = parseDocument(source, { lineCounter });
+	} catch (error) {
+		errors.push({
+			file: relPath,
+			line: 1,
+			col: 1,
+			code: "CA000",
+			message: `unparseable YAML: ${error instanceof Error ? error.message : String(error)}`,
+		});
+		return { blocks, errors };
+	}
+
+	for (const problem of doc.errors) {
+		const pos = lineCounter.linePos(problem.pos[0]);
+		errors.push({ file: relPath, line: pos.line, col: pos.col, code: "CA000", message: problem.message });
+	}
+	if (errors.length > 0) return { blocks, errors };
+
+	const using = doc.getIn(["runs", "using"]);
+	if (typeof using !== "string" || using.toLowerCase() !== "composite") return { blocks, errors };
+
+	const steps = doc.getIn(["runs", "steps"], true);
+	if (!isSeq(steps)) return { blocks, errors };
+
+	let stepIndex = 0;
+	for (const step of steps.items) {
+		stepIndex += 1;
+		if (!isMap(step)) continue;
+
+		const runNode = step.get("run", true);
+		if (runNode === undefined || runNode === null) continue;
+		const script = (runNode as { value?: unknown }).value;
+		if (typeof script !== "string") continue;
+
+		const range = (runNode as { range?: [number, number, number] }).range;
+		if (!range) continue;
+
+		const { startLine, indent } = locateScriptStart(source, range[0], lineCounter);
+
+		const shellValue = step.get("shell");
+		const shell = typeof shellValue === "string" ? shellValue : null;
+
+		const nameValue = step.get("name") ?? step.get("id");
+		const stepName = typeof nameValue === "string" ? nameValue : `step ${stepIndex}`;
+
+		if (shell === null) {
+			errors.push({
+				file: relPath,
+				line: startLine,
+				col: indent + 1,
+				code: "CA003",
+				message:
+					`composite \`run:\` step "${stepName}" has no \`shell:\`; the runner rejects the action with ` +
+					`"Required property is missing: shell"`,
+			});
+		}
+
+		blocks.push({ file: relPath, stepIndex, stepName, shell, script, startLine, indent });
+	}
+
+	return { blocks, errors };
+}
+
+/**
+ * Maps a `run:` scalar node's start offset to where its *content* starts.
+ *
+ * For a literal block scalar (`|`, `|-`, `>`, ...) the node begins at the
+ * indicator and the script starts on the following line; for a plain or quoted
+ * scalar the node start is the content start. Getting this right is what keeps
+ * a reported line number clickable.
+ */
+function locateScriptStart(
+	source: string,
+	nodeStart: number,
+	lineCounter: LineCounter,
+): { startLine: number; indent: number } {
+	const head = source[nodeStart];
+	if (head !== "|" && head !== ">") {
+		const pos = lineCounter.linePos(nodeStart);
+		return { startLine: pos.line, indent: pos.col - 1 };
+	}
+
+	const newline = source.indexOf("\n", nodeStart);
+	if (newline === -1) {
+		const pos = lineCounter.linePos(nodeStart);
+		return { startLine: pos.line, indent: pos.col - 1 };
+	}
+
+	const contentStart = newline + 1;
+	const rest = source.slice(contentStart);
+	const indentMatch = /^[ \t]*/.exec(rest.split("\n", 1)[0] ?? "");
+	const pos = lineCounter.linePos(contentStart);
+	return { startLine: pos.line, indent: indentMatch ? indentMatch[0].length : 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Shell tokenizing
+// ---------------------------------------------------------------------------
+
+/**
+ * A run of script text delimited by the control operator in front of it.
+ *
+ * `op` is what *preceded* this segment, which is the whole point: `EXIT_CODE=$?`
+ * after `||` reads a status the shell was allowed to survive, and the same text
+ * after `;` reads one errexit already exited on.
+ */
+interface Segment {
+	text: string;
+	/** Offset of `text[0]` in the original script. */
+	start: number;
+	op: "" | ";" | "\n" | "&&" | "||" | "|" | "&" | ";;";
+}
+
+/**
+ * Blanks out comments while preserving every offset, then splits into segments.
+ *
+ * Quote, `$(...)`, backtick and heredoc state are tracked so that a `#` inside a
+ * string stays script and a `;` inside one does not end a statement. This is a
+ * tokenizer for control operators, not a shell parser -- it does not need to
+ * know what any command means, only where one stops.
+ */
+function tokenize(script: string): { masked: string; segments: Segment[] } {
+	const masked = script.split("");
+	const segments: Segment[] = [];
+
+	let i = 0;
+	let segStart = 0;
+	let pendingOp: Segment["op"] = "";
+	const pendingHeredocs: { tag: string; indented: boolean }[] = [];
+
+	const push = (end: number, nextOp: Segment["op"]): void => {
+		segments.push({ text: masked.slice(segStart, end).join(""), start: segStart, op: pendingOp });
+		pendingOp = nextOp;
+	};
+
+	const blank = (from: number, to: number): void => {
+		for (let k = from; k < to; k += 1) if (masked[k] !== "\n") masked[k] = " ";
+	};
+
+	while (i < script.length) {
+		const ch = script[i] as string;
+
+		// Escapes, including line continuations, are never operators.
+		if (ch === "\\" && i + 1 < script.length) {
+			i += 2;
+			continue;
+		}
+
+		if (ch === "'") {
+			const end = script.indexOf("'", i + 1);
+			i = end === -1 ? script.length : end + 1;
+			continue;
+		}
+
+		if (ch === '"' || ch === "`") {
+			i = skipDelimited(script, i, ch);
+			continue;
+		}
+
+		if (ch === "$" && script[i + 1] === "(") {
+			i = skipParens(script, i + 1);
+			continue;
+		}
+
+		// `#` only opens a comment at the start of a word.
+		if (ch === "#" && isWordStart(script, i)) {
+			let end = script.indexOf("\n", i);
+			if (end === -1) end = script.length;
+			blank(i, end);
+			i = end;
+			continue;
+		}
+
+		// Heredocs: everything from the next newline to the tag is data, not code.
+		if (ch === "<" && script[i + 1] === "<" && script[i + 2] !== "<") {
+			const header = /^<<(-?)\s*(?:'([^']*)'|"([^"]*)"|\\?([A-Za-z_][A-Za-z0-9_]*))/.exec(script.slice(i));
+			if (header) {
+				pendingHeredocs.push({
+					tag: header[2] ?? header[3] ?? header[4] ?? "",
+					indented: header[1] === "-",
+				});
+				i += header[0].length;
+				continue;
+			}
+		}
+
+		if (ch === "\n") {
+			push(i, "\n");
+			i += 1;
+			if (pendingHeredocs.length > 0) i = skipHeredocs(script, i, pendingHeredocs);
+			segStart = i;
+			continue;
+		}
+
+		const two = script.slice(i, i + 2);
+		if (two === "&&" || two === "||" || two === ";;") {
+			push(i, two);
+			i += 2;
+			segStart = i;
+			continue;
+		}
+
+		if (ch === ";" || ch === "|" || ch === "&") {
+			push(i, ch as Segment["op"]);
+			i += 1;
+			segStart = i;
+			continue;
+		}
+
+		i += 1;
+	}
+
+	push(script.length, "");
+	return { masked: masked.join(""), segments };
+}
+
+function isWordStart(script: string, index: number): boolean {
+	if (index === 0) return true;
+	const prev = script[index - 1] as string;
+	return /[\s;&|(){}]/.test(prev);
+}
+
+/** Skips a `"`- or backtick-delimited run, honouring backslash escapes. */
+function skipDelimited(script: string, start: number, delim: string): number {
+	let i = start + 1;
+	while (i < script.length) {
+		const ch = script[i];
+		if (ch === "\\") {
+			i += 2;
+			continue;
+		}
+		if (delim === '"' && ch === "$" && script[i + 1] === "(") {
+			i = skipParens(script, i + 1);
+			continue;
+		}
+		if (ch === delim) return i + 1;
+		i += 1;
+	}
+	return script.length;
+}
+
+/** Skips a balanced `(...)`, starting at the opening paren. */
+function skipParens(script: string, start: number): number {
+	let depth = 0;
+	let i = start;
+	while (i < script.length) {
+		const ch = script[i];
+		if (ch === "\\") {
+			i += 2;
+			continue;
+		}
+		if (ch === "'") {
+			const end = script.indexOf("'", i + 1);
+			i = end === -1 ? script.length : end + 1;
+			continue;
+		}
+		if (ch === '"') {
+			i = skipDelimited(script, i, '"');
+			continue;
+		}
+		if (ch === "(") depth += 1;
+		else if (ch === ")") {
+			depth -= 1;
+			if (depth === 0) return i + 1;
+		}
+		i += 1;
+	}
+	return script.length;
+}
+
+function skipHeredocs(script: string, start: number, pending: { tag: string; indented: boolean }[]): number {
+	let i = start;
+	while (pending.length > 0 && i < script.length) {
+		let end = script.indexOf("\n", i);
+		if (end === -1) end = script.length;
+		const line = script.slice(i, end);
+		const doc = pending[0] as { tag: string; indented: boolean };
+		const candidate = doc.indented ? line.replace(/^[\t]+/, "") : line;
+		i = end < script.length ? end + 1 : script.length;
+		if (candidate === doc.tag) pending.shift();
+	}
+	pending.length = 0;
+	return i;
+}
+
+// ---------------------------------------------------------------------------
+// CA001 -- `$?` the runner's errexit makes unreachable
+// ---------------------------------------------------------------------------
+
+/** Segment texts after which `$?` is a live, meaningful status read. */
+const COMPOUND_TERMINATORS = /(^|[\s;])(fi|done|esac|then|else|do|\}|\))\s*$/;
+
+function checkErrexitStatusReads(block: RunBlock, segments: Segment[]): Finding[] {
+	const findings: Finding[] = [];
+
+	// A composite `shell: bash` step is run as `bash --noprofile --norc -e -o
+	// pipefail {0}` and `shell: sh` as `sh -e {0}`; errexit is on before the
+	// script's first line, whether or not the script says so.
+	let errexit = true;
+	let previous: Segment | null = null;
+
+	for (const segment of segments) {
+		const trimmed = segment.text.trim();
+
+		const statusIndex = segment.text.indexOf("$?");
+		if (
+			statusIndex !== -1 &&
+			errexit &&
+			previous !== null &&
+			segment.op !== "&&" &&
+			segment.op !== "||" &&
+			segment.op !== "|" &&
+			segment.op !== ";;" &&
+			!COMPOUND_TERMINATORS.test(previous.text.trimEnd()) &&
+			!/^\s*(if|while|until|case|elif)\b/.test(previous.text)
+		) {
+			const previousText = collapse(previous.text.trim());
+			findings.push({
+				file: block.file,
+				line: 0,
+				col: segment.start + statusIndex,
+				code: "CA001",
+				message:
+					`\`$?\` is unreachable here: the runner executes this step with errexit, so \`${previousText}\` ` +
+					`aborts the step on failure and never reaches this read. Guard the command instead, ` +
+					`e.g. \`${previousText} || status=$?\`.`,
+			});
+		}
+
+		const setFlags = /^set\s+((?:[-+][A-Za-z]+\s*)+|[-+]o\s+errexit)/.exec(trimmed);
+		if (setFlags) {
+			if (/[-]o\s+errexit/.test(trimmed) || /^set\s+-[A-Za-z]*e/.test(trimmed)) errexit = true;
+			else if (/[+]o\s+errexit/.test(trimmed) || /^set\s+\+[A-Za-z]*e/.test(trimmed)) errexit = false;
+		}
+
+		if (trimmed !== "") previous = segment;
+	}
+
+	return findings;
+}
+
+function collapse(text: string): string {
+	const flat = text.replace(/\s+/g, " ").trim();
+	return flat.length > 60 ? `${flat.slice(0, 57)}...` : flat;
+}
+
+// ---------------------------------------------------------------------------
+// CA002 -- workflow command syntax
+// ---------------------------------------------------------------------------
+
+const WORKFLOW_COMMANDS = new Set([
+	"add-mask",
+	"add-matcher",
+	"add-path",
+	"debug",
+	"echo",
+	"endgroup",
+	"error",
+	"group",
+	"notice",
+	"remove-matcher",
+	"save-state",
+	"set-env",
+	"set-output",
+	"stop-commands",
+	"warning",
+]);
+
+/**
+ * Flags `::` sequences that look like a workflow command but are not one.
+ *
+ * GitHub only accepts `::name::message` or `::name key=value,key=value::message`.
+ * `::notice:API is up to date` matches neither, so the runner prints it as plain
+ * text and the annotation is silently lost -- the exact typo #124 shipped.
+ *
+ * Anchored to a start-of-string, whitespace or quote boundary so that PowerShell
+ * type literals like `[Text.Encoding]::UTF8` in the repo-root action, or any
+ * `Foo::bar` in prose, are not mistaken for commands.
+ */
+function checkWorkflowCommands(block: RunBlock, masked: string): Finding[] {
+	const findings: Finding[] = [];
+	const pattern = /(?:^|[\s'"])::([a-z][a-z-]*)/g;
+
+	for (const match of masked.matchAll(pattern)) {
+		const name = match[1] as string;
+		const nameEnd = (match.index ?? 0) + match[0].length;
+		const rest = masked.slice(nameEnd);
+		const lineEnd = rest.indexOf("\n");
+		const tail = lineEnd === -1 ? rest : rest.slice(0, lineEnd);
+		const commandStart = nameEnd - name.length - 2;
+
+		if (!WORKFLOW_COMMANDS.has(name)) {
+			findings.push({
+				file: block.file,
+				line: 0,
+				col: commandStart,
+				code: "CA002",
+				message: `\`::${name}\` is not a GitHub workflow command; it will be printed verbatim instead of acted on.`,
+			});
+			continue;
+		}
+
+		if (tail.startsWith("::")) continue;
+		if (/^\s+\S/.test(tail) && tail.includes("::")) continue;
+
+		// Show only up to the string's closing quote, so the excerpt is the command
+		// as it would be emitted rather than the rest of the shell line.
+		const excerpt = collapse((/^[^'"]*/.exec(tail)?.[0] ?? tail).slice(0, 32));
+
+		findings.push({
+			file: block.file,
+			line: 0,
+			col: commandStart,
+			code: "CA002",
+			message:
+				`malformed workflow command \`::${name}${excerpt}\`: the name must be closed with \`::\` ` +
+				`(\`::${name}::message\`, or \`::${name} key=value::message\`). As written the runner prints it as text ` +
+				`and the annotation never appears.`,
+		});
+	}
+
+	return findings;
+}
+
+// ---------------------------------------------------------------------------
+// ShellCheck
+// ---------------------------------------------------------------------------
+
+interface ShellCheckComment {
+	line: number;
+	column: number;
+	level: string;
+	code: number;
+	message: string;
+}
+
+/** Composite `shell:` values whose scripts ShellCheck can read. */
+function shellDialect(shell: string | null): "bash" | "sh" | null {
+	if (shell === null) return null;
+	const head = shell.trim().split(/\s+/, 1)[0]?.toLowerCase() ?? "";
+	if (head === "bash") return "bash";
+	if (head === "sh") return "sh";
+	return null;
+}
+
+/**
+ * Replaces `${{ ... }}` with same-length filler before handing a block to
+ * ShellCheck, so an expression cannot be read as shell syntax and every
+ * remaining column still lines up with the source.
+ */
+function maskExpressions(script: string): string {
+	return script.replace(/\$\{\{[\s\S]*?\}\}/g, (m) => "x".repeat(m.length));
+}
+
+function runShellCheck(block: RunBlock, dialect: "bash" | "sh"): Finding[] {
+	// Prepended so ShellCheck analyses the script under the options the runner
+	// actually sets, rather than under bare defaults.
+	const prelude =
+		dialect === "bash"
+			? "#!/usr/bin/env bash\n# runner: bash --noprofile --norc -e -o pipefail {0}\nset -e -o pipefail\n"
+			: "#!/bin/sh\n# runner: sh -e {0}\nset -e\n";
+	const preludeLines = prelude.split("\n").length - 1;
+
+	let stdout: string;
+	let stderr: string;
+	let exitCode: number;
+	try {
+		const proc = Bun.spawnSync({
+			cmd: ["shellcheck", `--shell=${dialect}`, "--format=json1", "--color=never", "-"],
+			stdin: Buffer.from(prelude + maskExpressions(block.script)),
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		stdout = proc.stdout?.toString().trim() ?? "";
+		stderr = proc.stderr?.toString().trim() ?? "";
+		exitCode = proc.exitCode ?? 0;
+	} catch {
+		// Silently skipping would turn this gate into a no-op the day the tool is
+		// missing, which is the failure mode the gate exists to prevent.
+		throw new Error("shellcheck is not on PATH; run this through `task lint:actions:composite` (mise provides it)");
+	}
+
+	if (stdout === "") {
+		if (exitCode !== 0) {
+			throw new Error(`shellcheck failed on ${block.file} (${block.stepName}): ${stderr}`);
+		}
+		return [];
+	}
+
+	const parsed = JSON.parse(stdout) as { comments?: ShellCheckComment[] };
+	return (parsed.comments ?? []).map((c) => ({
+		file: block.file,
+		line: block.startLine + (c.line - preludeLines - 1),
+		col: block.indent + c.column,
+		code: `SC${c.code}`,
+		message: `${c.message} (${c.level})`,
+	}));
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+/** Turns an offset inside a block's script into a source line and column. */
+function resolvePosition(block: RunBlock, offset: number): { line: number; col: number } {
+	const before = block.script.slice(0, offset);
+	const lineOffset = before.split("\n").length - 1;
+	const lastNewline = before.lastIndexOf("\n");
+	const column = offset - (lastNewline + 1);
+	return {
+		line: block.startLine + lineOffset,
+		// Only the first line of a block scalar is already past the indent.
+		col: block.indent + column + 1,
+	};
+}
+
+function lintFile(absPath: string, root: string): { findings: Finding[]; blocks: RunBlock[] } {
+	const relPath = relative(root, absPath) || absPath;
+	const source = readFileSync(absPath, "utf8");
+	const { blocks, errors } = extractRunBlocks(relPath, source);
+	const findings = [...errors];
+
+	for (const block of blocks) {
+		const { masked, segments } = tokenize(block.script);
+
+		for (const finding of [...checkErrexitStatusReads(block, segments), ...checkWorkflowCommands(block, masked)]) {
+			const pos = resolvePosition(block, finding.col);
+			findings.push({ ...finding, line: pos.line, col: pos.col });
+		}
+
+		const dialect = shellDialect(block.shell);
+		if (dialect !== null) findings.push(...runShellCheck(block, dialect));
+	}
+
+	return { findings, blocks };
+}
+
+function main(): number {
+	const args = process.argv.slice(2);
+	const listOnly = args.includes("--list");
+	const paths = args.filter((a) => !a.startsWith("--"));
+	const root = process.env.COMPOSITE_ACTION_LINT_ROOT ?? process.cwd();
+
+	const files = paths.length > 0 ? paths.map((p) => resolve(root, p)) : discoverActionFiles(root);
+
+	if (files.length === 0) {
+		process.stderr.write("no composite action files found\n");
+		return 1;
+	}
+
+	const findings: Finding[] = [];
+	const blocks: RunBlock[] = [];
+	for (const file of files) {
+		const result = lintFile(file, root);
+		findings.push(...result.findings);
+		blocks.push(...result.blocks);
+	}
+
+	if (listOnly) {
+		for (const block of blocks) {
+			const lines = block.script.replace(/\n$/, "").split("\n").length;
+			process.stdout.write(
+				`${block.file}:${block.startLine} shell=${block.shell ?? "<missing>"} lines=${lines} step=${block.stepName}\n`,
+			);
+		}
+		process.stdout.write(`${blocks.length} run block(s) in ${files.length} action file(s)\n`);
+		return 0;
+	}
+
+	findings.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line || a.col - b.col);
+
+	for (const f of findings) {
+		process.stdout.write(`${f.file}:${f.line}:${f.col}: [${f.code}] ${f.message}\n`);
+		if (process.env.GITHUB_ACTIONS === "true") {
+			process.stdout.write(
+				`::error file=${f.file},line=${f.line},col=${f.col},title=${f.code}::${f.message.replace(/\n/g, "%0A")}\n`,
+			);
+		}
+	}
+
+	if (findings.length > 0) {
+		process.stdout.write(
+			`\n${findings.length} problem(s) in ${blocks.length} composite-action run block(s) across ${files.length} file(s)\n`,
+		);
+		return 1;
+	}
+
+	process.stdout.write(`composite-action shell OK: ${blocks.length} run block(s) in ${files.length} action file(s)\n`);
+	return 0;
+}
+
+process.exit(main());

--- a/scripts/lint-composite-actions.ts
+++ b/scripts/lint-composite-actions.ts
@@ -429,7 +429,7 @@ function skipHeredocs(script: string, start: number, pending: { tag: string; ind
 // ---------------------------------------------------------------------------
 
 /** Segment texts after which `$?` is a live, meaningful status read. */
-const COMPOUND_TERMINATORS = /(^|[\s;])(fi|done|esac|then|else|do|\}|\))\s*$/;
+const COMPOUND_TERMINATORS = /(^|[\s;])(fi|done|esac|then|else|do|\}|\)|\{)\s*$/;
 
 function checkErrexitStatusReads(block: RunBlock, segments: Segment[]): Finding[] {
 	const findings: Finding[] = [];
@@ -443,7 +443,10 @@ function checkErrexitStatusReads(block: RunBlock, segments: Segment[]): Finding[
 	for (const segment of segments) {
 		const trimmed = segment.text.trim();
 
-		const statusIndex = segment.text.indexOf("$?");
+		// A trap body runs *after* the command that tripped errexit, so its `$?`
+		// is the one status errexit guarantees is live -- `trap 'rc=$?; ...' ERR`
+		// is the reporting idiom this rule exists to steer people towards.
+		const statusIndex = /^\s*trap\b/.test(segment.text) ? -1 : segment.text.indexOf("$?");
 		if (
 			statusIndex !== -1 &&
 			errexit &&
@@ -594,12 +597,17 @@ function maskExpressions(script: string): string {
 }
 
 function runShellCheck(block: RunBlock, dialect: "bash" | "sh"): Finding[] {
-	// Prepended so ShellCheck analyses the script under the options the runner
-	// actually sets, rather than under bare defaults.
+	// Records the shell the runner picks (ShellCheck reads the shebang) and the
+	// flags it sets, but as comments only, never as a command: ShellCheck honours a file-level
+	// `# shellcheck disable=...` directive only when nothing executable precedes
+	// it, so a `set -e -o pipefail` here would silently demote every such
+	// directive written at the top of a `run:` block. It bought nothing anyway --
+	// ShellCheck's errexit-sensitive checks (SC2310-SC2312) are opt-in and this
+	// gate does not enable them.
 	const prelude =
 		dialect === "bash"
-			? "#!/usr/bin/env bash\n# runner: bash --noprofile --norc -e -o pipefail {0}\nset -e -o pipefail\n"
-			: "#!/bin/sh\n# runner: sh -e {0}\nset -e\n";
+			? "#!/usr/bin/env bash\n# runner: bash --noprofile --norc -e -o pipefail {0}\n"
+			: "#!/bin/sh\n# runner: sh -e {0}\n";
 	const preludeLines = prelude.split("\n").length - 1;
 
 	let stdout: string;
@@ -663,13 +671,20 @@ function lintFile(absPath: string, root: string): { findings: Finding[]; blocks:
 
 	for (const block of blocks) {
 		const { masked, segments } = tokenize(block.script);
+		const dialect = shellDialect(block.shell);
 
-		for (const finding of [...checkErrexitStatusReads(block, segments), ...checkWorkflowCommands(block, masked)]) {
+		// CA001 models `bash -e`. In a `shell: pwsh` step `$?` is PowerShell's
+		// boolean success variable and reading it is the idiom, so the rule is
+		// scoped to the shells it actually describes. CA002 stays shell-agnostic:
+		// a workflow command is lost the same way whatever printed it.
+		for (const finding of [
+			...(dialect === null ? [] : checkErrexitStatusReads(block, segments)),
+			...checkWorkflowCommands(block, masked),
+		]) {
 			const pos = resolvePosition(block, finding.col);
 			findings.push({ ...finding, line: pos.line, col: pos.col });
 		}
 
-		const dialect = shellDialect(block.shell);
 		if (dialect !== null) findings.push(...runShellCheck(block, dialect));
 	}
 

--- a/scripts/lint-composite-actions.ts
+++ b/scripts/lint-composite-actions.ts
@@ -38,13 +38,16 @@
  * Usage:
  *   bun scripts/lint-composite-actions.ts [--list] [paths...]
  *
- * With no paths it discovers `action.yml` at the repo root plus every
- * `.github/actions/**\/action.{yml,yaml}`. `--list` prints the blocks it found
- * and exits 0; that is the coverage assertion's hook, so a block silently
- * dropping out of scope is itself detectable.
+ * With no paths it walks the whole repository for `action.{yml,yaml}`, skipping
+ * only trees that hold no source this repo owns (`.git`, `node_modules`, build
+ * and coverage output). A composite action is a composite action wherever it
+ * lives, and scoping discovery to `.github/actions/` meant one `git mv` could
+ * take a file out of the gate silently. `--list` prints the blocks it found and
+ * exits 0; that is the coverage assertion's hook, so a block dropping out of
+ * scope is itself detectable.
  */
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { type Dirent, readdirSync, readFileSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { isMap, isSeq, LineCounter, parseDocument } from "yaml";
 
@@ -83,41 +86,59 @@ interface RunBlock {
 
 const ACTION_FILENAMES = new Set(["action.yml", "action.yaml"]);
 
+/**
+ * Directory names never descended into.
+ *
+ * This is a deny list rather than an allow list on purpose. An allow list is
+ * what the first version of this gate had -- root plus `.github/actions/` --
+ * and it made "is this file linted?" depend on where someone happened to put
+ * it. A deny list can only ever fail by linting something extra, which is a
+ * visible failure; an allow list fails by linting nothing, which is silent.
+ *
+ * Everything here is a tree this repo does not author: dependency and VCS
+ * metadata, and generated output. `action.yml` files under `node_modules/`
+ * belong to third-party actions and are their authors' to fix.
+ */
+const SKIP_DIRS = new Set([
+	".git",
+	".direnv",
+	".venv",
+	"node_modules",
+	"vendor",
+	"dist",
+	"build",
+	"out",
+	"coverage",
+	".wrangler",
+	".turbo",
+	".next",
+	".cache",
+]);
+
 function discoverActionFiles(root: string): string[] {
 	const found: string[] = [];
-
-	for (const name of ACTION_FILENAMES) {
-		const candidate = join(root, name);
-		if (safeIsFile(candidate)) found.push(candidate);
-	}
-
-	const actionsDir = join(root, ".github", "actions");
-	if (safeIsDir(actionsDir)) walk(actionsDir, found);
-
+	walk(root, found);
 	return found.sort();
 }
 
 function walk(dir: string, out: string[]): void {
-	for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+	let entries: Dirent[];
+	try {
+		entries = readdirSync(dir, { withFileTypes: true });
+	} catch {
+		// An unreadable directory is not a reason to fail the whole lint run;
+		// the coverage assertion in test-composite-action-lint.sh is what
+		// notices if something that should be linted stops being reachable.
+		return;
+	}
+
+	for (const entry of [...entries].sort((a, b) => a.name.localeCompare(b.name))) {
 		const full = join(dir, entry.name);
-		if (entry.isDirectory()) walk(full, out);
-		else if (ACTION_FILENAMES.has(entry.name)) out.push(full);
-	}
-}
-
-function safeIsFile(path: string): boolean {
-	try {
-		return statSync(path).isFile();
-	} catch {
-		return false;
-	}
-}
-
-function safeIsDir(path: string): boolean {
-	try {
-		return statSync(path).isDirectory();
-	} catch {
-		return false;
+		if (entry.isDirectory()) {
+			if (!SKIP_DIRS.has(entry.name)) walk(full, out);
+		} else if (ACTION_FILENAMES.has(entry.name) && !entry.isSymbolicLink()) {
+			out.push(full);
+		}
 	}
 }
 

--- a/scripts/test-composite-action-lint.sh
+++ b/scripts/test-composite-action-lint.sh
@@ -86,13 +86,21 @@ mutate_action() { # mutate_action <name> <source-rel> <sed-expr>
 	mutated_root="${root}"
 }
 
+# Writes a synthetic composite action at an arbitrary path and echoes the tree
+# root. The path is a parameter because "where does an action live" is exactly
+# the assumption that used to be baked into both the checker and this suite.
+fixture_action_at() { # fixture_action_at <name> <rel-path-to-action-file> <<<body
+	local name="$1" rel="$2"
+	local root="${workdir}/${name}"
+	mkdir -p "${root}/$(dirname "${rel}")"
+	cat >"${root}/${rel}"
+	printf '%s\n' "${root}"
+}
+
 # Writes a synthetic composite action and echoes the tree root.
 fixture_action() { # fixture_action <name> <<<body
 	local name="$1"
-	local root="${workdir}/${name}"
-	mkdir -p "${root}/.github/actions/${name}"
-	cat >"${root}/.github/actions/${name}/action.yml"
-	printf '%s\n' "${root}"
+	fixture_action_at "${name}" ".github/actions/${name}/action.yml"
 }
 
 printf 'composite-action lint gate\n'
@@ -108,18 +116,27 @@ fi
 # ---------------------------------------------------------------------------
 # Coverage: every run block in every composite action is actually visited.
 #
-# Computed against an independent grep for `run:` rather than trusting the
-# checker's own idea of scope, so an action file dropping out of discovery --
-# a new directory, a renamed key, a parser that stops understanding a file --
-# fails here instead of silently shrinking the gate.
+# The expected set comes from `git ls-files` -- the index -- not from a
+# directory walk. That matters more than it looks: the first version of this
+# assertion enumerated the repo root plus `.github/actions/**`, which was the
+# same assumption discoverActionFiles() made, so an action living anywhere else
+# was invisible to the checker *and* to the test written to catch exactly that.
+# A shared assumption is not a check. The index has no opinion about layout, so
+# the only way both sides agree now is if the file is genuinely linted.
+#
+# Tracked-only is the right scope for the oracle: an action.yml nobody committed
+# is not shipping shell. The gate itself still walks the filesystem, so it is a
+# superset -- which is the safe direction, and is what the out-of-tree fixture
+# below pins down.
 # ---------------------------------------------------------------------------
 new_case "every composite action holding a run block is in scope"
 listed="$(run_linter "${repo_root}" --list)"
 mapfile -t action_files < <(
-	{
-		[[ -f ${repo_root}/action.yml ]] && printf 'action.yml\n'
-		find .github/actions -name 'action.yml' -o -name 'action.yaml' | sed 's|^\./||'
-	} | sort
+	git -C "${repo_root}" ls-files -z -- '*action.yml' '*action.yaml' \
+		| tr '\0' '\n' \
+		| grep -E '(^|/)action\.ya?ml$' \
+		| grep -vE '(^|/)node_modules/' \
+		| sort
 )
 if ((${#action_files[@]} == 0)); then
 	fail "found no composite action files to check -- the test itself has gone blind"
@@ -131,12 +148,87 @@ for action_file in "${action_files[@]}"; do
 	fi
 done
 
+# The oracle above is only as good as its own reach. If `git ls-files` ever
+# stops finding the one action file this repo has always had, it has gone blind
+# in the same way the old find(1) did and every case using it is vacant.
+new_case "the coverage oracle reaches outside .github/actions/"
+if ! printf '%s\n' "${action_files[@]}" | grep -qxF 'action.yml'; then
+	fail "the tracked-file oracle does not see the root action.yml -- it cannot detect an out-of-tree action"
+fi
+
 # setup-bun writes its steps as a flow sequence of single-line flow mappings, so
 # it is the file that proves the extractor is a YAML parse and not a line regex:
 # nothing anchored to `^\s*run:` can see its `bun install`.
 new_case "flow-style steps are extracted, not just block-style ones"
 if ! grep -qF '.github/actions/setup-bun/action.yml:' <<<"${listed}"; then
 	fail "setup-bun's flow-mapping run: block is not in scope -- the extractor is line-based"
+fi
+
+# ---------------------------------------------------------------------------
+# Discovery is repo-wide, not two hard-coded locations.
+#
+# The original gate looked at the repo root plus `.github/actions/**`. An action
+# under any other directory -- `actions/`, one vendored beside a package, one a
+# `git mv` away from where it started -- was never linted, and because the
+# coverage assertion enumerated the same two places, nothing said so. These
+# cases assert on a path the old discovery provably could not reach.
+# ---------------------------------------------------------------------------
+new_case "an action outside .github/actions/ is discovered and linted"
+root="$(
+	fixture_action_at out-of-tree "actions/publish/action.yml" <<'YAML'
+name: out of tree
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: echo "::notice:never seen"
+YAML
+)"
+if output="$(run_linter "${root}")"; then
+	fail "an action.yml outside .github/actions/ was not linted:"$'\n'"${output}"
+elif ! grep -q 'CA002' <<<"${output}"; then
+	fail "out-of-tree action reached the gate but not the rules:"$'\n'"${output}"
+elif ! grep -qF 'actions/publish/action.yml:' <<<"${output}"; then
+	fail "finding does not name the out-of-tree file:"$'\n'"${output}"
+fi
+
+# Nested arbitrarily deep, and named action.yaml rather than action.yml, since
+# both are valid and a walk that only matches one spelling is the same hole.
+new_case "a deeply nested action.yaml is discovered too"
+root="$(
+	fixture_action_at nested-yaml "packages/tools/ci/deploy/action.yaml" <<'YAML'
+name: nested
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: echo "::warning:lost"
+YAML
+)"
+if output="$(run_linter "${root}")"; then
+	fail "a nested action.yaml was not linted:"$'\n'"${output}"
+elif ! grep -qF 'packages/tools/ci/deploy/action.yaml:' <<<"${output}"; then
+	fail "finding does not name the nested action.yaml:"$'\n'"${output}"
+fi
+
+# The other half of a repo-wide walk: it has to stay out of trees this repo does
+# not author. A third-party action.yml under node_modules/ is not ours to fail
+# on, and descending into it would make the gate depend on the dependency graph.
+new_case "node_modules is not descended into"
+root="$(
+	fixture_action_at skips-deps "node_modules/some-dep/action.yml" <<'YAML'
+name: vendored
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: echo "::notice:not our problem"
+YAML
+)"
+printf 'name: real\nruns:\n  using: composite\n  steps:\n    - shell: bash\n      run: echo ok\n' \
+	>"${root}/action.yml"
+if ! output="$(run_linter "${root}")"; then
+	fail "gate descended into node_modules and failed on a vendored action:"$'\n'"${output}"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/test-composite-action-lint.sh
+++ b/scripts/test-composite-action-lint.sh
@@ -183,6 +183,111 @@ if ! output="$(run_linter "${root}")"; then
 	fail "a comment quoting the broken shape was flagged as the shape itself:"$'\n'"${output}"
 fi
 
+# CA001's false-positive surface is the part that decides whether this gate
+# survives contact: there is no `# composite-lint disable`, so every one of
+# these is an unsuppressible red `task lint`.
+new_case "errexit-legitimate \`\$?\` reads are not flagged"
+root="$(
+	fixture_action errexit-ok <<'YAML'
+name: Errexit OK
+description: shapes where a $? read is live under errexit
+runs:
+  using: composite
+  steps:
+    - name: Trap
+      shell: bash
+      run: |
+        echo start
+        # Deliberately no variable: ShellCheck's own SC2154 does not track an
+        # assignment inside a single-quoted trap body, and this case is about
+        # CA001, not about that.
+        trap 'echo "step died with $?"' ERR
+        git diff
+    - name: Function body
+      shell: bash
+      run: |
+        report() {
+          echo "rc=$?"
+        }
+        git diff || report
+    - name: Guarded compound
+      shell: bash
+      run: |
+        if ! out="$(git diff)"; then
+          rc=$?
+          echo "${rc} ${out}"
+        fi
+YAML
+)"
+if ! output="$(run_linter "${root}")"; then
+	fail "CA001 fired on a live \$? read (trap body, function body, or guarded compound):"$'\n'"${output}"
+fi
+
+# The repo's own root action.yml is 77 lines of `shell: pwsh`, where `$?` is
+# PowerShell's boolean success variable and reading it is the idiom. CA001
+# describes `bash -e` and must not be aimed at a shell it does not model.
+new_case "CA001 is scoped to the shells it models, but CA002 is not"
+root="$(
+	fixture_action pwsh-status <<'YAML'
+name: Pwsh status
+description: PowerShell $? plus a malformed command from a non-shell step
+runs:
+  using: composite
+  steps:
+    - name: Pwsh
+      shell: pwsh
+      run: |
+        git diff
+        if (-not $?) { Write-Host "::error::git diff failed" }
+YAML
+)"
+if ! output="$(run_linter "${root}")"; then
+	fail "CA001 was applied to a pwsh block, where \$? is a boolean, not a status:"$'\n'"${output}"
+fi
+root="$(
+	fixture_action python-command <<'YAML'
+name: Python command
+description: a malformed workflow command is lost whatever printed it
+runs:
+  using: composite
+  steps:
+    - name: Py
+      shell: python
+      run: |
+        print("::notice:lost")
+YAML
+)"
+if output="$(run_linter "${root}")"; then
+	fail "CA002 stopped covering non-shell steps:"$'\n'"${output}"
+elif ! grep -q 'CA002' <<<"${output}"; then
+	fail "python step failed but not with CA002:"$'\n'"${output}"
+fi
+
+# A `set -e` in the ShellCheck prelude is a command, and ShellCheck only honours
+# a file-level directive when nothing executable precedes it -- so a prelude that
+# executes anything silently voids every `# shellcheck disable=` written at the
+# top of a run block, with no error to say so.
+new_case "a file-level shellcheck directive in a run block is honoured"
+root="$(
+	fixture_action directive <<'YAML'
+name: Directive
+description: block-scoped shellcheck disable must reach the whole block
+runs:
+  using: composite
+  steps:
+    - name: Disabled
+      shell: bash
+      run: |
+        # shellcheck disable=SC2086
+        files=$(ls)
+        printf '%s\n' $files
+        printf '%s\n' $files
+YAML
+)"
+if ! output="$(run_linter "${root}")"; then
+	fail "a file-level \`# shellcheck disable\` at the top of a run block was ignored:"$'\n'"${output}"
+fi
+
 # ---------------------------------------------------------------------------
 # Mutation 2: restore the malformed workflow command on the real file.
 # ---------------------------------------------------------------------------

--- a/scripts/test-composite-action-lint.sh
+++ b/scripts/test-composite-action-lint.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# Covers the invariant that shell embedded in a composite action cannot regress
+# without a lint failure.
+#
+# #124 repaired two bugs in .github/actions/check-api-changes/action.yml that
+# every existing gate was structurally blind to:
+#
+#   * `CHANGED="$(git diff --exit-code)"; EXIT_CODE=$?` -- the runner executes
+#     composite `shell: bash` as `bash --noprofile --norc -e -o pipefail {0}`, an
+#     assignment from a command substitution carries that command's status, so
+#     the step aborted at the assignment and the `EXIT_CODE=$?` reporting path
+#     was never reached. The job failed correctly and said nothing.
+#   * `::notice:` instead of `::notice::` -- not a workflow command at all, so
+#     the success annotation was printed as literal text and never appeared.
+#
+# `task lint:actions` feeds actionlint only .github/workflows/**, and actionlint
+# has no composite-action schema, so pointing it at an action.yml stops it at
+# `"jobs" section is missing in workflow` before its ShellCheck integration ever
+# runs. `task lint:shell` globs *.sh. Neither could see a byte of this.
+#
+# ShellCheck on its own would not have closed the hole either: on the historical
+# assignment shape, even at `-o all --enable=all`, it reports SC2250 about brace
+# style and nothing about the dead `$?`. That is why the gate is
+# scripts/lint-composite-actions.ts -- ShellCheck plus rules for the runner's own
+# semantics -- and why the mutation cases below matter more than the clean run.
+#
+# Every mutation is applied to a copy of the real action file, so these assert
+# against the shipping shell rather than against a fixture that resembles it.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+failures=0
+case_name=""
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+new_case() {
+	case_name="$1"
+	printf '  case: %s\n' "${case_name}"
+}
+
+fail() {
+	printf '    FAIL (%s): %s\n' "${case_name}" "$1" >&2
+	failures=$((failures + 1))
+}
+
+linter="${repo_root}/scripts/lint-composite-actions.ts"
+api_action=".github/actions/check-api-changes/action.yml"
+taskfile="${repo_root}/Taskfile.yml"
+
+for required in "${linter}" "${repo_root}/${api_action}" "${taskfile}"; do
+	if [[ ! -f ${required} ]]; then
+		printf 'missing %s\n' "${required}" >&2
+		exit 1
+	fi
+done
+
+# `mise exec` so the checker reaches the same pinned shellcheck `lint:shell`
+# uses, rather than whatever older copy happens to sit in /usr/bin.
+run_linter() { # run_linter <root> [args...] -> stdout+stderr on fd 1, status returned
+	local root="$1"
+	shift
+	COMPOSITE_ACTION_LINT_ROOT="${root}" GITHUB_ACTIONS='' \
+		mise exec -- bun "${linter}" "$@" 2>&1
+}
+
+# Builds a tree holding one mutated copy of a real action file, and publishes its
+# root in ${mutated_root}. A global rather than stdout because the "the sed no
+# longer matches" branch has to be able to raise a failure, and a fail() inside a
+# $(...) increments a counter in a subshell that then exits -- which would let a
+# mutation case that stopped mutating anything pass silently. That is precisely
+# the class of hole this suite exists to close, so it must not have one.
+mutated_root=""
+mutate_action() { # mutate_action <name> <source-rel> <sed-expr>
+	local name="$1" source_rel="$2" expr="$3"
+	local root="${workdir}/${name}"
+	mutated_root=""
+	mkdir -p "${root}/$(dirname "${source_rel}")"
+	sed -e "${expr}" "${repo_root}/${source_rel}" >"${root}/${source_rel}"
+	if diff -q "${repo_root}/${source_rel}" "${root}/${source_rel}" >/dev/null; then
+		fail "mutation '${name}' changed nothing -- the sed expression no longer matches ${source_rel}"
+		return 1
+	fi
+	mutated_root="${root}"
+}
+
+# Writes a synthetic composite action and echoes the tree root.
+fixture_action() { # fixture_action <name> <<<body
+	local name="$1"
+	local root="${workdir}/${name}"
+	mkdir -p "${root}/.github/actions/${name}"
+	cat >"${root}/.github/actions/${name}/action.yml"
+	printf '%s\n' "${root}"
+}
+
+printf 'composite-action lint gate\n'
+
+# ---------------------------------------------------------------------------
+# The tree as it stands must pass, or every mutation case below proves nothing.
+# ---------------------------------------------------------------------------
+new_case "the repository's own composite actions pass the gate"
+if ! output="$(run_linter "${repo_root}")"; then
+	fail "gate rejects the current tree:"$'\n'"${output}"
+fi
+
+# ---------------------------------------------------------------------------
+# Coverage: every run block in every composite action is actually visited.
+#
+# Computed against an independent grep for `run:` rather than trusting the
+# checker's own idea of scope, so an action file dropping out of discovery --
+# a new directory, a renamed key, a parser that stops understanding a file --
+# fails here instead of silently shrinking the gate.
+# ---------------------------------------------------------------------------
+new_case "every composite action holding a run block is in scope"
+listed="$(run_linter "${repo_root}" --list)"
+mapfile -t action_files < <(
+	{
+		[[ -f ${repo_root}/action.yml ]] && printf 'action.yml\n'
+		find .github/actions -name 'action.yml' -o -name 'action.yaml' | sed 's|^\./||'
+	} | sort
+)
+if ((${#action_files[@]} == 0)); then
+	fail "found no composite action files to check -- the test itself has gone blind"
+fi
+for action_file in "${action_files[@]}"; do
+	grep -qE '(^|[[:space:],{])run:' "${repo_root}/${action_file}" || continue
+	if ! grep -qF "${action_file}:" <<<"${listed}"; then
+		fail "${action_file} holds a run: block but the gate does not list it"
+	fi
+done
+
+# setup-bun writes its steps as a flow sequence of single-line flow mappings, so
+# it is the file that proves the extractor is a YAML parse and not a line regex:
+# nothing anchored to `^\s*run:` can see its `bun install`.
+new_case "flow-style steps are extracted, not just block-style ones"
+if ! grep -qF '.github/actions/setup-bun/action.yml:' <<<"${listed}"; then
+	fail "setup-bun's flow-mapping run: block is not in scope -- the extractor is line-based"
+fi
+
+# ---------------------------------------------------------------------------
+# Mutation 1: restore the historical assignment shape on the real file.
+# ---------------------------------------------------------------------------
+new_case "the historical \`CHANGED=\"\$(... --exit-code)\"; EXIT_CODE=\$?\` shape is rejected"
+if mutate_action errexit-status "${api_action}" 's/" || EXIT_CODE=\$?/"; EXIT_CODE=\$?/'; then
+	if output="$(run_linter "${mutated_root}" "${api_action}")"; then
+		fail "gate accepted the shape #124 had to repair:"$'\n'"${output}"
+	elif ! grep -q 'CA001' <<<"${output}"; then
+		fail "gate failed but not with CA001 (the errexit rule):"$'\n'"${output}"
+	fi
+fi
+
+# The guarded form is the fix, and a rule that rejected it too would just get
+# switched off. This is the false-positive half of the same invariant.
+new_case "the guarded \`|| EXIT_CODE=\$?\` form is accepted"
+if output="$(run_linter "${repo_root}" "${api_action}")"; then
+	:
+else
+	fail "gate rejects the repaired form:"$'\n'"${output}"
+fi
+
+# A grep-shaped implementation would trip over the comment in that same step
+# that quotes the historical shape verbatim while explaining it.
+new_case "the historical shape quoted inside a comment does not trigger CA001"
+root="$(
+	fixture_action commented <<'YAML'
+name: Commented
+description: the broken shape appears only inside a comment
+runs:
+  using: composite
+  steps:
+    - name: Explain
+      shell: bash
+      run: |
+        # CHANGED="$(git diff --exit-code)"; EXIT_CODE=$? aborted the step here.
+        EXIT_CODE=0
+        CHANGED="$(git diff --exit-code)" || EXIT_CODE=$?
+        printf '%s %s\n' "${CHANGED}" "${EXIT_CODE}"
+YAML
+)"
+if ! output="$(run_linter "${root}")"; then
+	fail "a comment quoting the broken shape was flagged as the shape itself:"$'\n'"${output}"
+fi
+
+# ---------------------------------------------------------------------------
+# Mutation 2: restore the malformed workflow command on the real file.
+# ---------------------------------------------------------------------------
+new_case "the malformed \`::notice:\` command is rejected"
+if mutate_action notice-typo "${api_action}" 's/::notice::/::notice:/'; then
+	if output="$(run_linter "${mutated_root}" "${api_action}")"; then
+		fail "gate accepted the ::notice: typo #124 had to repair:"$'\n'"${output}"
+	elif ! grep -q 'CA002' <<<"${output}"; then
+		fail "gate failed but not with CA002 (the workflow-command rule):"$'\n'"${output}"
+	fi
+fi
+
+# The typo class is wider than the one instance that shipped: a prefix can be
+# truncated, unterminated, or simply misspelled, and all three are silent.
+new_case "other malformed command prefixes are rejected too"
+while read -r command description; do
+	[[ -z ${command} ]] && continue
+	root="$(
+		fixture_action "cmd-${description}" <<YAML
+name: Command ${description}
+description: malformed workflow command -- ${description}
+runs:
+  using: composite
+  steps:
+    - name: Emit
+      shell: bash
+      run: |
+        echo "${command}"
+YAML
+	)"
+	if output="$(run_linter "${root}")"; then
+		fail "gate accepted ${description}: ${command}"$'\n'"${output}"
+	elif ! grep -q 'CA002' <<<"${output}"; then
+		fail "${description} failed but not with CA002:"$'\n'"${output}"
+	fi
+done <<'CASES'
+::error:missing second colon
+::warning single-colon-props
+::group unterminated-properties
+::endgroup unterminated-endgroup
+::notic::misspelled-name
+CASES
+
+new_case "well-formed workflow commands are accepted"
+root="$(
+	fixture_action cmd-valid <<'YAML'
+name: Valid commands
+description: every accepted workflow-command form, plus a PowerShell type literal
+runs:
+  using: composite
+  steps:
+    - name: Emit
+      shell: bash
+      run: |
+        echo "::error::plain message"
+        echo "::notice title=Up to date::with properties"
+        printf '::add-mask::%s\n' "${SECRET-}"
+        echo "::group::open"
+        echo "::endgroup::"
+    - name: Emit from PowerShell
+      shell: pwsh
+      run: |
+        $temp = [System.IO.Path]::GetTempPath()
+        Write-Host "::notice::$temp"
+YAML
+)"
+if ! output="$(run_linter "${root}")"; then
+	fail "gate rejects well-formed commands or a PowerShell type literal:"$'\n'"${output}"
+fi
+
+# ---------------------------------------------------------------------------
+# ShellCheck has to actually reach the extracted block. Without this, a broken
+# pipe into the tool would leave the gate green on anything it alone can catch.
+# ---------------------------------------------------------------------------
+new_case "ShellCheck findings surface from inside a run block"
+root="$(
+	fixture_action shellcheck <<'YAML'
+name: Shellcheck reachability
+description: an unquoted expansion ShellCheck alone is expected to catch
+runs:
+  using: composite
+  steps:
+    - name: Unquoted
+      shell: bash
+      run: |
+        files=$(ls)
+        printf '%s\n' $files
+YAML
+)"
+if output="$(run_linter "${root}")"; then
+	fail "gate accepted an unquoted expansion -- ShellCheck is not reaching the block:"$'\n'"${output}"
+elif ! grep -q 'SC2086' <<<"${output}"; then
+	fail "gate failed but not with SC2086:"$'\n'"${output}"
+fi
+
+new_case "ShellCheck findings point at the action.yml's own line"
+if ! grep -qE 'action\.yml:10:[0-9]+: \[SC2086\]' <<<"${output}"; then
+	fail "SC2086 was not reported at line 10 of the action file:"$'\n'"${output}"
+fi
+
+# ---------------------------------------------------------------------------
+# A composite `run:` step without `shell:` is rejected by the runner at load
+# time, which is a red job for a reason no log explains well.
+# ---------------------------------------------------------------------------
+new_case "a run step with no shell: is rejected"
+root="$(
+	fixture_action noshell <<'YAML'
+name: No shell
+description: composite run step missing its required shell
+runs:
+  using: composite
+  steps:
+    - name: Missing
+      run: echo hello
+YAML
+)"
+if output="$(run_linter "${root}")"; then
+	fail "gate accepted a run: step with no shell::"$'\n'"${output}"
+elif ! grep -q 'CA003' <<<"${output}"; then
+	fail "gate failed but not with CA003:"$'\n'"${output}"
+fi
+
+# ---------------------------------------------------------------------------
+# Wiring. A gate nobody runs is the state this whole change exists to leave.
+# ---------------------------------------------------------------------------
+new_case "the gate is reachable from task lint"
+lint_plan="$(mise exec -- task --list-all 2>/dev/null || true)"
+if ! grep -q 'lint:actions:composite' <<<"${lint_plan}"; then
+	fail "lint:actions:composite is not a task"
+fi
+if ! grep -qF 'task: lint:actions:composite' "${taskfile}"; then
+	fail "no task calls lint:actions:composite, so \`task lint\` does not reach it"
+fi
+
+# The point is a gate that is added to, not swapped in: #124's workflow and
+# standalone-shell coverage has to survive this change.
+new_case "actionlint and standalone-shell linting are not weakened"
+if ! grep -qF 'xargs -r mise exec -- actionlint' "${taskfile}"; then
+	fail "lint:actions no longer runs actionlint over the workflows"
+fi
+if ! grep -qF 'shellcheck -x .github/scripts/*.sh scripts/*.sh' "${taskfile}"; then
+	fail "lint:shell no longer shellchecks the standalone scripts"
+fi
+
+new_case "this suite runs as part of task test"
+if ! grep -qF 'task: test:composite-actions' "${taskfile}"; then
+	fail "test:composite-actions is not in the test aggregates"
+fi
+
+# ---------------------------------------------------------------------------
+# The gap itself, asserted rather than remembered: if actionlint ever grows a
+# composite-action schema this fails, and the note above stops being true.
+# ---------------------------------------------------------------------------
+new_case "actionlint still cannot read a composite action (the gap this closes)"
+if actionlint_out="$(mise exec -- actionlint "${repo_root}/${api_action}" 2>&1)"; then
+	fail "actionlint now accepts composite actions -- re-evaluate whether this gate is still the right tool"
+elif ! grep -qF '"jobs" section is missing' <<<"${actionlint_out}"; then
+	fail "actionlint failed for a new reason; the recorded gap needs revisiting:"$'\n'"${actionlint_out}"
+fi
+
+if ((failures > 0)); then
+	printf '\n%d case(s) failed\n' "${failures}" >&2
+	exit 1
+fi
+
+printf '\nall cases passed\n'


### PR DESCRIPTION
Closes #126.

Adds an explicit lint path for shell embedded in composite GitHub actions instead of pretending actionlint or the standalone `.sh` ShellCheck pass covers it. The implementation parses composite action YAML, ShellChecks bash/sh `run:` blocks with runner-like flags, and adds repository-specific guards for the historical errexit/dead-`$?` pattern and malformed workflow-command syntax. It also fixes the existing `::notice:` typo and wires the new gate behind `lint:actions` without weakening actionlint or `lint:shell`.

The implementation run reproduced the original blind spot first, evaluated alternative tooling, mutation-tested the two historical regressions, and reports the full relevant lint/test/format/typecheck suite passing.