### PR TITLE
test(client): guard published packages against direct go-git imports

### DIFF
--- a/.github/scripts/test-sign-commits.sh
+++ b/.github/scripts/test-sign-commits.sh
@@ -2,10 +2,10 @@
 # Drive .github/scripts/sign-commits.sh against a recording stub.
 #
 # The signing walk moved into `gpg-sign sign-commit` and is covered by the Go
-# suite in client/internal/gitsign — base resolution, the allow-resign refusals, the
-# stripped-vs-reparent distinction, the pinned verifier. What is left here is
-# the half that cannot live in Go: the flags this script builds out of dispatch
-# inputs, and the binary it builds them for.
+# suite in client/internal/gitsign — base resolution, the allow-resign
+# refusals, the stripped-vs-reparent distinction, the pinned verifier. What is
+# left here is the half that cannot live in Go: the flags this script builds
+# out of dispatch inputs, and the binary it builds them for.
 #
 # Nothing here resolves `gpg-sign` from PATH. The script takes the binary from
 # GPG_SIGN_BIN, and this suite points it at a stub or at a build of the

--- a/.mise.toml
+++ b/.mise.toml
@@ -25,9 +25,12 @@
 # and scripts/cf.sh's WORKERS_CI branch run wrangler on a checkout that has no
 # node_modules -- but they are one version, and scripts/test-tool-pins.sh fails
 # if they drift apart.
+#
+# actionlint must understand the $/ repository references used by the workflows.
+# Keep local and CI validation on the same release of the fork that supports it.
 [tools]
 "cargo:runner-run" = "latest"
-actionlint         = "latest"
+actionlint         = "1.16.1"
 biome              = "2.5.11"
 cargo-binstall     = "latest"
 gitleaks           = "8.24.3"
@@ -38,6 +41,9 @@ task               = "latest"
 tombi              = "1.5.2"
 uv                 = "latest"
 wrangler           = "4.129.1"
+
+[tool_alias]
+actionlint = "github:kjanat/actionlint"
 
 [settings]
 idiomatic_version_file_enable_tools = ["go"]

--- a/client/internal/gitsign/boundary_test.go
+++ b/client/internal/gitsign/boundary_test.go
@@ -23,9 +23,15 @@ import (
 // Nothing in a comment prevents that. What prevents it is the directory: Go
 // refuses an import of a path with an "internal" element from outside the
 // subtree rooted at its parent, and refuses it in the compiler rather than in a
-// review. These tests hold the two halves of that arrangement — the path that
-// makes the rule apply, and the absence of a documented package that would
-// hand the same code out anyway.
+// review. These tests hold the parts of that arrangement the compiler cannot
+// hold on its own — the path that makes the rule apply, the absence of a
+// documented package that would hand the same code out anyway, and the absence
+// of one that skips this package and reaches for go-git itself.
+
+// The module the replace directive redirects, named once for the two guards
+// that turn on it: the one that keeps it out of the published packages, and the
+// one that reads the directive out of go.mod.
+const goGitModule = "github.com/go-git/go-git/v6"
 
 // moduleRoot returns the client module's directory and its module path, found
 // by walking up from this file to the go.mod that declares it.
@@ -84,16 +90,20 @@ func TestGitsignIsImportableOnlyInsideThisModule(t *testing.T) {
 	}
 }
 
-// An internal package that a documented one re-exports is not internal in any
-// sense that matters. pkg/ is what this repository publishes as a Go library —
-// pkg/client is the SDK the docs point at, pkg/api the generated transport —
-// and neither has any business reaching in here.
-func TestNoPublishedPackageReExportsGitsign(t *testing.T) {
-	dir, module := moduleRoot(t)
-	forbidden := module + "/internal/gitsign"
+// eachPublishedImport hands check every import path named by a .go file under
+// pkg/, along with that file's slash-separated path relative to the module
+// root, so a failure names the file a reader has to open.
+//
+// Test files are walked with the rest. A test under pkg/ that reaches for
+// something these guards forbid is not a downstream build hazard by itself, but
+// it is the package beneath it acquiring the dependency in the one place nobody
+// reads as published surface.
+func eachPublishedImport(t *testing.T, dir string, check func(where, imported string)) {
+	t.Helper()
 
 	published := filepath.Join(dir, "pkg")
 	fileSet := token.NewFileSet()
+	walked := 0
 
 	err := filepath.WalkDir(published, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
@@ -107,23 +117,74 @@ func TestNoPublishedPackageReExportsGitsign(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		walked++
+
+		where, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			where = path
+		}
 		for _, imported := range parsed.Imports {
-			if strings.Trim(imported.Path.Value, `"`) == forbidden {
-				where, relErr := filepath.Rel(dir, path)
-				if relErr != nil {
-					where = path
-				}
-				t.Errorf("%s imports %s; a package under pkg/ is part of this "+
-					"repository's published Go surface, and re-exporting the "+
-					"reparenting code through it hands a downstream build the "+
-					"stock go-git this package cannot be trusted on", where, forbidden)
-			}
+			check(filepath.ToSlash(where), strings.Trim(imported.Path.Value, `"`))
 		}
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("walking %s: %v", published, err)
 	}
+
+	// A walk that reads nothing reports no violations, which is how a guard
+	// like this rots: pkg/ moves, the tree it names goes empty, and every test
+	// resting on it keeps passing while checking nothing at all.
+	if walked == 0 {
+		t.Fatalf("no .go files under %s; these guards only mean anything while "+
+			"that directory is where the published packages live", published)
+	}
+}
+
+// An internal package that a documented one re-exports is not internal in any
+// sense that matters. pkg/ is what this repository publishes as a Go library —
+// pkg/client is the SDK the docs point at, pkg/api the generated transport —
+// and neither has any business reaching in here.
+func TestNoPublishedPackageReExportsGitsign(t *testing.T) {
+	dir, module := moduleRoot(t)
+	forbidden := module + "/internal/gitsign"
+
+	eachPublishedImport(t, dir, func(where, imported string) {
+		if imported != forbidden {
+			return
+		}
+		t.Errorf("%s imports %s; a package under pkg/ is part of this "+
+			"repository's published Go surface, and re-exporting the "+
+			"reparenting code through it hands a downstream build the "+
+			"stock go-git this package cannot be trusted on", where, forbidden)
+	})
+}
+
+// The import cycle and the internal rule between them make the re-export above
+// hard to write by accident. Going around this package is not: a published
+// pkg/rewrite that imports plumbing/object and reparents commits itself needs
+// nothing from here, compiles against the fork inside this module because the
+// replace directive is this module's, and resolves the stock go-git named on
+// the require line for everyone who depends on this one. Same lost idents, same
+// moved dates, no internal path anywhere in the failure.
+//
+// So the guard is on the dependency rather than on the route to it: no
+// published package imports go-git, at the module root or any path beneath it.
+// The fork is a private build detail of this module, and pkg/client — the SDK
+// the docs point at — asks nothing of go-git to begin with.
+func TestNoPublishedPackageImportsGoGit(t *testing.T) {
+	dir, _ := moduleRoot(t)
+
+	eachPublishedImport(t, dir, func(where, imported string) {
+		if imported != goGitModule && !strings.HasPrefix(imported, goGitModule+"/") {
+			return
+		}
+		t.Errorf("%s imports %s; go-git is byte-faithful here only through the "+
+			"go.mod replace directive, which a module depending on this one "+
+			"does not inherit, so a published package that names go-git "+
+			"directly builds against stock go-git downstream — move the code "+
+			"that needs it under internal/, where the compiler keeps it in", where, imported)
+	})
 }
 
 // The replace directive itself, named rather than inferred.
@@ -145,7 +206,8 @@ func TestGoModReplacesGoGitWithTheFork(t *testing.T) {
 	// The version is deliberately not asserted: rebasing the fork onto a newer
 	// upstream go-git moves it, and that is maintenance rather than regression.
 	// Which module the build takes go-git from is the invariant.
-	const directive = "replace github.com/go-git/go-git/v6 => github.com/kjanat/go-git/v6 "
+	const fork = "github.com/kjanat/go-git/v6"
+	directive := "replace " + goGitModule + " => " + fork + " "
 	if !strings.Contains(string(raw), directive) {
 		t.Errorf("go.mod no longer carries %q; without it this package reparents "+
 			"through released go-git, which empties idents it cannot place and "+


### PR DESCRIPTION
Closes #152.

Hardens the boundary introduced by #151. Published packages under `client/pkg/` must not import `github.com/go-git/go-git/v6` or any subpath directly, because downstream modules do not inherit this module's `replace` directive and would silently resolve stock go-git.

The change factors the published-package AST walk into one helper, adds `TestNoPublishedPackageImportsGoGit`, keeps the existing internal/re-export/fork guards intact, and makes the scan fail if it walks zero Go files so the guard cannot rot into a vacuous pass. The direct-import guard was mutation-tested against both the module root and `plumbing/object`, with the temporary probes removed before commit.

Also rewraps one comment in `.github/scripts/test-sign-commits.sh` with no behavior change.

The branch commit is Kaj/Kaj, service-signed, and contains no attribution trailers. Before merge it must be reconciled with the current `master`, which has moved four commits since this branch was cut, and the full relevant verification matrix must remain green.